### PR TITLE
Add OL6 facts for Facter 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ FacterDB::get_facts('osfamily=Debian')
 | OpenSuSE 15                 |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |  1  |  1  |  1  |  1  |     |     |     |
 | OpenSuSE 42                 |  1  |  1  |  1  |  1  |  1  |  1  |  1  |  1  |     |     |     |     |  1  |  1  |  1  |  1  |  1  |  1  |     |     |     |     |     |     |     |     |
 | OracleLinux 5               |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |     |  2  |  2  |  2  |  2  |  2  |  2  |  1  |  1  |  1  |     |     |     |     |     |     |
-| OracleLinux 6               |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |     |  2  |  2  |  2  |  2  |  2  |  2  |  1  |  1  |  2  |  1  |  1  |  1  |     |     |     |
+| OracleLinux 6               |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  2  |     |  2  |  2  |  2  |  2  |  2  |  2  |  1  |  1  |  2  |  1  |  1  |  1  |     |     |  1  |
 | OracleLinux 7               |  2  |  2  |  2  |  2  |  2  |  2  |  2  |  1  |  2  |  2  |     |  2  |  1  |  1  |  2  |  1  |  1  |  1  |  1  |  2  |  1  |  1  |  1  |  1  |     |  1  |
 | OracleLinux 8               |  1  |  1  |  1  |  1  |  1  |  1  |  1  |  1  |     |     |     |     |     |     |     |     |     |     |     |  1  |  1  |  1  |  1  |     |     |  1  |
 | OracleLinux 9               |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |  1  |
