### PR TITLE
Adds Rocky Linux vagrant image, facts and get_facts.sh support

### DIFF
--- a/facts/3.14/rocky-8-x86_64.facts
+++ b/facts/3.14/rocky-8-x86_64.facts
@@ -1,0 +1,625 @@
+{
+  "aio_agent_version": "6.23.0",
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "02/06/2015",
+  "bios_vendor": "EFI Development Kit II / OVMF",
+  "bios_version": "0.0.0",
+  "blockdevice_sda_model": "QEMU HARDDISK",
+  "blockdevice_sda_size": 1073741824,
+  "blockdevice_sda_vendor": "QEMU",
+  "blockdevice_sdb_model": "QEMU HARDDISK",
+  "blockdevice_sdb_size": 21474836480,
+  "blockdevice_sdb_vendor": "QEMU",
+  "blockdevices": "sdb,sda",
+  "chassistype": "Other",
+  "disks": {
+    "sda": {
+      "model": "QEMU HARDDISK",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "vendor": "QEMU"
+    },
+    "sdb": {
+      "model": "QEMU HARDDISK",
+      "size": "20.00 GiB",
+      "size_bytes": 21474836480,
+      "vendor": "QEMU"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "02/06/2015",
+      "vendor": "EFI Development Kit II / OVMF",
+      "version": "0.0.0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "QEMU",
+    "product": {
+      "name": "Standard PC (Q35 + ICH9, 2009)",
+      "uuid": "11212105-1cf1-4a18-beb9-25d00961e8cd"
+    }
+  },
+  "domain": "localdomain",
+  "facterversion": "3.14.18",
+  "filesystems": "ext2,ext3,ext4,vfat",
+  "fips_enabled": false,
+  "fqdn": "localhost.localdomain",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "localhost",
+  "hypervisors": {
+    "kvm": {}
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "enp0s3,enp1s0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fec0::5054:ff:fe12:3456",
+  "ipaddress6_enp0s3": "fec0::5054:ff:fe12:3456",
+  "ipaddress6_enp1s0": "fec0::5054:ff:fe53:c079",
+  "ipaddress6_lo": "::1",
+  "ipaddress_enp0s3": "10.0.2.15",
+  "ipaddress_enp1s0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-305.7.1.el8_4.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.11,
+    "1m": 0.23,
+    "5m": 0.15
+  },
+  "macaddress": "52:54:00:12:34:56",
+  "macaddress_enp0s3": "52:54:00:12:34:56",
+  "macaddress_enp1s0": "52:54:00:53:c0:79",
+  "manufacturer": "QEMU",
+  "memory": {
+    "system": {
+      "available": "3.34 GiB",
+      "available_bytes": 3589058560,
+      "capacity": "8.32%",
+      "total": "3.65 GiB",
+      "total_bytes": 3914555392,
+      "used": "310.42 MiB",
+      "used_bytes": 325496832
+    }
+  },
+  "memoryfree": "3.34 GiB",
+  "memoryfree_mb": 3422.79296875,
+  "memorysize": "3.65 GiB",
+  "memorysize_mb": 3733.2109375,
+  "mountpoints": {
+    "/": {
+      "available": "3.86 GiB",
+      "available_bytes": 4146978816,
+      "capacity": "30.13%",
+      "device": "/dev/mapper/centos-root",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "5.84 GiB",
+      "size_bytes": 6274220032,
+      "used": "1.67 GiB",
+      "used_bytes": 1788342272
+    },
+    "/boot": {
+      "available": "303.74 MiB",
+      "available_bytes": 318490624,
+      "capacity": "33.45%",
+      "device": "/dev/sda2",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "485.89 MiB",
+      "size_bytes": 509495296,
+      "used": "152.66 MiB",
+      "used_bytes": 160071680
+    },
+    "/boot/efi": {
+      "available": "505.25 MiB",
+      "available_bytes": 529788928,
+      "capacity": "1.12%",
+      "device": "/dev/sda1",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "510.98 MiB",
+      "size_bytes": 535805952,
+      "used": "5.74 MiB",
+      "used_bytes": 6017024
+    },
+    "/dev": {
+      "available": "1.80 GiB",
+      "available_bytes": 1937723392,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=1892308k",
+        "nr_inodes=473077",
+        "mode=755"
+      ],
+      "size": "1.80 GiB",
+      "size_bytes": 1937723392,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.82 GiB",
+      "available_bytes": 1957277696,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "1.82 GiB",
+      "size_bytes": 1957277696,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "1.81 GiB",
+      "available_bytes": 1948303360,
+      "capacity": "0.46%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "1.82 GiB",
+      "size_bytes": 1957277696,
+      "used": "8.56 MiB",
+      "used_bytes": 8974336
+    },
+    "/run/user/0": {
+      "available": "373.32 MiB",
+      "available_bytes": 391454720,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=382280k",
+        "mode=700"
+      ],
+      "size": "373.32 MiB",
+      "size_bytes": 391454720,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "1.82 GiB",
+      "available_bytes": 1957277696,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "1.82 GiB",
+      "size_bytes": 1957277696,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/var": {
+      "available": "4.37 GiB",
+      "available_bytes": 4687581184,
+      "capacity": "4.96%",
+      "device": "/dev/mapper/centos-var",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "4.86 GiB",
+      "size_bytes": 5217320960,
+      "used": "233.20 MiB",
+      "used_bytes": 244527104
+    },
+    "/var/log": {
+      "available": "7.82 GiB",
+      "available_bytes": 8395927552,
+      "capacity": "0.51%",
+      "device": "/dev/mapper/centos-var_log",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "8.30 GiB",
+      "size_bytes": 8912228352,
+      "used": "41.38 MiB",
+      "used_bytes": 43393024
+    },
+    "/var/tmp": {
+      "available": "451.35 MiB",
+      "available_bytes": 473272320,
+      "capacity": "0.17%",
+      "device": "/dev/mapper/centos-var_tmp",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "487.95 MiB",
+      "size_bytes": 511647744,
+      "used": "780.00 KiB",
+      "used_bytes": 798720
+    }
+  },
+  "mtu_enp0s3": 1500,
+  "mtu_enp1s0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp1s0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_enp0s3": "255.255.255.0",
+  "netmask_enp1s0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fec0::",
+  "network6_enp0s3": "fec0::",
+  "network6_enp1s0": "fec0::",
+  "network6_lo": "::1",
+  "network_enp0s3": "10.0.2.0",
+  "network_enp1s0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "localdomain",
+    "fqdn": "localhost.localdomain",
+    "hostname": "localhost",
+    "interfaces": {
+      "enp0s3": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fec0::5054:ff:fe12:3456",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fec0::"
+          },
+          {
+            "address": "fe80::5054:ff:fe12:3456",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip": "10.0.2.15",
+        "ip6": "fec0::5054:ff:fe12:3456",
+        "mac": "52:54:00:12:34:56",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fec0::",
+        "scope6": "site"
+      },
+      "enp1s0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fec0::5054:ff:fe53:c079",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fec0::"
+          },
+          {
+            "address": "fe80::5054:ff:fe53:c079",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip": "10.0.2.15",
+        "ip6": "fec0::5054:ff:fe53:c079",
+        "mac": "52:54:00:53:c0:79",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fec0::",
+        "scope6": "site"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fec0::5054:ff:fe12:3456",
+    "mac": "52:54:00:12:34:56",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fec0::",
+    "primary": "enp0s3",
+    "scope6": "site"
+  },
+  "operatingsystem": "Rocky",
+  "operatingsystemmajrelease": "8",
+  "operatingsystemrelease": "8.4",
+  "os": {
+    "architecture": "x86_64",
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.4",
+      "major": "8",
+      "minor": "4"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/mapper/centos-root": {
+      "filesystem": "ext4",
+      "mount": "/",
+      "size": "6.00 GiB",
+      "size_bytes": 6442450944,
+      "uuid": "70f4abdc-01d8-413f-9541-e3e8707fe419"
+    },
+    "/dev/mapper/centos-var": {
+      "filesystem": "ext4",
+      "mount": "/var",
+      "size": "5.00 GiB",
+      "size_bytes": 5368709120,
+      "uuid": "fc55c5ea-a59c-42b8-8c6e-79340139ba75"
+    },
+    "/dev/mapper/centos-var_log": {
+      "filesystem": "ext4",
+      "mount": "/var/log",
+      "size": "8.50 GiB",
+      "size_bytes": 9122611200,
+      "uuid": "9cc9a92e-1576-46bd-9ce8-f84f392efc7b"
+    },
+    "/dev/mapper/centos-var_tmp": {
+      "filesystem": "ext4",
+      "mount": "/var/tmp",
+      "size": "512.00 MiB",
+      "size_bytes": 536870912,
+      "uuid": "fe716cb3-6120-47e0-a278-f17262d233ca"
+    },
+    "/dev/sda1": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partlabel": "EFI System Partition",
+      "partuuid": "7a18ddce-2923-40b1-82e0-1ca329dd392d",
+      "size": "512.00 MiB",
+      "size_bytes": 536870912,
+      "uuid": "6F44-BFF9"
+    },
+    "/dev/sda2": {
+      "filesystem": "ext4",
+      "mount": "/boot",
+      "partuuid": "60fc9784-f032-4ebf-90c5-f7efdbefc46b",
+      "size": "510.00 MiB",
+      "size_bytes": 534773760,
+      "uuid": "abe85d10-fa5b-4963-be23-c454d8b2bc66"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel Core Processor (Skylake, IBRS)",
+  "processor1": "Intel Core Processor (Skylake, IBRS)",
+  "processorcount": 2,
+  "processors": {
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "Intel Core Processor (Skylake, IBRS)",
+      "Intel Core Processor (Skylake, IBRS)"
+    ],
+    "physicalcount": 1
+  },
+  "productname": "Standard PC (Q35 + ICH9, 2009)",
+  "puppetversion": "6.23.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+    "version": "2.5.9"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+  "rubyversion": "2.5.9",
+  "scope6": "site",
+  "scope6_enp0s3": "site",
+  "scope6_enp1s0": "site",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 d35ce5ec2bb051b8de803c7da2f60c04e27bc5d8",
+        "sha256": "SSHFP 3 2 649d8978f580194da62a459c6781be686e1cea5c33310d5af8af17e8a93c8641"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBK0Ec87Moqy+Nh9pYhjbFcBVqvUE1GtnU4eD6iXIKzkNcZCpc4EMnaZ9+LAQ25+6wI+wXKO8c31b4j3osy6K6VU=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 8572a09e3e407b7b59aeca6c3fdfa8d8a3951a1b",
+        "sha256": "SSHFP 4 2 495dda9d4fbb4f579875d704fec26d025f177b078eed65e030129aa7cb68bdee"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKXr0SdBbCrSYPfb7r1MK1Sj0x8fxAyv0Nuz8uMvlBeN",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 620e1aedfe7661dc2a62d037231f5697af23a30a",
+        "sha256": "SSHFP 1 2 272f93382a217af268d7e0a8e231d035091ee75dfe13d612bfcfb4a124f6d70e"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCypUhz1KQ4T8e3eh4ihLrUd3yu2daEQrnCMh8O/yWKIz8W9EWiKsq1nVVbash44ddE99HW3ZzfAzNP5BeRpwK8hN99kRhPJE8vGUhOSqwO2ZWPIrKE8LQ8RmVcLvTSnhTLoNb1KBP4NrAR5TYDJQ7B2RQr9mHQWvkoDgRx+ujAMJcO5eBLS7JFdtmcAADikGGJ/+9I3Qsl8rn6BzwW0k6Mqzr6LHc7QlH7e0NXNcqwz2WfSFWgQUzQK9zny+qC/rdKZdCpJzO1QTw4yx4tbalwtShOYcxgou+Y7Tr4eCr0ut9UwWmVv6BDrsAXPxsW1xcl74lB+etr17hjstN5fnrF2S9mLCg/TCTxaTCwZjRKwiRPEbmrDUD+uhPTh1WDZi+99Y9TjcGpbvYj2GlsW3ctchNI8OVMxhSLrar2gQGkipTwXgI44XL4i2nMSlETlO18k6fDFJWK+pDHJZEaQJROsTpHMTU1DEZ2LTe+0lIudaU+r7n//2on+Mvw0S+Qe30=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBK0Ec87Moqy+Nh9pYhjbFcBVqvUE1GtnU4eD6iXIKzkNcZCpc4EMnaZ9+LAQ25+6wI+wXKO8c31b4j3osy6K6VU=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIKXr0SdBbCrSYPfb7r1MK1Sj0x8fxAyv0Nuz8uMvlBeN",
+  "sshfp_ecdsa": "SSHFP 3 1 d35ce5ec2bb051b8de803c7da2f60c04e27bc5d8\nSSHFP 3 2 649d8978f580194da62a459c6781be686e1cea5c33310d5af8af17e8a93c8641",
+  "sshfp_ed25519": "SSHFP 4 1 8572a09e3e407b7b59aeca6c3fdfa8d8a3951a1b\nSSHFP 4 2 495dda9d4fbb4f579875d704fec26d025f177b078eed65e030129aa7cb68bdee",
+  "sshfp_rsa": "SSHFP 1 1 620e1aedfe7661dc2a62d037231f5697af23a30a\nSSHFP 1 2 272f93382a217af268d7e0a8e231d035091ee75dfe13d612bfcfb4a124f6d70e",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCypUhz1KQ4T8e3eh4ihLrUd3yu2daEQrnCMh8O/yWKIz8W9EWiKsq1nVVbash44ddE99HW3ZzfAzNP5BeRpwK8hN99kRhPJE8vGUhOSqwO2ZWPIrKE8LQ8RmVcLvTSnhTLoNb1KBP4NrAR5TYDJQ7B2RQr9mHQWvkoDgRx+ujAMJcO5eBLS7JFdtmcAADikGGJ/+9I3Qsl8rn6BzwW0k6Mqzr6LHc7QlH7e0NXNcqwz2WfSFWgQUzQK9zny+qC/rdKZdCpJzO1QTw4yx4tbalwtShOYcxgou+Y7Tr4eCr0ut9UwWmVv6BDrsAXPxsW1xcl74lB+etr17hjstN5fnrF2S9mLCg/TCTxaTCwZjRKwiRPEbmrDUD+uhPTh1WDZi+99Y9TjcGpbvYj2GlsW3ctchNI8OVMxhSLrar2gQGkipTwXgI44XL4i2nMSlETlO18k6fDFJWK+pDHJZEaQJROsTpHMTU1DEZ2LTe+0lIudaU+r7n//2on+Mvw0S+Qe30=",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 1216,
+    "uptime": "0:20 hours"
+  },
+  "timezone": "CEST",
+  "uptime": "0:20 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1216,
+  "uuid": "11212105-1cf1-4a18-beb9-25d00961e8cd",
+  "virtual": "kvm"
+}

