### PR TITLE
Ensure all facts have osfamily/operatingsystem facts

### DIFF
--- a/facts/2.2/sles-15-x86_64.facts
+++ b/facts/2.2/sles-15-x86_64.facts
@@ -72,6 +72,7 @@
   "netmask_lo": "255.0.0.0",
   "mtu_lo": "65536",
   "id": "root",
+  "operatingsystem": "SLES",
   "os": {
     "family": "Linux",
     "release": {

--- a/facts/2.3/sles-15-x86_64.facts
+++ b/facts/2.3/sles-15-x86_64.facts
@@ -14,6 +14,7 @@
   "virtual": "kvm",
   "is_virtual": true,
   "hardwaremodel": "x86_64",
+  "operatingsystem": "SLES",
   "os": {
     "family": "Linux",
     "release": {

--- a/facts/2.4/sles-15-x86_64.facts
+++ b/facts/2.4/sles-15-x86_64.facts
@@ -74,6 +74,7 @@
   "netmask_lo": "255.0.0.0",
   "mtu_lo": 65536,
   "id": "root",
+  "operatingsystem": "SLES",
   "os": {
     "family": "Linux",
     "release": {

--- a/facts/2.5/sles-15-x86_64.facts
+++ b/facts/2.5/sles-15-x86_64.facts
@@ -14,6 +14,8 @@
   "virtual": "kvm",
   "is_virtual": true,
   "hardwaremodel": "x86_64",
+  "operatingsystem": "SLES",
+  "osfamily": "Suse",
   "os": {
     "family": "Linux",
     "release": {

--- a/facts/3.0/ubuntu-15.10-i386.facts
+++ b/facts/3.0/ubuntu-15.10-i386.facts
@@ -128,6 +128,8 @@
     "network": "10.0.2.0",
     "network6": "fe80::"
   },
+  "operatingsystem": "Ubuntu",
+  "osfamily": "Debian",
   "os": {
     "architecture": "i386",
     "distro": {

--- a/facts/3.0/ubuntu-15.10-x86_64.facts
+++ b/facts/3.0/ubuntu-15.10-x86_64.facts
@@ -128,6 +128,8 @@
     "network": "10.0.2.0",
     "network6": "fe80::"
   },
+  "operatingsystem": "Ubuntu",
+  "osfamily": "Debian",
   "os": {
     "architecture": "amd64",
     "distro": {

--- a/facts/3.10/ubuntu-18.04-aarch64.facts
+++ b/facts/3.10/ubuntu-18.04-aarch64.facts
@@ -467,6 +467,8 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Ubuntu",
+  "osfamily": "Debian",
   "os": {
     "architecture": "aarch64",
     "distro": {

--- a/facts/3.2/aix-53-powerpc.facts
+++ b/facts/3.2/aix-53-powerpc.facts
@@ -87,6 +87,8 @@
     "network": "10.32.77.0",
     "primary": "en0"
   },
+  "operatingsystem": "AIX",
+  "osfamily": "AIX",
   "os": {
     "architecture": "PowerPC_POWER7",
     "family": "AIX",

--- a/facts/3.2/aix-61-powerpc.facts
+++ b/facts/3.2/aix-61-powerpc.facts
@@ -87,6 +87,8 @@
     "network": "10.32.77.0",
     "primary": "en0"
   },
+  "operatingsystem": "AIX",
+  "osfamily": "AIX",
   "os": {
     "architecture": "PowerPC_POWER7",
     "family": "AIX",

--- a/facts/3.2/aix-71-powerpc.facts
+++ b/facts/3.2/aix-71-powerpc.facts
@@ -87,6 +87,8 @@
     "network": "10.32.77.0",
     "primary": "en0"
   },
+  "operatingsystem": "AIX",
+  "osfamily": "AIX",
   "os": {
     "architecture": "PowerPC_POWER7",
     "family": "AIX",

--- a/facts/3.6/pcs-6-x86_64.facts
+++ b/facts/3.6/pcs-6-x86_64.facts
@@ -286,6 +286,8 @@
     "network6": "fec0::",
     "primary": "eth0"
   },
+  "operatingsystem": "RedHat",
+  "osfamily": "RedHat",
   "os": {
     "architecture": "x86_64",
     "family": "RedHat",

--- a/facts/4.0/centos-7-x86_64.facts
+++ b/facts/4.0/centos-7-x86_64.facts
@@ -1,5 +1,7 @@
 {
   "ipaddress": "192.168.0.1",
+  "operatingsystem": "CentOS",
+  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "CentOS",

--- a/facts/4.0/debian-10-x86_64.facts
+++ b/facts/4.0/debian-10-x86_64.facts
@@ -1,5 +1,7 @@
 {
   "ipaddress": "192.168.0.1",
+  "operatingsystem": "Debian",
+  "osfamily": "Debian",
   "os": {
     "architecture": "amd64",
     "release": {

--- a/facts/4.0/oraclelinux-7-x86_64.facts
+++ b/facts/4.0/oraclelinux-7-x86_64.facts
@@ -1,5 +1,7 @@
 {
   "ipaddress": "192.168.0.1",
+  "operatingsystem": "OracleLinux",
+  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "OracleLinux",

--- a/facts/4.0/redhat-7-x86_64.facts
+++ b/facts/4.0/redhat-7-x86_64.facts
@@ -1,5 +1,7 @@
 {
   "ipaddress": "192.168.0.1",
+  "operatingsystem": "RedHat",
+  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "RedHat",

--- a/facts/4.0/scientific-7-x86_64.facts
+++ b/facts/4.0/scientific-7-x86_64.facts
@@ -1,5 +1,7 @@
 {
   "ipaddress": "192.168.0.1",
+  "operatingsystem": "Scientific",
+  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "Scientific",

--- a/facts/4.0/solaris-11-sun4v.facts
+++ b/facts/4.0/solaris-11-sun4v.facts
@@ -22,6 +22,8 @@
   },
   "facterversion": "4.0.52",
   "timezone": "PST",
+  "operatingsystem": "Solaris",
+  "osfamily": "Solaris",
   "os": {
     "name": "Solaris",
     "hardware": "sun4v",

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -110,6 +110,12 @@ describe 'Default Facts' do
         expect(content['fqdn']).to eq('foo.example.com')
         expect(content['domain']).to eq('example.com')
       end
+      it 'contains the legacy osfamily fact' do
+        expect(content['osfamily']).to_not be_nil
+      end
+      it 'contains the legacy operatingsystem fact' do
+        expect(content['operatingsystem']).to_not be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the issues seen in
[cc06549](https://github.com/voxpupuli/facterdb/pull/228/commits/cc06549fcc3f0c994968561adafa79423af65447)