### PR TITLE
(#200) Updated get_facts.sh and several os facts missing mountpoints

### DIFF
--- a/facts/3.14/fedora-33-x86_64.facts
+++ b/facts/3.14/fedora-33-x86_64.facts
@@ -1,10 +1,5 @@
 {
-  "aio_agent_version": "7.12.0",
   "architecture": "x86_64",
-  "augeas": {
-    "version": "1.12.0"
-  },
-  "augeasversion": "1.12.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
@@ -16,15 +11,11 @@
   "boardproductname": "VirtualBox",
   "boardserialnumber": "0",
   "chassistype": "Other",
-  "dhcp_servers": {
-    "system": null
-  },
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
       "size": "128.00 GiB",
       "size_bytes": 137438953472,
-      "type": "hdd",
       "vendor": "ATA"
     }
   },
@@ -46,24 +37,18 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "27961108-1973-4660-a1b0-938050051403"
+      "uuid": "1222893a-092a-403f-973f-4cb3ee72340f"
     }
   },
   "domain": "example.com",
-  "facterversion": "4.2.5",
-  "filesystems": "xfs",
+  "facterversion": "3.14.7",
+  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
   "gid": "root",
   "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
-  "hypervisors": {
-    "virtualbox": {
-      "revision": "145957",
-      "version": "6.1.26"
-    }
-  },
   "id": "root",
   "identity": {
     "gid": 0,
@@ -78,50 +63,47 @@
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "4.18",
-  "kernelrelease": "4.18.0-305.el8.x86_64",
-  "kernelversion": "4.18.0",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.13-100.fc33.x86_64",
+  "kernelversion": "5.14.13",
   "load_averages": {
-    "15m": 0.37,
-    "1m": 1.56,
-    "5m": 0.89
+    "15m": 0.15,
+    "1m": 1.06,
+    "5m": 0.41
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:75:c4:9b",
-  "macaddress_eth0": "08:00:27:75:c4:9b",
+  "macaddress": "08:00:27:29:97:5c",
+  "macaddress_eth0": "08:00:27:29:97:5c",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "2.06 GiB",
-      "available_bytes": 2210394112,
-      "capacity": "0.00%",
-      "total": "2.06 GiB",
-      "total_bytes": 2210394112,
+      "available": "2.96 GiB",
+      "available_bytes": 3178225664,
+      "capacity": "0%",
+      "total": "2.96 GiB",
+      "total_bytes": 3178225664,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.35 GiB",
-      "available_bytes": 1450811392,
-      "capacity": "23.86%",
-      "total": "1.77 GiB",
-      "total_bytes": 1905377280,
-      "used": "433.51 MiB",
-      "used_bytes": 454565888
+      "available": "1.63 GiB",
+      "available_bytes": 1754828800,
+      "capacity": "14.89%",
+      "total": "1.92 GiB",
+      "total_bytes": 2061717504,
+      "used": "292.67 MiB",
+      "used_bytes": 306888704
     }
   },
-  "memoryfree": "1.35 GiB",
-  "memoryfree_mb": 1383.6015625,
-  "memorysize": "1.77 GiB",
-  "memorysize_mb": 1817.109375,
+  "memoryfree": "1.63 GiB",
+  "memoryfree_mb": 1673.53515625,
+  "memorysize": "1.92 GiB",
+  "memorysize_mb": 1966.20703125,
   "mountpoints": {
     "/": {
-      "available": "67.34 GiB",
-      "available_bytes": 72310030336,
-      "capacity": "3.75%",
-      "device": "/dev/mapper/rhel_rhel8-root",
+      "available": "121.75 GiB",
+      "available_bytes": 130725580800,
+      "capacity": "2.55%",
+      "device": "/dev/mapper/fedora-root",
       "filesystem": "xfs",
       "options": [
         "rw",
@@ -133,15 +115,15 @@
         "logbsize=32k",
         "noquota"
       ],
-      "size": "69.97 GiB",
-      "size_bytes": 75125227520,
-      "used": "2.62 GiB",
-      "used_bytes": 2815197184
+      "size": "124.94 GiB",
+      "size_bytes": 134148001792,
+      "used": "3.19 GiB",
+      "used_bytes": 3422420992
     },
     "/boot": {
-      "available": "823.84 MiB",
-      "available_bytes": 863862784,
-      "capacity": "18.75%",
+      "available": "876.48 MiB",
+      "available_bytes": 919060480,
+      "capacity": "13.56%",
       "device": "/dev/sda1",
       "filesystem": "xfs",
       "options": [
@@ -156,12 +138,12 @@
       ],
       "size": "1014.00 MiB",
       "size_bytes": 1063256064,
-      "used": "190.16 MiB",
-      "used_bytes": 199393280
+      "used": "137.52 MiB",
+      "used_bytes": 144195584
     },
     "/dev": {
-      "available": "890.11 MiB",
-      "available_bytes": 933351424,
+      "available": "969.31 MiB",
+      "available_bytes": 1016393728,
       "capacity": "0%",
       "device": "devtmpfs",
       "filesystem": "devtmpfs",
@@ -169,12 +151,14 @@
         "rw",
         "seclabel",
         "nosuid",
-        "size=911476k",
-        "nr_inodes=227869",
-        "mode=755"
+        "noexec",
+        "size=992572k",
+        "nr_inodes=248143",
+        "mode=755",
+        "inode64"
       ],
-      "size": "890.11 MiB",
-      "size_bytes": 933351424,
+      "size": "969.31 MiB",
+      "size_bytes": 1016393728,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -204,6 +188,9 @@
       "options": [
         "rw",
         "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
         "relatime"
       ],
       "size": "0 bytes",
@@ -233,8 +220,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "908.55 MiB",
-      "available_bytes": 952688640,
+      "available": "983.10 MiB",
+      "available_bytes": 1030856704,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -242,17 +229,18 @@
         "rw",
         "seclabel",
         "nosuid",
-        "nodev"
+        "nodev",
+        "inode64"
       ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
+      "size": "983.10 MiB",
+      "size_bytes": 1030856704,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "892.16 MiB",
-      "available_bytes": 935493632,
-      "capacity": "1.80%",
+      "available": "387.75 MiB",
+      "available_bytes": 406585344,
+      "capacity": "1.40%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -260,17 +248,20 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "mode=755"
+        "size=402680k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
       ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
-      "used": "16.40 MiB",
-      "used_bytes": 17195008
+      "size": "393.24 MiB",
+      "size_bytes": 412344320,
+      "used": "5.49 MiB",
+      "used_bytes": 5758976
     },
     "/run/user/1000": {
-      "available": "181.71 MiB",
-      "available_bytes": 190537728,
-      "capacity": "0%",
+      "available": "196.61 MiB",
+      "available_bytes": 206163968,
+      "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -279,53 +270,32 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=186072k",
+        "size=201336k",
+        "nr_inodes=50334",
         "mode=700",
         "uid=1000",
-        "gid=1000"
+        "gid=1000",
+        "inode64"
       ],
-      "size": "181.71 MiB",
-      "size_bytes": 190537728,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/sys/fs/cgroup": {
-      "available": "908.55 MiB",
-      "available_bytes": 952688640,
-      "capacity": "0%",
-      "device": "tmpfs",
-      "filesystem": "tmpfs",
-      "options": [
-        "ro",
-        "seclabel",
-        "nosuid",
-        "nodev",
-        "noexec",
-        "mode=755"
-      ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "size": "196.62 MiB",
+      "size_bytes": 206168064,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
     },
     "/vagrant": {
       "available": "1.68 TiB",
-      "available_bytes": 1851170643968,
-      "capacity": "7.43%",
+      "available_bytes": 1847571525632,
+      "capacity": "7.61%",
       "device": "vagrant",
       "filesystem": "vboxsf",
       "options": [
         "rw",
-        "nodev",
-        "relatime",
-        "iocharset=utf8",
-        "uid=1000",
-        "gid=1000"
+        "relatime"
       ],
       "size": "1.82 TiB",
       "size_bytes": 1999738298368,
-      "used": "138.36 GiB",
-      "used_bytes": 148567654400
+      "used": "141.72 GiB",
+      "used_bytes": 152166772736
     }
   },
   "mtu_eth0": 1500,
@@ -350,7 +320,7 @@
           }
         ],
         "ip": "10.0.2.15",
-        "mac": "08:00:27:75:c4:9b",
+        "mac": "08:00:27:29:97:5c",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "network": "10.0.2.0"
@@ -370,34 +340,23 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:75:c4:9b",
+    "mac": "08:00:27:29:97:5c",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "network": "10.0.2.0",
     "primary": "eth0"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
