### PR TITLE
add spec tests for legacy osfamily and operatingsystem facts

### DIFF
--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -110,6 +110,12 @@ describe 'Default Facts' do
         expect(content['fqdn']).to eq('foo.example.com')
         expect(content['domain']).to eq('example.com')
       end
+      it 'contains the legacy osfamily fact' do
+        expect(content['osfamily']).to_not be_nil
+      end
+      it 'contains the legacy operatingsystem fact' do
+        expect(content['operatingsystem']).to_not be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
The base service provider depends upon these facts. See:

https://github.com/puppetlabs/puppet/blob/a18679dad09c92dc26918aa1f45ad910cafa784f/lib/puppet/provider/service/init.rb#L6-L27