--- a/facts/Vagrantfile
+++ b/facts/Vagrantfile
@@ -158,6 +158,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host.vm.provision "shell", path: "get_facts.sh"
     host.vm.provision "shell", inline: "/sbin/shutdown -h now"
   end
+  config.vm.define "rockylinux-8-x86_64" do |host|
+    host.vm.box = "https://github.com/anoncam/rocky-linux-vagrant/blob/main/rockylinux.box"
+    host.vm.synced_folder ".", "/vagrant"
+    host.vm.provision "shell", inline: "dnf -y install wget make gcc net-tools"
+    host.vm.provision "file", source: "Gemfile", destination: "Gemfile"
+    host.vm.provision "shell", path: "get_facts.sh"
+    host.vm.provision "shell", inline: "/sbin/shutdown -h now"
+  end
   config.vm.define "redhat-8-x86_64" do |host|
     host.vm.box = "generic/rhel8"
     host.vm.synced_folder ".", "/vagrant"

--- a/facts/get_facts.sh
+++ b/facts/get_facts.sh
@@ -31,14 +31,17 @@ elif test -f /usr/bin/apt-get; then
 elif test -f /etc/redhat-release ; then
   operatingsystemmajrelease=$(rpm -qf /etc/redhat-release --queryformat '%{version}' | cut -f1 -d'.')
   case $(rpm -qf /etc/redhat-release --queryformat '%{name}') in