+  "operatingsystem": "Fedora",
+  "operatingsystemmajrelease": "33",
+  "operatingsystemrelease": "33",
   "os": {
     "architecture": "x86_64",
-    "distro": {
-      "codename": "Ootpa",
-      "description": "Red Hat Enterprise Linux release 8.4 (Ootpa)",
-      "id": "RedHatEnterprise",
-      "release": {
-        "full": "8.4",
-        "major": "8",
-        "minor": "4"
-      }
-    },
     "family": "RedHat",
     "hardware": "x86_64",
-    "name": "RedHat",
+    "name": "Fedora",
     "release": {
-      "full": "8.4",
-      "major": "8",
-      "minor": "4"
+      "full": "33",
+      "major": "33"
     },
     "selinux": {
       "config_mode": "enforcing",
@@ -410,61 +369,59 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/rhel_rhel8-root": {
+    "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
+      "label": "root",
       "mount": "/",
-      "size": "70.00 GiB",
-      "size_bytes": 75161927680,
-      "uuid": "aff90eef-5284-45bb-b8e7-b7eb6041f432"
+      "size": "125.00 GiB",
+      "size_bytes": 134213533696,
+      "uuid": "8c41a481-a6f3-48a7-9928-5ccc8e751b82"
     },
-    "/dev/mapper/rhel_rhel8-swap": {
+    "/dev/mapper/fedora-swap": {
       "filesystem": "swap",
-      "size": "2.06 GiB",
-      "size_bytes": 2210398208,
-      "uuid": "5b20229a-5202-4cb8-bb1c-cf3d2e5e1e4c"
+      "size": "2.00 GiB",
+      "size_bytes": 2147483648,
+      "uuid": "e4fc7689-35c6-43ce-b90d-e8c975ca3ea5"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
+      "label": "boot",
       "mount": "/boot",
-      "partuuid": "18628db8-01",
+      "partuuid": "f1c9e755-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "68ac9249-ebc1-4c53-8991-17bd52dc4135"
+      "uuid": "ada0ce4c-60a6-4942-93c2-587a4bbf6133"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "18628db8-02",
+      "partuuid": "f1c9e755-02",
       "size": "127.00 GiB",
       "size_bytes": 136364163072,
-      "uuid": "9x9cKz-OdFp-R1be-hG92-xZ35-Wb9d-rlv9qt"
+      "uuid": "ivtgiI-vMBC-D7XV-n46l-8nMd-OubV-16cNq7"
     }
   },
-  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
   "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processorcount": 2,
   "processors": {
-    "cores": 2,
     "count": 2,
     "isa": "x86_64",
     "models": [
       "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
       "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
     ],
-    "physicalcount": 1,
-    "speed": "3.00 GHz",
-    "threads": 1
+    "physicalcount": 1
   },
   "productname": "VirtualBox",
-  "puppetversion": "7.12.0",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "2.7.3"
   },
   "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
   "rubyversion": "2.7.3",
   "selinux": true,
   "selinux_config_mode": "enforcing",
@@ -476,50 +433,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992",
-        "sha256": "SSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1"
+        "sha1": "SSHFP 3 1 fc3ed2395336e543c9c4fb9499ea6b360db4094d",
+        "sha256": "SSHFP 3 2 96c91a1f453555790b1f73f51fea4c903f209c597ef79a03ca49e4241751c3fa"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOPNLQhzPcf6mlagr7222DcISV6drFyTmapVtTAAc5jm+ELA1nk4W1zYW/TR2ZCk0m/3pgCYXPx5ZRoQ8GvU8aw=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c",
-        "sha256": "SSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc"
+        "sha1": "SSHFP 4 1 479439af8c9ce96bb0b6b4373cf6555264dda4d1",
+        "sha256": "SSHFP 4 2 585f1f8c2cebd1890b8781ce9479f20ad42b9310b7e5c166fac03932f2b5d321"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIBlyRZEB0ECT/kpKF4KY+fUocsX6iXkyrZU/AWBs+umn",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e",
-        "sha256": "SSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7"
+        "sha1": "SSHFP 1 1 1534433bf4d96a080b0dacbf441ca3055e296657",
+        "sha256": "SSHFP 1 2 668c92b87f2919af21355e9b7e65b58af07d04dc22d930458b4536ab8144ed45"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMca0ouKgKHvMgizXdL6evmOPrMAv34MERrUd0CtRqFC5EDX2c1ellQZhwnHfY9FDMtOdPnYWcCiE4kN69QH3uVnUuByEqEH4kmPe9k2/FZys3SzfmaKetG978INOWY65wOqWkXBavrYNFAAhKj6OvLK+Epvp7Fwg2vK514SB5GxnyFlk20q5CQFZ/bQuzaW2KCxPafanDF+Y0Ysw/YUBNmxiLRbBsvjGNHSxugxcUZtvwCdxq07NY33j1/rQ3mxwnNyN/1K4ffpgezelLL7jJ1bAIB4HhlTAZIPL1Y0WkSOhg0PL//QzuvWG+IOIPkKUi5q71d8sKiFNXacQ9D8QTOxHMnkIMIoCzITxVLrC9kYOrQvG7s3jcgVSoCh0Kmqg77IRgyXLWYR9ebulmF1YtV/jSwi/k1d9wQgdHiBc1Lee7mFwZumQZPwB+u4ofPnL7w5vUtxXLEg6RCT63BCjVL4c7EWy5YVnOb5cbBvcedA7oHe2Rh5vd0x+ns006fc=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
-  "sshfp_ecdsa": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992\nSSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1",
-  "sshfp_ed25519": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c\nSSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc",
-  "sshfp_rsa": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e\nSSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2107.99609375,
-  "swapsize": "2.06 GiB",
-  "swapsize_mb": 2107.99609375,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOPNLQhzPcf6mlagr7222DcISV6drFyTmapVtTAAc5jm+ELA1nk4W1zYW/TR2ZCk0m/3pgCYXPx5ZRoQ8GvU8aw=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIBlyRZEB0ECT/kpKF4KY+fUocsX6iXkyrZU/AWBs+umn",
+  "sshfp_ecdsa": "SSHFP 3 1 fc3ed2395336e543c9c4fb9499ea6b360db4094d\nSSHFP 3 2 96c91a1f453555790b1f73f51fea4c903f209c597ef79a03ca49e4241751c3fa",
+  "sshfp_ed25519": "SSHFP 4 1 479439af8c9ce96bb0b6b4373cf6555264dda4d1\nSSHFP 4 2 585f1f8c2cebd1890b8781ce9479f20ad42b9310b7e5c166fac03932f2b5d321",
+  "sshfp_rsa": "SSHFP 1 1 1534433bf4d96a080b0dacbf441ca3055e296657\nSSHFP 1 2 668c92b87f2919af21355e9b7e65b58af07d04dc22d930458b4536ab8144ed45",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDJMca0ouKgKHvMgizXdL6evmOPrMAv34MERrUd0CtRqFC5EDX2c1ellQZhwnHfY9FDMtOdPnYWcCiE4kN69QH3uVnUuByEqEH4kmPe9k2/FZys3SzfmaKetG978INOWY65wOqWkXBavrYNFAAhKj6OvLK+Epvp7Fwg2vK514SB5GxnyFlk20q5CQFZ/bQuzaW2KCxPafanDF+Y0Ysw/YUBNmxiLRbBsvjGNHSxugxcUZtvwCdxq07NY33j1/rQ3mxwnNyN/1K4ffpgezelLL7jJ1bAIB4HhlTAZIPL1Y0WkSOhg0PL//QzuvWG+IOIPkKUi5q71d8sKiFNXacQ9D8QTOxHMnkIMIoCzITxVLrC9kYOrQvG7s3jcgVSoCh0Kmqg77IRgyXLWYR9ebulmF1YtV/jSwi/k1d9wQgdHiBc1Lee7mFwZumQZPwB+u4ofPnL7w5vUtxXLEg6RCT63BCjVL4c7EWy5YVnOb5cbBvcedA7oHe2Rh5vd0x+ns006fc=",
+  "swapfree": "2.96 GiB",
+  "swapfree_mb": 3030.9921875,
+  "swapsize": "2.96 GiB",
+  "swapsize_mb": 3030.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 242,
-    "uptime": "0:04 hours"
+    "seconds": 85,
+    "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
+  "uptime": "0:01 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 242,
-  "uuid": "27961108-1973-4660-a1b0-938050051403",
+  "uptime_seconds": 85,
+  "uuid": "1222893a-092a-403f-973f-4cb3ee72340f",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/redhat-8-x86_64.facts
+++ b/facts/4.0/redhat-8-x86_64.facts
@@ -1,5 +1,5 @@
 {
-  "aio_agent_version": "6.6.0",
+  "aio_agent_version": "7.5.0",
   "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
@@ -46,7 +46,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "9e6ae33f-ed34-471c-ab4f-ff8cfc4d9f78"
+      "uuid": "27961108-1973-4660-a1b0-938050051403"
     }
   },
   "domain": "example.com",
@@ -54,7 +54,6 @@
   "filesystems": "xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.0.0",
   "gid": "root",
   "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
@@ -83,15 +82,15 @@
   "kernelrelease": "4.18.0-305.el8.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.12,
-    "1m": 0.81,
-    "5m": 0.33
+    "15m": 0.33,
+    "1m": 1.79,
+    "5m": 0.83
   },
   "lsbdistrelease": "8.4",
   "lsbmajdistrelease": "8",
   "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:dc:e4:34",
-  "macaddress_eth0": "08:00:27:dc:e4:34",
+  "macaddress": "08:00:27:75:c4:9b",
+  "macaddress_eth0": "08:00:27:75:c4:9b",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -104,19 +103,231 @@
       "used_bytes": 0
     },
     "system": {
-      "available": "1.38 GiB",
-      "available_bytes": 1486987264,
-      "capacity": "21.96%",
+      "available": "1.35 GiB",
+      "available_bytes": 1447981056,
+      "capacity": "24.01%",
       "total": "1.77 GiB",
       "total_bytes": 1905377280,
-      "used": "399.01 MiB",
-      "used_bytes": 418390016
+      "used": "436.21 MiB",
+      "used_bytes": 457396224
     }
   },
-  "memoryfree": "1.38 GiB",
-  "memoryfree_mb": 1418.1,
+  "memoryfree": "1.35 GiB",
+  "memoryfree_mb": 1380.9,
   "memorysize": "1.77 GiB",
   "memorysize_mb": 1817.11,
