### PR TITLE
Arch Linux: Fix factset for facter 4.2

### DIFF
--- a/facts/4.2/archlinux-x86_64.facts
+++ b/facts/4.2/archlinux-x86_64.facts
@@ -204,6 +204,17 @@
   "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "Arch Linux",
+      "id": "Arch",
+      "release": {
+        "full": "rolling",
+        "major": "rolling",
+        "minor": null
+      },
+      "specification": "n/a"
+    },
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",


### PR DESCRIPTION
For the initial package on Arch Linux, a dependency was missing, which
caused some missing facts.