### PR TITLE
Fix hostname facts for freebsd13 and add spec test

### DIFF
--- a/facts/4.0/freebsd-13-x86_64.facts
+++ b/facts/4.0/freebsd-13-x86_64.facts
@@ -24,13 +24,14 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "divms.uiowa.edu",
+  "domain": "example.com",
   "facterversion": "4.0.52",
+  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
   "gid": "wheel",
   "hardwareisa": "amd64",
   "hardwaremodel": "amd64",
-  "hostname": "",
+  "hostname": "foo",
   "id": "root",
   "identity": {
     "gid": 0,
@@ -301,8 +302,9 @@
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
   "networking": {
-    "domain": "divms.uiowa.edu",
-    "hostname": "",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
     "interfaces": {
       "em0": {
         "bindings": [

--- a/facts/4.1/freebsd-13-x86_64.facts
+++ b/facts/4.1/freebsd-13-x86_64.facts
@@ -24,13 +24,14 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "divms.uiowa.edu",
+  "domain": "example.com",
   "facterversion": "4.1.1",
+  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
   "gid": "wheel",
   "hardwareisa": "amd64",
   "hardwaremodel": "amd64",
-  "hostname": "",
+  "hostname": "foo",
   "id": "root",
   "identity": {
     "gid": 0,
@@ -301,8 +302,9 @@
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
   "networking": {
-    "domain": "divms.uiowa.edu",
-    "hostname": "",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
     "interfaces": {
       "em0": {
         "bindings": [

--- a/facts/4.2/freebsd-13-x86_64.facts
+++ b/facts/4.2/freebsd-13-x86_64.facts
@@ -24,13 +24,14 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "divms.uiowa.edu",
+  "domain": "example.com",
   "facterversion": "4.2.5",
+  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
   "gid": "wheel",
   "hardwareisa": "amd64",
   "hardwaremodel": "amd64",
-  "hostname": "",
+  "hostname": "foo",
   "id": "root",
   "identity": {
     "gid": 0,
@@ -301,8 +302,9 @@
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
   "networking": {
-    "domain": "divms.uiowa.edu",
-    "hostname": "",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
     "interfaces": {
       "em0": {
         "bindings": [

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -82,6 +82,19 @@ describe 'Default Facts' do
     'facts/3.0/ubuntu-15.10-i386.facts' => 'no puppet-agent package',
   }
 
+  KNOWN_HOSTNAME_PENDING = {
+    'facts/3.10/ubuntu-18.04-aarch64.facts' => 'unable to regenerate facts',
+    'facts/3.2/aix-61-powerpc.facts' => 'unable to regenerate facts',
+    'facts/3.2/aix-71-powerpc.facts' => 'unable to regenerate facts',
+    'facts/3.2/aix-53-powerpc.facts' => 'unable to regenerate facts',
+    'facts/3.6/pcs-6-x86_64.facts' => 'unable to regenerate facts',
+    'facts/3.0/ubuntu-15.10-x86_64.facts' => 'no puppet-agent package',
+    'facts/3.0/ubuntu-15.10-i386.facts' => 'no puppet-agent package',
+    'facts/4.2/centos-9-x86_64.facts' => 'no legacy facts',
+    'facts/4.2/oraclelinux-9-x86_64.facts' => 'no legacy facts',
+    'facts/4.2/redhat-9-x86_64.facts' => 'no legacy facts',
+  }
+
   project_dir = Pathname.new(__dir__).parent
   FacterDB.default_fact_files.each do |filepath|
     relative_path = Pathname.new(filepath).relative_path_from(project_dir).to_s
@@ -122,6 +135,10 @@ describe 'Default Facts' do
         expect(content['systemd']).to be_nil
         expect(content['systemd_version']).to be_nil
         expect(content['systemd_internal_services']).to be_nil
+      end
+      it 'contains a hostname fact' do
+        pending KNOWN_HOSTNAME_PENDING[relative_path] if KNOWN_HOSTNAME_PENDING.key?(relative_path)
+        expect(content['hostname']).to not_be_nil.and not_be_empty
       end
     end
   end


### PR DESCRIPTION
Restores hostname, domain and fqdn facts removed by #210

Adds spec test to confirm hostname is present in future commits.

Fixes #215 