+  "mountpoints": {
+    "/": {
+      "available": "67.34 GiB",
+      "available_bytes": 72307232768,
+      "capacity": "3.75%",
+      "device": "/dev/mapper/rhel_rhel8-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "69.97 GiB",
+      "size_bytes": 75125227520,
+      "used": "2.62 GiB",
+      "used_bytes": 2817994752
+    },
+    "/boot": {
+      "available": "823.84 MiB",
+      "available_bytes": 863862784,
+      "capacity": "18.75%",
+      "device": "/dev/sda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "190.16 MiB",
+      "used_bytes": 199393280
+    },
+    "/dev": {
+      "available": "890.11 MiB",
+      "available_bytes": 933351424,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=911476k",
+        "nr_inodes=227869",
+        "mode=755"
+      ],
+      "size": "890.11 MiB",
+      "size_bytes": 933351424,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "908.55 MiB",
+      "available_bytes": 952688640,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "892.16 MiB",
+      "available_bytes": 935501824,
+      "capacity": "1.80%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "16.39 MiB",
+      "used_bytes": 17186816
+    },
+    "/run/user/1000": {
+      "available": "181.71 MiB",
+      "available_bytes": 190537728,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=186072k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "181.71 MiB",
+      "size_bytes": 190537728,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "908.55 MiB",
+      "available_bytes": 952688640,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "1.68 TiB",
+      "available_bytes": 1851170680832,
+      "capacity": "7.43%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "1.82 TiB",
+      "size_bytes": 1999738298368,
+      "used": "138.36 GiB",
+      "used_bytes": 148567617536
+    }
+  },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
@@ -139,7 +350,7 @@
           }
         ],
         "ip": "10.0.2.15",
-        "mac": "08:00:27:dc:e4:34",
+        "mac": "08:00:27:75:c4:9b",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "network": "10.0.2.0"
@@ -159,7 +370,7 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:dc:e4:34",
+    "mac": "08:00:27:75:c4:9b",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "network": "10.0.2.0",
@@ -201,55 +412,58 @@
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
+      "mount": "/",
       "size": "70.00 GiB",
       "size_bytes": 75161927680,
-      "uuid": "a3dfbd25-503a-413a-a281-45cfaad69feb"
+      "uuid": "aff90eef-5284-45bb-b8e7-b7eb6041f432"
     },
     "/dev/mapper/rhel_rhel8-swap": {
       "filesystem": "swap",
       "size": "2.06 GiB",
       "size_bytes": 2210398208,
-      "uuid": "7e5dc044-a7d1-4384-8a2e-e5d829e31945"
+      "uuid": "5b20229a-5202-4cb8-bb1c-cf3d2e5e1e4c"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
-      "partuuid": "b3c3fd6c-01",
+      "mount": "/boot",
+      "partuuid": "18628db8-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "ae6c1777-c1c9-42a1-8fcf-513077aac39b"
+      "uuid": "68ac9249-ebc1-4c53-8991-17bd52dc4135"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "b3c3fd6c-02",
+      "partuuid": "18628db8-02",
       "size": "127.00 GiB",
       "size_bytes": 136364163072,
-      "uuid": "g7SkxV-RYrT-JL47-mMcA-qBOB-Zjjk-mdaQSN"
+      "uuid": "9x9cKz-OdFp-R1be-hG92-xZ35-Wb9d-rlv9qt"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
   "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+  "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
     "models": [
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
     ],
     "physicalcount": 1,
-    "speed": "1.70 GHz"
+    "speed": "3.00 GHz"
   },
   "productname": "VirtualBox",
+  "puppetversion": "7.5.0",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-    "version": "2.5.3"
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.2"
   },
   "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.3",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.2",
   "selinux": true,
   "selinux_config_mode": "enforcing",
   "selinux_config_policy": "targeted",
@@ -260,35 +474,35 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 48db451610fb9ec65a275f44b48149130433b66f",
-        "sha256": "SSHFP 3 2 12d510705fce7e2babb9e58afa5bc7df8ae748ddd4f5e9e77de5acd0ec866e77"
+        "sha1": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992",
+        "sha256": "SSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGh+XkQJYz45F9uBJUyorl1cE6/voU/zDOuhzQvD/wmdnMAZqdGR9nzj/u2dx0GKbK79XTgtadekJmW+fzwT7BQ=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 23ed1e0ceb72933591728836762eb65031205a39",
-        "sha256": "SSHFP 4 2 a612ea6a3d43a92062e1b84703e5b498f07a1edd3c24f3ce555ad5c23a36c711"
+        "sha1": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c",
+        "sha256": "SSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIA2aLi6UOtT0udUe5sFnrYszlG1pio5h/NBCYmIgbda4",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 50e249431559c623f0a693983f2dac0fcf3b943b",
-        "sha256": "SSHFP 1 2 daa988ad809bb76fe350b4ca5794bdf9a57240ea64bc1c29a7e7a52b9dd48c87"
+        "sha1": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e",
+        "sha256": "SSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9GeFR3D7dTmzfYrRvto65d7e19TrzAqSkMQ1uPpC2zCeEY3bnxx4xjlS1YYPxnFSAYPUdprE1hdJWZIrRrF5wCfMNmRKyzxXeG8bIOhLz03Fi4J1ntKI3UMaBeiHOCEf2/IxKgorz6iUyg3IPhU2qeZaJGbXVR70fpSO6QWj/jV35npP9GwFij0Yew65xY1h83qkQlElm6VzKJ7DEqeb4bai3pUEXaqUc76X/4YRNWIC1+/XR+kNlDzAFfxEQXTLsn4l3hXcapTCp39q2jQTRtMRWiN33X3MTsZshf7H5bFO8Lckb8DxrWagWiMdyiBIIg7zdGz8oYrUCPe9gZbI8tA30mzMhB+YcXULSrmwsvqvU/sfYZMaDu+v60o4r04cqax8F1rCTHp45d1Vrqig94JPKGw2rZ3GNJambNnuRr5H4ruAHABwA6O11tNpNwk6Gwkzi3ZNB1fEXRL2HDbWOSPTO+1W8p/OtTibjJnleLEkyViQdZ0h5UmTwXisqcoc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGh+XkQJYz45F9uBJUyorl1cE6/voU/zDOuhzQvD/wmdnMAZqdGR9nzj/u2dx0GKbK79XTgtadekJmW+fzwT7BQ=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIA2aLi6UOtT0udUe5sFnrYszlG1pio5h/NBCYmIgbda4",
-  "sshfp_ecdsa": "SSHFP 3 1 48db451610fb9ec65a275f44b48149130433b66f\nSSHFP 3 2 12d510705fce7e2babb9e58afa5bc7df8ae748ddd4f5e9e77de5acd0ec866e77",
-  "sshfp_ed25519": "SSHFP 4 1 23ed1e0ceb72933591728836762eb65031205a39\nSSHFP 4 2 a612ea6a3d43a92062e1b84703e5b498f07a1edd3c24f3ce555ad5c23a36c711",
-  "sshfp_rsa": "SSHFP 1 1 50e249431559c623f0a693983f2dac0fcf3b943b\nSSHFP 1 2 daa988ad809bb76fe350b4ca5794bdf9a57240ea64bc1c29a7e7a52b9dd48c87",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9GeFR3D7dTmzfYrRvto65d7e19TrzAqSkMQ1uPpC2zCeEY3bnxx4xjlS1YYPxnFSAYPUdprE1hdJWZIrRrF5wCfMNmRKyzxXeG8bIOhLz03Fi4J1ntKI3UMaBeiHOCEf2/IxKgorz6iUyg3IPhU2qeZaJGbXVR70fpSO6QWj/jV35npP9GwFij0Yew65xY1h83qkQlElm6VzKJ7DEqeb4bai3pUEXaqUc76X/4YRNWIC1+/XR+kNlDzAFfxEQXTLsn4l3hXcapTCp39q2jQTRtMRWiN33X3MTsZshf7H5bFO8Lckb8DxrWagWiMdyiBIIg7zdGz8oYrUCPe9gZbI8tA30mzMhB+YcXULSrmwsvqvU/sfYZMaDu+v60o4r04cqax8F1rCTHp45d1Vrqig94JPKGw2rZ3GNJambNnuRr5H4ruAHABwA6O11tNpNwk6Gwkzi3ZNB1fEXRL2HDbWOSPTO+1W8p/OtTibjJnleLEkyViQdZ0h5UmTwXisqcoc=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
+  "sshfp_ecdsa": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992\nSSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1",
+  "sshfp_ed25519": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c\nSSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc",
+  "sshfp_rsa": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e\nSSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
   "swapfree": "2.06 GiB",
   "swapfree_mb": 2108.0,
   "swapsize": "2.06 GiB",
@@ -296,14 +510,14 @@
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 133,
-    "uptime": "0:02 hours"
+    "seconds": 203,
+    "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 133,
-  "uuid": "9e6ae33f-ed34-471c-ab4f-ff8cfc4d9f78",
+  "uptime_seconds": 203,
+  "uuid": "27961108-1973-4660-a1b0-938050051403",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/redhat-8-x86_64.facts
+++ b/facts/4.1/redhat-8-x86_64.facts
@@ -1,5 +1,5 @@
 {
-  "aio_agent_version": "6.6.0",
+  "aio_agent_version": "7.6.1",
   "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
@@ -46,7 +46,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "9e6ae33f-ed34-471c-ab4f-ff8cfc4d9f78"
+      "uuid": "27961108-1973-4660-a1b0-938050051403"
     }
   },
   "domain": "example.com",
@@ -54,7 +54,6 @@
   "filesystems": "xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.1.0",
   "gid": "root",
   "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
@@ -83,15 +82,15 @@
   "kernelrelease": "4.18.0-305.el8.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.13,
-    "1m": 0.83,
-    "5m": 0.34
+    "15m": 0.34,
+    "1m": 1.58,
+    "5m": 0.85
   },
   "lsbdistrelease": "8.4",
   "lsbmajdistrelease": "8",
   "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:dc:e4:34",
