### PR TITLE
Add some CentOS 9 legacy facts

### DIFF
--- a/facts/4.2/centos-9-x86_64.facts
+++ b/facts/4.2/centos-9-x86_64.facts
@@ -1,4 +1,5 @@
 {
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
@@ -41,6 +42,8 @@
   "filesystems": "iso9660,xfs",
   "fips_enabled": false,
   "gem_version": "~> 4.2.0",
+  "hardwaremodel": "x86_64",
+  "hostname": "multi-1",
   "identity": {
     "gid": 1000,
     "group": "stack",
@@ -48,6 +51,7 @@
     "uid": 1000,
     "user": "stack"
   },
+  "ipaddress": "10.109.1.2",
   "is_virtual": false,
   "kernel": "Linux",
   "kernelmajversion": "5.13",
@@ -181,6 +185,9 @@
     "primary": "ens3",
     "scope6": "link"
   },
+  "operatingsystem": "CentOS",
+  "operatingsystemmajrelease": "9",
+  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -207,6 +214,7 @@
       "policy_version": "33"
     }
   },
+  "osfamily": "RedHat",
   "partitions": {
     "/dev/vda1": {
       "size": "1.00 MiB",

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -90,7 +90,6 @@ describe 'Default Facts' do
     'facts/3.6/pcs-6-x86_64.facts' => 'unable to regenerate facts',
     'facts/3.0/ubuntu-15.10-x86_64.facts' => 'no puppet-agent package',
     'facts/3.0/ubuntu-15.10-i386.facts' => 'no puppet-agent package',
-    'facts/4.2/centos-9-x86_64.facts' => 'no legacy facts',
     'facts/4.2/oraclelinux-9-x86_64.facts' => 'no legacy facts',
     'facts/4.2/redhat-9-x86_64.facts' => 'no legacy facts',
   }


### PR DESCRIPTION
This is only manual addition of

```
facter --version 4.2.5
facter operatingsystem operatingsystemmajrelease operatingsystemrelease osfamily hardwaremodel architecture hostname ipaddress
```
To last CentOS 9 facts.

It's certainly enough for rspec-puppet-facts to consider this a valid
fact set.

In addition it also allows the `redhat` provider for `service` to
operate correctly.