+  almalinux*)
+    osfamily='AlmaLinux'
+    ;;
   centos*|redhat*)
     osfamily='RedHat'
     ;;
   fedora*)
     osfamily='Fedora'
     ;;
-  almalinux*)
-    osfamily='AlmaLinux'
+  rocky-*)
+    osfamily='RockyLinux'
     ;;
   *)
     echo 'Failed to determine osfamily from /etc/redhat-release'
@@ -153,7 +156,7 @@ case "${osfamily}" in
     yum remove -y puppet6-release
   fi
   ;;
-'AlmaLinux')
+'RockyLinux'|'AlmaLinux')
   dnf localinstall -y "http://yum.puppetlabs.com/puppet6-release-el-${operatingsystemmajrelease}.noarch.rpm"
   if dnf install -y puppet-agent; then
     output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemmajrelease)-$(facter hardwaremodel).facts"
@@ -311,7 +314,7 @@ bundle install --path vendor/bundler
 for version in 1.6.0 1.7.0 2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 2.5.0; do
   FACTER_GEM_VERSION="~> ${version}" bundle update
   case "${operatingsystem}" in
-    almalinux)
+    almalinux|rocky)
       break
       ;;
     openbsd)


### PR DESCRIPTION
I've added Rocky Linux support.
The factset is from a local KVM VM, so you'd have to regenerate it with Vagrant. I've added a stanza for Rocky as well, but can't test it.