-  "macaddress_eth0": "08:00:27:dc:e4:34",
+  "macaddress": "08:00:27:75:c4:9b",
+  "macaddress_eth0": "08:00:27:75:c4:9b",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -104,19 +103,231 @@
       "used_bytes": 0
     },
     "system": {
-      "available": "1.38 GiB",
-      "available_bytes": 1484369920,
-      "capacity": "22.10%",
+      "available": "1.35 GiB",
+      "available_bytes": 1449517056,
+      "capacity": "23.92%",
       "total": "1.77 GiB",
       "total_bytes": 1905377280,
-      "used": "401.50 MiB",
-      "used_bytes": 421007360
+      "used": "434.74 MiB",
+      "used_bytes": 455860224
     }
   },
-  "memoryfree": "1.38 GiB",
-  "memoryfree_mb": 1415.60546875,
+  "memoryfree": "1.35 GiB",
+  "memoryfree_mb": 1382.3671875,
   "memorysize": "1.77 GiB",
   "memorysize_mb": 1817.109375,
+  "mountpoints": {
+    "/": {
+      "available": "67.34 GiB",
+      "available_bytes": 72305332224,
+      "capacity": "3.75%",
+      "device": "/dev/mapper/rhel_rhel8-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "69.97 GiB",
+      "size_bytes": 75125227520,
+      "used": "2.63 GiB",
+      "used_bytes": 2819895296
+    },
+    "/boot": {
+      "available": "823.84 MiB",
+      "available_bytes": 863862784,
+      "capacity": "18.75%",
+      "device": "/dev/sda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "190.16 MiB",
+      "used_bytes": 199393280
+    },
+    "/dev": {
+      "available": "890.11 MiB",
+      "available_bytes": 933351424,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=911476k",
+        "nr_inodes=227869",
+        "mode=755"
+      ],
+      "size": "890.11 MiB",
+      "size_bytes": 933351424,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "908.55 MiB",
+      "available_bytes": 952688640,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "892.16 MiB",
+      "available_bytes": 935497728,
+      "capacity": "1.80%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "16.39 MiB",
+      "used_bytes": 17190912
+    },
+    "/run/user/1000": {
+      "available": "181.71 MiB",
+      "available_bytes": 190537728,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=186072k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "181.71 MiB",
+      "size_bytes": 190537728,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "908.55 MiB",
+      "available_bytes": 952688640,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "908.55 MiB",
+      "size_bytes": 952688640,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "1.68 TiB",
+      "available_bytes": 1851170660352,
+      "capacity": "7.43%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "1.82 TiB",
+      "size_bytes": 1999738298368,
+      "used": "138.36 GiB",
+      "used_bytes": 148567638016
+    }
+  },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
@@ -139,7 +350,7 @@
           }
         ],
         "ip": "10.0.2.15",
-        "mac": "08:00:27:dc:e4:34",
+        "mac": "08:00:27:75:c4:9b",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "network": "10.0.2.0"
@@ -159,7 +370,7 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:dc:e4:34",
+    "mac": "08:00:27:75:c4:9b",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "network": "10.0.2.0",
@@ -201,57 +412,60 @@
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
+      "mount": "/",
       "size": "70.00 GiB",
       "size_bytes": 75161927680,
-      "uuid": "a3dfbd25-503a-413a-a281-45cfaad69feb"
+      "uuid": "aff90eef-5284-45bb-b8e7-b7eb6041f432"
     },
     "/dev/mapper/rhel_rhel8-swap": {
       "filesystem": "swap",
       "size": "2.06 GiB",
       "size_bytes": 2210398208,
-      "uuid": "7e5dc044-a7d1-4384-8a2e-e5d829e31945"
+      "uuid": "5b20229a-5202-4cb8-bb1c-cf3d2e5e1e4c"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
-      "partuuid": "b3c3fd6c-01",
+      "mount": "/boot",
+      "partuuid": "18628db8-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "ae6c1777-c1c9-42a1-8fcf-513077aac39b"
+      "uuid": "68ac9249-ebc1-4c53-8991-17bd52dc4135"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "b3c3fd6c-02",
+      "partuuid": "18628db8-02",
       "size": "127.00 GiB",
       "size_bytes": 136364163072,
-      "uuid": "g7SkxV-RYrT-JL47-mMcA-qBOB-Zjjk-mdaQSN"
+      "uuid": "9x9cKz-OdFp-R1be-hG92-xZ35-Wb9d-rlv9qt"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
   "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+  "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
     "isa": "x86_64",
     "models": [
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
     ],
     "physicalcount": 1,
-    "speed": "1.70 GHz",
+    "speed": "3.00 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
+  "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-    "version": "2.5.3"
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.3"
   },
   "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.3",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.3",
   "selinux": true,
   "selinux_config_mode": "enforcing",
   "selinux_config_policy": "targeted",
@@ -262,35 +476,35 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 48db451610fb9ec65a275f44b48149130433b66f",
-        "sha256": "SSHFP 3 2 12d510705fce7e2babb9e58afa5bc7df8ae748ddd4f5e9e77de5acd0ec866e77"
+        "sha1": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992",
+        "sha256": "SSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGh+XkQJYz45F9uBJUyorl1cE6/voU/zDOuhzQvD/wmdnMAZqdGR9nzj/u2dx0GKbK79XTgtadekJmW+fzwT7BQ=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 23ed1e0ceb72933591728836762eb65031205a39",
-        "sha256": "SSHFP 4 2 a612ea6a3d43a92062e1b84703e5b498f07a1edd3c24f3ce555ad5c23a36c711"
+        "sha1": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c",
+        "sha256": "SSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIA2aLi6UOtT0udUe5sFnrYszlG1pio5h/NBCYmIgbda4",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 50e249431559c623f0a693983f2dac0fcf3b943b",
-        "sha256": "SSHFP 1 2 daa988ad809bb76fe350b4ca5794bdf9a57240ea64bc1c29a7e7a52b9dd48c87"
+        "sha1": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e",
+        "sha256": "SSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9GeFR3D7dTmzfYrRvto65d7e19TrzAqSkMQ1uPpC2zCeEY3bnxx4xjlS1YYPxnFSAYPUdprE1hdJWZIrRrF5wCfMNmRKyzxXeG8bIOhLz03Fi4J1ntKI3UMaBeiHOCEf2/IxKgorz6iUyg3IPhU2qeZaJGbXVR70fpSO6QWj/jV35npP9GwFij0Yew65xY1h83qkQlElm6VzKJ7DEqeb4bai3pUEXaqUc76X/4YRNWIC1+/XR+kNlDzAFfxEQXTLsn4l3hXcapTCp39q2jQTRtMRWiN33X3MTsZshf7H5bFO8Lckb8DxrWagWiMdyiBIIg7zdGz8oYrUCPe9gZbI8tA30mzMhB+YcXULSrmwsvqvU/sfYZMaDu+v60o4r04cqax8F1rCTHp45d1Vrqig94JPKGw2rZ3GNJambNnuRr5H4ruAHABwA6O11tNpNwk6Gwkzi3ZNB1fEXRL2HDbWOSPTO+1W8p/OtTibjJnleLEkyViQdZ0h5UmTwXisqcoc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGh+XkQJYz45F9uBJUyorl1cE6/voU/zDOuhzQvD/wmdnMAZqdGR9nzj/u2dx0GKbK79XTgtadekJmW+fzwT7BQ=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIA2aLi6UOtT0udUe5sFnrYszlG1pio5h/NBCYmIgbda4",
-  "sshfp_ecdsa": "SSHFP 3 1 48db451610fb9ec65a275f44b48149130433b66f\nSSHFP 3 2 12d510705fce7e2babb9e58afa5bc7df8ae748ddd4f5e9e77de5acd0ec866e77",
-  "sshfp_ed25519": "SSHFP 4 1 23ed1e0ceb72933591728836762eb65031205a39\nSSHFP 4 2 a612ea6a3d43a92062e1b84703e5b498f07a1edd3c24f3ce555ad5c23a36c711",
-  "sshfp_rsa": "SSHFP 1 1 50e249431559c623f0a693983f2dac0fcf3b943b\nSSHFP 1 2 daa988ad809bb76fe350b4ca5794bdf9a57240ea64bc1c29a7e7a52b9dd48c87",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9GeFR3D7dTmzfYrRvto65d7e19TrzAqSkMQ1uPpC2zCeEY3bnxx4xjlS1YYPxnFSAYPUdprE1hdJWZIrRrF5wCfMNmRKyzxXeG8bIOhLz03Fi4J1ntKI3UMaBeiHOCEf2/IxKgorz6iUyg3IPhU2qeZaJGbXVR70fpSO6QWj/jV35npP9GwFij0Yew65xY1h83qkQlElm6VzKJ7DEqeb4bai3pUEXaqUc76X/4YRNWIC1+/XR+kNlDzAFfxEQXTLsn4l3hXcapTCp39q2jQTRtMRWiN33X3MTsZshf7H5bFO8Lckb8DxrWagWiMdyiBIIg7zdGz8oYrUCPe9gZbI8tA30mzMhB+YcXULSrmwsvqvU/sfYZMaDu+v60o4r04cqax8F1rCTHp45d1Vrqig94JPKGw2rZ3GNJambNnuRr5H4ruAHABwA6O11tNpNwk6Gwkzi3ZNB1fEXRL2HDbWOSPTO+1W8p/OtTibjJnleLEkyViQdZ0h5UmTwXisqcoc=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
+  "sshfp_ecdsa": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992\nSSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1",
+  "sshfp_ed25519": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c\nSSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc",
+  "sshfp_rsa": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e\nSSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
   "swapfree": "2.06 GiB",
   "swapfree_mb": 2107.99609375,
   "swapsize": "2.06 GiB",