@@ -193,6 +193,9 @@ $ bundle exec rake rhel_alts
 ```
 
 Then update the table in this README by running `bundle exec rake table`
+
+*NOTE*: When using Facter version 4, by default some "legacy facts" are hidden from the output.
+To generate a fact set with the legacy facts use the command `puppet facts show --show-legacy`
 
 ## Supplying custom external facts
 

--- a/facts/4.2/oraclelinux-6-x86_64.facts
+++ b/facts/4.2/oraclelinux-6-x86_64.facts
@@ -1,0 +1,554 @@
+{
+  "aio_agent_version": "7.14.0",
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "03/14/2014",
+  "bios_vendor": "BHYVE",
+  "bios_version": "1.00",
+  "blockdevice_vda_size": 63999836160,
+  "blockdevice_vda_vendor": "0x1af4",
+  "blockdevices": "vda",
+  "chassisassettag": "None",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "vda": {
+      "size": "59.60 GiB",
+      "size_bytes": 63999836160,
+      "type": "hdd",
+      "vendor": "0x1af4"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "03/14/2014",
+      "vendor": "BHYVE",
+      "version": "1.00"
+    },
+    "chassis": {
+      "asset_tag": "None"
+    },
+    "product": {
+      "name": "BHYVE",
+      "serial_number": "None",
+      "uuid": "2d874099-0000-0000-8ec5-395db61b7fb0"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.2.7",
+  "filesystems": "ext2,ext3,ext4,iso9660,msdos,squashfs,udf,vfat,xfs",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "docker": {
+      "id": "7a0d09c6bbd26261e5c9acee31c171d73c4889b04402150e84f074deeb1c83c8"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,ip6tnl0,lo,tunl0",
+  "ipaddress": "172.17.0.3",
+  "ipaddress_eth0": "172.17.0.3",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.19",
+  "kernelrelease": "4.19.121-linuxkit",
+  "kernelversion": "4.19.121",
+  "load_averages": {
+    "15m": 0.08,
+    "1m": 0.02,
+    "5m": 0.07
+  },
+  "lsbdistrelease": "6.10",
+  "lsbmajdistrelease": "6",
+  "lsbminordistrelease": "10",
+  "macaddress": "02:42:ac:11:00:03",
+  "macaddress_eth0": "02:42:ac:11:00:03",
+  "macaddress_ip6tnl0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+  "memory": {
+    "swap": {
+      "available": "1.00 GiB",
+      "available_bytes": 1073737728,
+      "capacity": "0.00%",
+      "total": "1.00 GiB",
+      "total_bytes": 1073737728,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "14.24 GiB",
+      "available_bytes": 15287238656,
+      "capacity": "8.97%",
+      "total": "15.64 GiB",
+      "total_bytes": 16794206208,
+      "used": "1.40 GiB",
+      "used_bytes": 1506967552
+    }
+  },
+  "memoryfree": "14.24 GiB",
+  "memoryfree_mb": 14579.046875,
+  "memorysize": "15.64 GiB",
+  "memorysize_mb": 16016.203125,
+  "mountpoints": {
+    "/": {
+      "available": "29.34 GiB",
+      "available_bytes": 31499145216,
+      "capacity": "47.07%",
+      "device": "overlay",
+      "filesystem": "overlay",
+      "options": [
+        "rw",
+        "relatime",
+        "lowerdir=/var/lib/docker/overlay2/l/BHZVYG7X7HJF75ZHR4ZECR3BO6:/var/lib/docker/overlay2/l/PHBMFFQX4KHTEZSYTPE6RGFA2S",
+        "upperdir=/var/lib/docker/overlay2/5309b3c69c044f6a7c91823d0bf0b4db11f0dee1f8179f476681e370ef642883/diff",
+        "workdir=/var/lib/docker/overlay2/5309b3c69c044f6a7c91823d0bf0b4db11f0dee1f8179f476681e370ef642883/work"
+      ],
+      "size": "58.42 GiB",
+      "size_bytes": 62725623808,
+      "used": "26.09 GiB",
+      "used_bytes": 28009762816
+    },
+    "/dev": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=65536k",
+        "mode=755"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/console": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=666"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=666"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "shm",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=65536k"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/downloads": {
+      "available": "301.93 GiB",
+      "available_bytes": 324195192832,
+      "capacity": "33.11%",
+      "device": "grpcfuse",
+      "filesystem": "fuse.grpcfuse",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "user_id=0",
+        "group_id=0",
+        "allow_other",
+        "max_read=1048576"
+      ],
+      "size": "465.63 GiB",
+      "size_bytes": 499963174912,
+      "used": "149.43 GiB",
+      "used_bytes": 160449630208
+    },
+    "/etc/hostname": {
+      "available": "29.34 GiB",
+      "available_bytes": 31499145216,
+      "capacity": "47.07%",
+      "device": "/dev/vda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "58.42 GiB",
+      "size_bytes": 62725623808,
+      "used": "26.09 GiB",
+      "used_bytes": 28009762816
+    },
+    "/etc/hosts": {
+      "available": "29.34 GiB",
+      "available_bytes": 31499145216,
+      "capacity": "47.07%",
+      "device": "/dev/vda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "58.42 GiB",
+      "size_bytes": 62725623808,
+      "used": "26.09 GiB",
+      "used_bytes": 28009762816
+    },
+    "/etc/resolv.conf": {
+      "available": "29.34 GiB",
+      "available_bytes": 31499145216,
+      "capacity": "47.07%",
+      "device": "/dev/vda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "58.42 GiB",
+      "size_bytes": 62725623808,
+      "used": "26.09 GiB",
+      "used_bytes": 28009762816
+    },
+    "/proc/acpi": {
+      "available": "7.82 GiB",
+      "available_bytes": 8397103104,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "relatime"
+      ],
+      "size": "7.82 GiB",
+      "size_bytes": 8397103104,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/proc/kcore": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=65536k",
+        "mode=755"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/proc/keys": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=65536k",
+        "mode=755"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/proc/sched_debug": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=65536k",
+        "mode=755"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/proc/timer_list": {
+      "available": "64.00 MiB",
+      "available_bytes": 67108864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=65536k",
+        "mode=755"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/firmware": {
+      "available": "7.82 GiB",
+      "available_bytes": 8397103104,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "relatime"
+      ],
+      "size": "7.82 GiB",
+      "size_bytes": 8397103104,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "7.82 GiB",
+      "available_bytes": 8397103104,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=755"
+      ],
+      "size": "7.82 GiB",
+      "size_bytes": 8397103104,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_ip6tnl0": 1452,
+  "mtu_lo": 65536,
+  "mtu_tunl0": 1480,
+  "netmask": "255.255.0.0",
+  "netmask_eth0": "255.255.0.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "172.17.0.0",
+  "network_eth0": "172.17.0.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "172.17.0.3",
+            "netmask": "255.255.0.0",
+            "network": "172.17.0.0"
+          }
+        ],
+        "ip": "172.17.0.3",
+        "mac": "02:42:ac:11:00:03",
+        "mtu": 1500,
+        "netmask": "255.255.0.0",
+        "network": "172.17.0.0"
+      },
+      "ip6tnl0": {
+        "mac": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+        "mtu": 1452
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "network": "127.0.0.0"
+      },
+      "tunl0": {
+        "mtu": 1480
+      }
+    },
+    "ip": "172.17.0.3",
+    "mac": "02:42:ac:11:00:03",
+    "mtu": 1500,
+    "netmask": "255.255.0.0",
+    "network": "172.17.0.0",
+    "primary": "eth0"
+  },
+  "operatingsystem": "OracleLinux",
+  "operatingsystemmajrelease": "6",
+  "operatingsystemrelease": "6.10",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Santiago",
+      "description": "Red Hat Enterprise Linux Server release 6.10 (Santiago)",
+      "id": "RedHatEnterpriseServer",
+      "release": {
+        "full": "6.10",
+        "major": "6",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "OracleLinux",
+    "release": {
+      "full": "6.10",
+      "major": "6",
+      "minor": "10"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/vda1": {
+      "mount": "/etc/resolv.conf",
+      "size": "59.60 GiB",
+      "size_bytes": 63998787584
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin",
+  "physicalprocessorcount": 8,
+  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor1": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor2": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor3": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor4": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor5": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor6": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processor7": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+  "processorcount": 8,
+  "processors": {
+    "cores": 1,
+    "count": 8,
+    "isa": "x86_64",
+    "models": [
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz"
+    ],
+    "physicalcount": 8,
+    "speed": "2.60 GHz",
+    "threads": 1
+  },
+  "productname": "BHYVE",
+  "puppetversion": "7.14.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.5"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.5",
+  "selinux": false,
+  "serialnumber": "None",
+  "swapfree": "1.00 GiB",
+  "swapfree_mb": 1023.99609375,
+  "swapsize": "1.00 GiB",
+  "swapsize_mb": 1023.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 1,
+    "seconds": 6207,
+    "uptime": "1:43 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "1:43 hours",
+  "uptime_days": 0,
+  "uptime_hours": 1,
+  "uptime_seconds": 6207,
+  "uuid": "2d874099-0000-0000-8ec5-395db61b7fb0",
+  "virtual": "docker"
+}


### PR DESCRIPTION
Need to add OL6 facts for the newer version of Facter. The most recent Puppet Enterprise version (and LTS) currently supports this operating system and version.

https://puppet.com/docs/pe/2021.5/supported_operating_systems.html#supported_operating_systems_and_devices-supported-agent-platforms