@@ -298,14 +512,14 @@
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 135,
-    "uptime": "0:02 hours"
+    "seconds": 223,
+    "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 135,
-  "uuid": "9e6ae33f-ed34-471c-ab4f-ff8cfc4d9f78",
+  "uptime_seconds": 223,
+  "uuid": "27961108-1973-4660-a1b0-938050051403",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/debian-11-x86_64.facts
+++ b/facts/4.2/debian-11-x86_64.facts
@@ -1,5 +1,5 @@
 {
-  "aio_agent_version": "6.24.0",
+  "aio_agent_version": "7.12.0",
   "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
@@ -47,7 +47,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "3d18202c-5f26-1a4c-90de-b77d957db4f8"
+      "uuid": "24df0931-a04b-bf45-94b5-5b370b55bee9"
     }
   },
   "domain": "example.com",
@@ -55,7 +55,6 @@
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.2.0",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
@@ -76,45 +75,232 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fede:c333",
-  "ipaddress6_eth0": "fe80::a00:27ff:fede:c333",
+  "ipaddress6": "fe80::a00:27ff:fe0e:e67a",
+  "ipaddress6_eth0": "fe80::a00:27ff:fe0e:e67a",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
   "kernelmajversion": "5.10",
-  "kernelrelease": "5.10.0-8-amd64",
+  "kernelrelease": "5.10.0-9-amd64",
   "kernelversion": "5.10.0",
   "load_averages": {
-    "15m": 0.09,
-    "1m": 0.81,
-    "5m": 0.25
+    "15m": 0.15,
+    "1m": 0.93,
+    "5m": 0.39
   },
   "lsbdistcodename": "bullseye",
   "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
   "lsbdistid": "Debian",
-  "lsbdistrelease": "11.0",
+  "lsbdistrelease": "11.1",
   "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:de:c3:33",
-  "macaddress_eth0": "08:00:27:de:c3:33",
+  "lsbminordistrelease": "1",
+  "macaddress": "08:00:27:0e:e6:7a",
+  "macaddress_eth0": "08:00:27:0e:e6:7a",
   "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
-      "available": "1.69 GiB",
-      "available_bytes": 1819942912,
-      "capacity": "12.46%",
+      "available": "1.67 GiB",
+      "available_bytes": 1789521920,
+      "capacity": "13.93%",
       "total": "1.94 GiB",
-      "total_bytes": 2079068160,
-      "used": "247.12 MiB",
-      "used_bytes": 259125248
+      "total_bytes": 2079055872,
+      "used": "276.12 MiB",
+      "used_bytes": 289533952
     }
   },
-  "memoryfree": "1.69 GiB",
-  "memoryfree_mb": 1735.6328125,
+  "memoryfree": "1.67 GiB",
+  "memoryfree_mb": 1706.62109375,
   "memorysize": "1.94 GiB",
-  "memorysize_mb": 1982.75390625,
+  "memorysize_mb": 1982.7421875,
+  "mountpoints": {
+    "/": {
+      "available": "16.83 GiB",
+      "available_bytes": 18069925888,
+      "capacity": "9.04%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime",
+        "errors=remount-ro"
+      ],
+      "size": "19.52 GiB",
+      "size_bytes": 20955348992,
+      "used": "1.67 GiB",
+      "used_bytes": 1795010560
+    },
+    "/dev": {
+      "available": "975.47 MiB",
+      "available_bytes": 1022857216,
+      "capacity": "0%",
+      "device": "udev",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "relatime",
+        "size=998884k",
+        "nr_inodes=249721",
+        "mode=755"
+      ],
+      "size": "975.47 MiB",
+      "size_bytes": 1022857216,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "991.37 MiB",
+      "available_bytes": 1039527936,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "991.37 MiB",
+      "size_bytes": 1039527936,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "195.40 MiB",
+      "available_bytes": 204894208,
+      "capacity": "1.45%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=203036k",
+        "mode=755"
+      ],
+      "size": "198.28 MiB",
+      "size_bytes": 207908864,
+      "used": "2.88 MiB",
+      "used_bytes": 3014656
+    },
+    "/run/lock": {
+      "available": "5.00 MiB",
+      "available_bytes": 5242880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=5120k"
+      ],
+      "size": "5.00 MiB",
+      "size_bytes": 5242880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "198.27 MiB",
+      "available_bytes": 207904768,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=203032k",
+        "nr_inodes=50758",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "198.27 MiB",
+      "size_bytes": 207904768,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "1.68 TiB",
+      "available_bytes": 1847910035456,
+      "capacity": "7.59%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "1.82 TiB",
+      "size_bytes": 1999738298368,
+      "used": "141.40 GiB",
+      "used_bytes": 151828262912
+    }
+  },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
@@ -145,7 +331,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fede:c333",
+            "address": "fe80::a00:27ff:fe0e:e67a",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -156,8 +342,8 @@
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fede:c333",
-        "mac": "08:00:27:de:c3:33",
+        "ip6": "fe80::a00:27ff:fe0e:e67a",
+        "mac": "08:00:27:0e:e6:7a",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -195,8 +381,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fede:c333",
-    "mac": "08:00:27:de:c3:33",
+    "ip6": "fe80::a00:27ff:fe0e:e67a",
+    "mac": "08:00:27:0e:e6:7a",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -207,7 +393,7 @@
   },
   "operatingsystem": "Debian",
   "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.0",
+  "operatingsystemrelease": "11.1",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -215,18 +401,18 @@
       "description": "Debian GNU/Linux 11 (bullseye)",
       "id": "Debian",
       "release": {
-        "full": "11.0",
+        "full": "11.1",
         "major": "11",
-        "minor": "0"
+        "minor": "1"
       }
     },
     "family": "Debian",
     "hardware": "x86_64",
     "name": "Debian",
     "release": {
-      "full": "11.0",
+      "full": "11.1",
       "major": "11",
-      "minor": "0"
+      "minor": "1"
     },
     "selinux": {
       "enabled": false
@@ -237,38 +423,40 @@
     "/dev/sda1": {
       "filesystem": "ext4",
       "label": "root",
-      "partuuid": "e20a10d0-01",
+      "mount": "/",
+      "partuuid": "ced51ae4-01",
       "size": "20.00 GiB",
       "size_bytes": 21472739328,
-      "uuid": "4539dbb4-1c3f-4de4-a6b0-eaebb53f4656"
+      "uuid": "591397da-e911-4277-bf43-db0b99840752"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
   "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+  "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
     "isa": "unknown",
     "models": [
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
     ],
     "physicalcount": 1,
-    "speed": "1.70 GHz",
+    "speed": "3.00 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
+  "puppetversion": "7.12.0",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-    "version": "2.5.9"
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.3"
   },
   "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.3",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -277,56 +465,56 @@
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 20714333e369256013d97ab72b7958c1a99f7eb4",
-        "sha256": "SSHFP 2 2 f0d40553684d823370ced44972e45bd8ba45691ec1cfda9b2f65559cf0d41dc1"
+        "sha1": "SSHFP 2 1 69b39921f8b28901a1976e9a70bfca0ae2931cc2",
+        "sha256": "SSHFP 2 2 d71e7fd88c2644af82de90343f340fb4b97d810ef013b8792226b2d473b15eb7"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAPmGgtQAi0xpVkov/yMQmgsv71SO7bhdZnDynjFsJBMl/5J5L2LtI7HjOZ3OaZkOUho6JcdaU7SPbIiRCUFeTEg7l54z8I/EkAHU5fYbK5sBhG29599uMop2d4BRUcWpKYF6TY2ZZmKx/vkh1HWOQJtnukyxrNY3TD/v5pgKLldvAAAAFQDCTotLZejo9AZfLrrVXNiaWZoBNwAAAIEApG8AEoyzk2j8VKPDEME2WCRG200U0E67LpPA6dAwPSekGGenfOHNAO08Te4KIKjKgyh0UONjokIzLqkwnZYDzRc/BH0UsdU/6eGjWVTN4k4KvaQ3mRNbv8F3xbJlSiD/18CReLgF0aZeBY+ErhOsg5Jvl9IbafQmIobICmY4CTcAAACBALRsdlN3WZKZU8L9Hv7K7YMCBoSdekWf8buCihUDTvQtrvmDEIkDXUXVrMcqd8+bZrUc/iDmO1oHqGmyCZES7cPoJs9L2AVGqGCQEfnw0BUgNSNgrhDh1pRvw5wfdPAVgM8fp1oXZWdmBFV3tPVQM6fMoY3+ZO8p4h8UMbfNuEBM",
+      "key": "AAAAB3NzaC1kc3MAAACBANLCkJONqWKqB1y5DoZiOsvIqinwOwF2D0Yvc8afBADOb9Rz7UhtZg0t+foNJRkBk6/FBuCylIxJVotB4YzfhumHgsBt67rn84ABledRPeXjLC/cZ4lPawe4Hc1omeoEm7G5WTBgy9Hy/gF1X7+Iq6rhlYavqyjwRj79lvZESjgfAAAAFQDOW4KuHMz5OVisFw6kcUY5Pk2FswAAAIA0Azd0Nspj2AF2qGHRUg9Vu6ekduJqYVzZfL5Dc9+hAGHUzg48bgJfuXtEnH/G4Dk5WkkYTxrqtQA8HIxFQJyYao6KFntz6LNYF5b6MguBDvsyT4DdDsW7W+0gJbP8wNiC00bjjr56v9e+/zl6C/L1Sw73635riSElyDG+wO9DkwAAAIEAtU35EgoW1Qc61vTPQKhqcvz3GD7mLJs9VXx+v/YK8ivtyl0otpw7OfFeDm6PUduPtuikLN3QOK+z9sWWBRgoYBLQMJvvIF7uXN9J01ROi1s6wDQGlKd8zYCieVkhGsGm3qyXw/rqQYRojrsOq5JfsLrBK40OIDKZ/1QeB9aZRXE=",
       "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 9f6ff369030d3f6b2fe9eceb1eaf21f64afe7672",
-        "sha256": "SSHFP 3 2 904f97eb50eaaa3b3c61451135d7ac3b8d54d183dbe64a72d8b5e522d16dbd4f"
+        "sha1": "SSHFP 3 1 07457179da950794b007a67344a6d3dee55c671e",
+        "sha256": "SSHFP 3 2 d63e11d5bf3ffb75e9c97ba01321099c4ca15604b50f79c4e34a48620855308f"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEwNCZvagei6e3QhTzBCW2h6DJGXEG91ISYCdWYpYoJcRuy14HDmBEGopvmw2QVEfff/SIMKFFAVzYOzRHxbfBI=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI3l5N8KQpH6uwyWk49Pvb3eD7TeMMpN0MGleJJ2/m1dLSMQypH6Fa+yf4Uvgo/EdkJVfSBIr8ppNUZe1DPIswM=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 400fb26de786c404d69d72d74498289d65a4aa05",
-        "sha256": "SSHFP 4 2 eefdb0a5a135c3e0eedeade50921789b6d3aed0c521a06adb95c90c2c72f0830"
+        "sha1": "SSHFP 4 1 e87c8fe6185f678730522689b91744fca0284ae1",
+        "sha256": "SSHFP 4 2 4c61563cc9103a4b89b517ef91e1a8269d6dddafef923a54c5148e8fc3e1325f"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPkDp91xozn1K1S9t9mhb12CghjqUrYNWs6+At1Vr7fK",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIIw100belXkwWA6NgID9V2GQGvXLRF33BFkId/YF+jpW",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 7406e4fe0149296318ef1693dc7569df9ca97a02",
-        "sha256": "SSHFP 1 2 a3eef44f719b3fc2de062976484f1a6c920626880ec5ac9113a1f5835c798453"
+        "sha1": "SSHFP 1 1 7cf767f640d86e0b4a1d2dbf062ea6d507157740",
+        "sha256": "SSHFP 1 2 98ac6144eb3bbd169f304dfac09deb06ac4e2e29ecfe41d081a230831dd3bef6"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC8c1q6m7UHy59FIZngbc78cY13D+JZR1bqe4QySQb2HqYmO7KboU8GTwogkKO+T20cYwyfD/+7YwpzPoXujqFNLPoCIdbffz+a5dIeFCdzV2yqArIi6InzCG/9jHPFbciEaEkIgZh5usCAs0pNEpihMxj2UpI8R29+GK6jSAgckWOucrqprd7MO6xus5SDLZAUD59y25f/viPNYjKye0PdXZrJO/vwIqD6jE64x3BvMdStyS+MuQbbHJVQAeMWC2rEiEqb2pyH8gLnQNGGP2lYcssBGLt28E3145jDXAOSW3EhEEoMjBFko6tDWnXo/0TbofH9jZYfjF2IOZWwekUmKhPiTKyP8cJba34VfciY0o20SZAeeD42MYRvsk3FC3Ux+sfP6h+HTjPr9BUGg0Msf+2GMAc5ncaVI+LqTu4FUn5bLpIhXEU/ytOr9+qfXiaLRrfr+92yJlMTM3w127M7U6NDYBhqGKD2dMmLMrfgIdQDdvWMF0kzufVuxFKbzjU=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCm4rA1Hv20QFSnNntRoP5A/ADlG9YFpGhjlVlMITOSjlBAtiuaufQ7LibVd47p/0qou8VuT/FPptSr+mHoDl+w/IG5zz2bhcfN3H1BCUMyDCh2XntxCLRASXNxzjj6NFI4TzS7cZEwU6skKPszTzL1MvjaUcWT7H6DeIazwG2qZOFcRato7O++TC+51SkpTbfGda/TBk9vqa5ma78+BbQLgnukzrtOqfbnwuZXms/9rQcQ0wmSmsRnIdzC5MZhQIbq4Z9koQeRaXKSpYm89nitRqYFMW91iS6ndIq2pNwJh7OnIrRUAHngw7IUlxApOoIqe0zc7SDikToNDMQgDhmkO8ivggo2CTdrKNuj2sUBl9jCLFbSTge2D4r0zHAL9pKxNK+gzFJdVfBZZwuUKdYjSjutHYH7q/G/Ti0dhdF2Vp1G0JuXb0A1xymgXowIG9Rf6maULEKJhuNJD9/tlomqO2E1/7BcoyMzwRJ6TihuriY+T5eO8GZTQyfxQ1YVvMU=",
       "type": "ssh-rsa"
     }
   },
-  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPmGgtQAi0xpVkov/yMQmgsv71SO7bhdZnDynjFsJBMl/5J5L2LtI7HjOZ3OaZkOUho6JcdaU7SPbIiRCUFeTEg7l54z8I/EkAHU5fYbK5sBhG29599uMop2d4BRUcWpKYF6TY2ZZmKx/vkh1HWOQJtnukyxrNY3TD/v5pgKLldvAAAAFQDCTotLZejo9AZfLrrVXNiaWZoBNwAAAIEApG8AEoyzk2j8VKPDEME2WCRG200U0E67LpPA6dAwPSekGGenfOHNAO08Te4KIKjKgyh0UONjokIzLqkwnZYDzRc/BH0UsdU/6eGjWVTN4k4KvaQ3mRNbv8F3xbJlSiD/18CReLgF0aZeBY+ErhOsg5Jvl9IbafQmIobICmY4CTcAAACBALRsdlN3WZKZU8L9Hv7K7YMCBoSdekWf8buCihUDTvQtrvmDEIkDXUXVrMcqd8+bZrUc/iDmO1oHqGmyCZES7cPoJs9L2AVGqGCQEfnw0BUgNSNgrhDh1pRvw5wfdPAVgM8fp1oXZWdmBFV3tPVQM6fMoY3+ZO8p4h8UMbfNuEBM",
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEwNCZvagei6e3QhTzBCW2h6DJGXEG91ISYCdWYpYoJcRuy14HDmBEGopvmw2QVEfff/SIMKFFAVzYOzRHxbfBI=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPkDp91xozn1K1S9t9mhb12CghjqUrYNWs6+At1Vr7fK",
-  "sshfp_dsa": "SSHFP 2 1 20714333e369256013d97ab72b7958c1a99f7eb4\nSSHFP 2 2 f0d40553684d823370ced44972e45bd8ba45691ec1cfda9b2f65559cf0d41dc1",
-  "sshfp_ecdsa": "SSHFP 3 1 9f6ff369030d3f6b2fe9eceb1eaf21f64afe7672\nSSHFP 3 2 904f97eb50eaaa3b3c61451135d7ac3b8d54d183dbe64a72d8b5e522d16dbd4f",
-  "sshfp_ed25519": "SSHFP 4 1 400fb26de786c404d69d72d74498289d65a4aa05\nSSHFP 4 2 eefdb0a5a135c3e0eedeade50921789b6d3aed0c521a06adb95c90c2c72f0830",
-  "sshfp_rsa": "SSHFP 1 1 7406e4fe0149296318ef1693dc7569df9ca97a02\nSSHFP 1 2 a3eef44f719b3fc2de062976484f1a6c920626880ec5ac9113a1f5835c798453",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC8c1q6m7UHy59FIZngbc78cY13D+JZR1bqe4QySQb2HqYmO7KboU8GTwogkKO+T20cYwyfD/+7YwpzPoXujqFNLPoCIdbffz+a5dIeFCdzV2yqArIi6InzCG/9jHPFbciEaEkIgZh5usCAs0pNEpihMxj2UpI8R29+GK6jSAgckWOucrqprd7MO6xus5SDLZAUD59y25f/viPNYjKye0PdXZrJO/vwIqD6jE64x3BvMdStyS+MuQbbHJVQAeMWC2rEiEqb2pyH8gLnQNGGP2lYcssBGLt28E3145jDXAOSW3EhEEoMjBFko6tDWnXo/0TbofH9jZYfjF2IOZWwekUmKhPiTKyP8cJba34VfciY0o20SZAeeD42MYRvsk3FC3Ux+sfP6h+HTjPr9BUGg0Msf+2GMAc5ncaVI+LqTu4FUn5bLpIhXEU/ytOr9+qfXiaLRrfr+92yJlMTM3w127M7U6NDYBhqGKD2dMmLMrfgIdQDdvWMF0kzufVuxFKbzjU=",
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBANLCkJONqWKqB1y5DoZiOsvIqinwOwF2D0Yvc8afBADOb9Rz7UhtZg0t+foNJRkBk6/FBuCylIxJVotB4YzfhumHgsBt67rn84ABledRPeXjLC/cZ4lPawe4Hc1omeoEm7G5WTBgy9Hy/gF1X7+Iq6rhlYavqyjwRj79lvZESjgfAAAAFQDOW4KuHMz5OVisFw6kcUY5Pk2FswAAAIA0Azd0Nspj2AF2qGHRUg9Vu6ekduJqYVzZfL5Dc9+hAGHUzg48bgJfuXtEnH/G4Dk5WkkYTxrqtQA8HIxFQJyYao6KFntz6LNYF5b6MguBDvsyT4DdDsW7W+0gJbP8wNiC00bjjr56v9e+/zl6C/L1Sw73635riSElyDG+wO9DkwAAAIEAtU35EgoW1Qc61vTPQKhqcvz3GD7mLJs9VXx+v/YK8ivtyl0otpw7OfFeDm6PUduPtuikLN3QOK+z9sWWBRgoYBLQMJvvIF7uXN9J01ROi1s6wDQGlKd8zYCieVkhGsGm3qyXw/rqQYRojrsOq5JfsLrBK40OIDKZ/1QeB9aZRXE=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI3l5N8KQpH6uwyWk49Pvb3eD7TeMMpN0MGleJJ2/m1dLSMQypH6Fa+yf4Uvgo/EdkJVfSBIr8ppNUZe1DPIswM=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIIw100belXkwWA6NgID9V2GQGvXLRF33BFkId/YF+jpW",
+  "sshfp_dsa": "SSHFP 2 1 69b39921f8b28901a1976e9a70bfca0ae2931cc2\nSSHFP 2 2 d71e7fd88c2644af82de90343f340fb4b97d810ef013b8792226b2d473b15eb7",
+  "sshfp_ecdsa": "SSHFP 3 1 07457179da950794b007a67344a6d3dee55c671e\nSSHFP 3 2 d63e11d5bf3ffb75e9c97ba01321099c4ca15604b50f79c4e34a48620855308f",
+  "sshfp_ed25519": "SSHFP 4 1 e87c8fe6185f678730522689b91744fca0284ae1\nSSHFP 4 2 4c61563cc9103a4b89b517ef91e1a8269d6dddafef923a54c5148e8fc3e1325f",
+  "sshfp_rsa": "SSHFP 1 1 7cf767f640d86e0b4a1d2dbf062ea6d507157740\nSSHFP 1 2 98ac6144eb3bbd169f304dfac09deb06ac4e2e29ecfe41d081a230831dd3bef6",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCm4rA1Hv20QFSnNntRoP5A/ADlG9YFpGhjlVlMITOSjlBAtiuaufQ7LibVd47p/0qou8VuT/FPptSr+mHoDl+w/IG5zz2bhcfN3H1BCUMyDCh2XntxCLRASXNxzjj6NFI4TzS7cZEwU6skKPszTzL1MvjaUcWT7H6DeIazwG2qZOFcRato7O++TC+51SkpTbfGda/TBk9vqa5ma78+BbQLgnukzrtOqfbnwuZXms/9rQcQ0wmSmsRnIdzC5MZhQIbq4Z9koQeRaXKSpYm89nitRqYFMW91iS6ndIq2pNwJh7OnIrRUAHngw7IUlxApOoIqe0zc7SDikToNDMQgDhmkO8ivggo2CTdrKNuj2sUBl9jCLFbSTge2D4r0zHAL9pKxNK+gzFJdVfBZZwuUKdYjSjutHYH7q/G/Ti0dhdF2Vp1G0JuXb0A1xymgXowIG9Rf6maULEKJhuNJD9/tlomqO2E1/7BcoyMzwRJ6TihuriY+T5eO8GZTQyfxQ1YVvMU=",
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 95,
+    "seconds": 112,
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
   "uptime": "0:01 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 95,
-  "uuid": "3d18202c-5f26-1a4c-90de-b77d957db4f8",
+  "uptime_seconds": 112,
+  "uuid": "24df0931-a04b-bf45-94b5-5b370b55bee9",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-34-x86_64.facts
+++ b/facts/4.2/fedora-34-x86_64.facts
@@ -1,5 +1,5 @@
 {
-  "aio_agent_version": "6.25.0",
+  "aio_agent_version": "7.12.0",
   "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
@@ -46,7 +46,7 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "60fada07-8be3-446e-8e44-bf1775069390"
+      "uuid": "62d55f89-94b0-4900-a33b-4df028bf33ff"
     }
   },
   "domain": "example.com",
@@ -54,15 +54,14 @@
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.2.0",
   "gid": "root",
   "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
-      "revision": "147628",
-      "version": "6.1.28"
+      "revision": "145957",
+      "version": "6.1.26"
     }
   },
   "id": "root",
@@ -79,18 +78,18 @@
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.13",
-  "kernelrelease": "5.13.14-200.fc34.x86_64",
-  "kernelversion": "5.13.14",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.13-200.fc34.x86_64",
+  "kernelversion": "5.14.13",
   "load_averages": {
-    "15m": 0.04,
-    "1m": 0.49,
-    "5m": 0.13
+    "15m": 0.2,
+    "1m": 1.2,
+    "5m": 0.51
   },
   "lsbdistrelease": "34",
   "lsbmajdistrelease": "34",
-  "macaddress": "08:00:27:b7:6d:60",
-  "macaddress_eth0": "08:00:27:b7:6d:60",
+  "macaddress": "08:00:27:c7:3b:23",
+  "macaddress_eth0": "08:00:27:c7:3b:23",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
@@ -103,19 +102,218 @@
       "used_bytes": 0
     },
     "system": {
-      "available": "1.50 GiB",
-      "available_bytes": 1609625600,
-      "capacity": "21.93%",
+      "available": "1.47 GiB",
+      "available_bytes": 1580879872,
+      "capacity": "23.32%",
       "total": "1.92 GiB",
-      "total_bytes": 2061705216,
-      "used": "431.14 MiB",
-      "used_bytes": 452079616
+      "total_bytes": 2061713408,
+      "used": "458.56 MiB",
+      "used_bytes": 480833536
     }
   },
-  "memoryfree": "1.50 GiB",
-  "memoryfree_mb": 1535.05859375,
+  "memoryfree": "1.47 GiB",
+  "memoryfree_mb": 1507.64453125,
   "memorysize": "1.92 GiB",
-  "memorysize_mb": 1966.1953125,
+  "memorysize_mb": 1966.203125,
+  "mountpoints": {
+    "/": {
+      "available": "121.86 GiB",
+      "available_bytes": 130843123712,
+      "capacity": "2.46%",
+      "device": "/dev/mapper/fedora-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "124.94 GiB",
+      "size_bytes": 134148001792,
+      "used": "3.08 GiB",
+      "used_bytes": 3304878080
+    },
+    "/boot": {
+      "available": "883.52 MiB",
+      "available_bytes": 926437376,
+      "capacity": "12.87%",
+      "device": "/dev/sda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "130.48 MiB",
+      "used_bytes": 136818688
+    },
+    "/dev": {
+      "available": "969.92 MiB",
+      "available_bytes": 1017032704,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=993196k",
+        "nr_inodes=248299",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "969.92 MiB",
+      "size_bytes": 1017032704,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "983.10 MiB",
+      "available_bytes": 1030856704,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "983.10 MiB",
+      "size_bytes": 1030856704,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "387.74 MiB",
+      "available_bytes": 406577152,
+      "capacity": "1.40%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=402680k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "393.24 MiB",
+      "size_bytes": 412344320,
+      "used": "5.50 MiB",
+      "used_bytes": 5767168
+    },
+    "/run/user/1000": {
+      "available": "196.61 MiB",
+      "available_bytes": 206163968,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=201336k",
+        "nr_inodes=50334",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "196.62 MiB",
+      "size_bytes": 206168064,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/vagrant": {
+      "available": "1.68 TiB",
+      "available_bytes": 1849519456256,
+      "capacity": "7.51%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "1.82 TiB",
+      "size_bytes": 1999738298368,
+      "used": "139.90 GiB",
+      "used_bytes": 150218842112
+    }
+  },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
@@ -138,7 +336,7 @@
           }
         ],
         "ip": "10.0.2.15",
-        "mac": "08:00:27:b7:6d:60",
+        "mac": "08:00:27:c7:3b:23",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "network": "10.0.2.0"
@@ -158,7 +356,7 @@
       }
     },
     "ip": "10.0.2.15",
-    "mac": "08:00:27:b7:6d:60",
+    "mac": "08:00:27:c7:3b:23",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "network": "10.0.2.0",
@@ -199,58 +397,61 @@
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
       "label": "root",
+      "mount": "/",
       "size": "125.00 GiB",
       "size_bytes": 134213533696,
-      "uuid": "e0c20c8d-d534-4849-9e94-e4c0c9bdddc9"
+      "uuid": "e12aabe4-b5fc-4763-b8d6-88cae44d4852"
     },
     "/dev/mapper/fedora-swap": {
       "filesystem": "swap",
       "size": "2.00 GiB",
       "size_bytes": 2147483648,
-      "uuid": "9912b5c1-7197-40ea-a2f5-625f696a8376"
+      "uuid": "1deab112-ccd3-4443-bfa7-96e1485106b8"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
       "label": "boot",
-      "partuuid": "e20863d6-01",
+      "mount": "/boot",
+      "partuuid": "d8c58091-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "e5dc988f-95d4-4899-826f-5ec5286b7329"
+      "uuid": "72d7f998-aa29-40e3-b23f-2b24d7611c09"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "e20863d6-02",
+      "partuuid": "d8c58091-02",
       "size": "127.00 GiB",
       "size_bytes": 136364163072,
-      "uuid": "KmzS5o-sjMG-5oA7-0bQZ-RHca-8GzU-cfGK0G"
+      "uuid": "AFShL6-PLAA-EvMc-nZ11-ItSS-ceWB-LIGgbQ"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
+  "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+  "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
   "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-      "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz"
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
     ],
     "physicalcount": 1,
-    "speed": "3.79 GHz",
+    "speed": "3.00 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
+  "puppetversion": "7.12.0",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-    "version": "2.5.9"
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.3"
   },
   "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.3",
   "selinux": true,
   "selinux_config_mode": "enforcing",
   "selinux_config_policy": "targeted",
@@ -261,35 +462,35 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 1832500be0cfb082181cdfecfba3fea9485d4fd1",
-        "sha256": "SSHFP 3 2 4c6db057255b2b0e9351eae1878e110fefbb3643b4f5b4f9b53b7e5447595571"
+        "sha1": "SSHFP 3 1 bffef0f2fe23a9119c79bd114182c5e75d88bf96",
+        "sha256": "SSHFP 3 2 e7844b231d4ef435945e31cae9e2324d4a8bea86363bcc2817d768b765677150"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFNADgAiA/atlu41xQmaPAdIhfMlnBFpaIkF9Z3HIRuER/NnfhRlne75qesroYfbrBLhQywplGWqv849v83Xp0s=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIX4AATliWhzrCSK1oQjuGNLcwcPSkVsla7cDYjfnPNHSgGA8dNj9EZv7RV9HmVC/PIbtHz7IawPQvdlWzU41T4=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 aafdfa3638e33ceba720efa3832d71996241e051",
-        "sha256": "SSHFP 4 2 1f12f7f2f80580538fcccffab5b2aee674263d4107ac11fe3f2ca2827e4062e1"
+        "sha1": "SSHFP 4 1 2ea8a0e2d5fe525205f50d46a221c5e813f64a45",
+        "sha256": "SSHFP 4 2 229c0fd63a7c76dc4973ed6becc016118d29329845fc5dde0f0c3cfd76d1b5eb"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOJMAgWcueXLbtL9c9yQ64rGWzyU0EUzKHC2p+JFvbsj",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ1j0r6vS8agiErPPcXtHonRrd2yxORESuiDhweU3d/5",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 f11b9ef5926744f927046ed23dda0ea5707cc94f",
-        "sha256": "SSHFP 1 2 5a64c7ec99316dab1b6bc450b29ab0af2aac1d8143d5dac3ac5289af821bcce3"
+        "sha1": "SSHFP 1 1 f75396acc1878bf4c98cb255c12d2a5a5b0bebda",
+        "sha256": "SSHFP 1 2 4eaa9dd8f78802b4dd1f855fd7d94e7818d98511414cc8c802b5ad42317e408e"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCnSCtxQ1/3YIJWEgq8KwsxQ4lPltKC+VGeXGo4njoZSpTjWYCXh29VPtuvbNCeWFn+lbOaAQG0Kiil4uYeg9RqKvV2cF/30jSK9MfMRGmmy3FjUO3aKAv87S86wTavtl8Lw/0EXRzZ/m+piyaN+MXpTgaJeJVu5wiqnwONf0cVhGAFV932PIY+zsq5rDiDvPJI4M0/+u8Fj+wDB+i+a+7m96mggy1jUQljyUWXBLliHftytd73hG8xYis410Ws9UYUpmxfNMHvtMxhpz23U+ZqmuLizzxXO7maBmI5q6LiHGYfHa9ZSL1zHZmwe7bwCxw0DB5uPpO7gLZeaByqI0QJ0CajBEe+gce4BxZo45VmcVCsVaRF+BaMP6wZYdoXUS1Z2pkIM2GZC7U7VL2AbCE4di80xPg5+sHweAOJluxMauVwbCJsmldwPX7A5gw1/UYxQtbH/FTZN0xQVquRSLbtB/dsVbMkITEshpToU4evGGc3tsjtKxEChiJiGfSDouE=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCmVm0ziG232hGiaFu8i6BPhDl02rP7CjRMmCnRjkcb+9xVN7+T38CnGd7iuiSG54AGzeK27KjjZy979RaG8M36edECn7sAyV/d+C13iGZcCax4yjT05i+VRfV81lfUtQ+2YzqFGozVl6FB45rhwFcF4cQXFTIxzBoEZrXtJP1FET9ToOI8ShRKRZHZh7YZr8VDLd9iStbVh+o3/EJrWkoG8iUos/Iqb7ysx8jT8gfBGvIGEA5njZrg0hCNohMZuFKuiQ3GJhP5eQBh/WINrD9e9DvZBjBfoMgwyjd0h2TRIyQQh8YzN/J3OIxYQYVwwZTiMYXDUSgUyt6MdzJXPjgzLUeXEiCVO1VrJR3kasX59kLkYuzhRKaeKOgMlrEO09A9ILbBVu2Ru+D/d11tZzvT11QSgbTU/pu7JP1sVlXIk0MHTwl0B1XcANXpH8NSYliGgKfIJPSKOcdKQwjcFSi8bo+RrycR5rJCOppM39Qv7vbqRFaCuuWVYkNVQapEtwk=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFNADgAiA/atlu41xQmaPAdIhfMlnBFpaIkF9Z3HIRuER/NnfhRlne75qesroYfbrBLhQywplGWqv849v83Xp0s=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOJMAgWcueXLbtL9c9yQ64rGWzyU0EUzKHC2p+JFvbsj",
-  "sshfp_ecdsa": "SSHFP 3 1 1832500be0cfb082181cdfecfba3fea9485d4fd1\nSSHFP 3 2 4c6db057255b2b0e9351eae1878e110fefbb3643b4f5b4f9b53b7e5447595571",
-  "sshfp_ed25519": "SSHFP 4 1 aafdfa3638e33ceba720efa3832d71996241e051\nSSHFP 4 2 1f12f7f2f80580538fcccffab5b2aee674263d4107ac11fe3f2ca2827e4062e1",
-  "sshfp_rsa": "SSHFP 1 1 f11b9ef5926744f927046ed23dda0ea5707cc94f\nSSHFP 1 2 5a64c7ec99316dab1b6bc450b29ab0af2aac1d8143d5dac3ac5289af821bcce3",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCnSCtxQ1/3YIJWEgq8KwsxQ4lPltKC+VGeXGo4njoZSpTjWYCXh29VPtuvbNCeWFn+lbOaAQG0Kiil4uYeg9RqKvV2cF/30jSK9MfMRGmmy3FjUO3aKAv87S86wTavtl8Lw/0EXRzZ/m+piyaN+MXpTgaJeJVu5wiqnwONf0cVhGAFV932PIY+zsq5rDiDvPJI4M0/+u8Fj+wDB+i+a+7m96mggy1jUQljyUWXBLliHftytd73hG8xYis410Ws9UYUpmxfNMHvtMxhpz23U+ZqmuLizzxXO7maBmI5q6LiHGYfHa9ZSL1zHZmwe7bwCxw0DB5uPpO7gLZeaByqI0QJ0CajBEe+gce4BxZo45VmcVCsVaRF+BaMP6wZYdoXUS1Z2pkIM2GZC7U7VL2AbCE4di80xPg5+sHweAOJluxMauVwbCJsmldwPX7A5gw1/UYxQtbH/FTZN0xQVquRSLbtB/dsVbMkITEshpToU4evGGc3tsjtKxEChiJiGfSDouE=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIX4AATliWhzrCSK1oQjuGNLcwcPSkVsla7cDYjfnPNHSgGA8dNj9EZv7RV9HmVC/PIbtHz7IawPQvdlWzU41T4=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ1j0r6vS8agiErPPcXtHonRrd2yxORESuiDhweU3d/5",
+  "sshfp_ecdsa": "SSHFP 3 1 bffef0f2fe23a9119c79bd114182c5e75d88bf96\nSSHFP 3 2 e7844b231d4ef435945e31cae9e2324d4a8bea86363bcc2817d768b765677150",
+  "sshfp_ed25519": "SSHFP 4 1 2ea8a0e2d5fe525205f50d46a221c5e813f64a45\nSSHFP 4 2 229c0fd63a7c76dc4973ed6becc016118d29329845fc5dde0f0c3cfd76d1b5eb",
+  "sshfp_rsa": "SSHFP 1 1 f75396acc1878bf4c98cb255c12d2a5a5b0bebda\nSSHFP 1 2 4eaa9dd8f78802b4dd1f855fd7d94e7818d98511414cc8c802b5ad42317e408e",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCmVm0ziG232hGiaFu8i6BPhDl02rP7CjRMmCnRjkcb+9xVN7+T38CnGd7iuiSG54AGzeK27KjjZy979RaG8M36edECn7sAyV/d+C13iGZcCax4yjT05i+VRfV81lfUtQ+2YzqFGozVl6FB45rhwFcF4cQXFTIxzBoEZrXtJP1FET9ToOI8ShRKRZHZh7YZr8VDLd9iStbVh+o3/EJrWkoG8iUos/Iqb7ysx8jT8gfBGvIGEA5njZrg0hCNohMZuFKuiQ3GJhP5eQBh/WINrD9e9DvZBjBfoMgwyjd0h2TRIyQQh8YzN/J3OIxYQYVwwZTiMYXDUSgUyt6MdzJXPjgzLUeXEiCVO1VrJR3kasX59kLkYuzhRKaeKOgMlrEO09A9ILbBVu2Ru+D/d11tZzvT11QSgbTU/pu7JP1sVlXIk0MHTwl0B1XcANXpH8NSYliGgKfIJPSKOcdKQwjcFSi8bo+RrycR5rJCOppM39Qv7vbqRFaCuuWVYkNVQapEtwk=",
   "swapfree": "3.92 GiB",
   "swapfree_mb": 4013.9921875,
   "swapsize": "3.92 GiB",
@@ -297,14 +498,14 @@
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 64,
-    "uptime": "0:01 hours"
+    "seconds": 141,
+    "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
+  "uptime": "0:02 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 64,
-  "uuid": "60fada07-8be3-446e-8e44-bf1775069390",
+  "uptime_seconds": 141,
+  "uuid": "62d55f89-94b0-4900-a33b-4df028bf33ff",
   "virtual": "virtualbox"
 }


### PR DESCRIPTION
- Added functionality to get_facts.sh to iterate through the version 7 puppet agents and their facter versions for Debian, Fedora, and RedHat OS families.
- Generated more complete facts for redhat 8
- Generated more complete facts for debian 11
- Generated facter 3.14 facts for fedora 33
- Generated more complete facts for fedora 34

Ref https://github.com/voxpupuli/facterdb/issues/200