### PR TITLE
Fix Red Hat facts on version 4.2

### DIFF
--- a/facts/4.2/redhat-7-x86_64.facts
+++ b/facts/4.2/redhat-7-x86_64.facts
@@ -1,58 +1,55 @@
 {
-  "aio_agent_version": "7.9.0",
+  "aio_agent_version": "7.20.0",
   "architecture": "x86_64",
   "augeas": {
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
+  "augeasversion": "1.13.0",
+  "bios_release_date": "04/01/2014",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "1.14.0-1.el8s",
+  "blockdevice_sda_model": "QEMU HARDDISK",
   "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
+  "blockdevice_sda_vendor": "QEMU",
   "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
+  "boardmanufacturer": "Red Hat",
+  "boardproductname": "RHEL-AV",
   "chassistype": "Other",
   "dhcp_servers": {
-    "eth0": "10.0.2.2",
-    "eth1": "192.168.56.100",
-    "system": "10.0.2.2"
+    "system": ""
   },
   "disks": {
     "sda": {
-      "model": "VBOX HARDDISK",
+      "model": "QEMU HARDDISK",
+      "serial": "c16b1e54-944d-40da-b9c1-e5062d90b206",
       "size": "40.00 GiB",
       "size_bytes": 42949672960,
       "type": "hdd",
-      "vendor": "ATA"
+      "vendor": "QEMU"
     }
   },
   "dmi": {
     "bios": {
-      "release_date": "12/01/2006",
-      "vendor": "innotek GmbH",
-      "version": "VirtualBox"
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "1.14.0-1.el8s"
     },
     "board": {
-      "manufacturer": "Oracle Corporation",
-      "product": "VirtualBox",
-      "serial_number": "0"
+      "manufacturer": "Red Hat",
+      "product": "RHEL-AV"
     },
     "chassis": {
       "type": "Other"
     },
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "oVirt",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0",
-      "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2"
+      "name": "RHEL",
+      "serial_number": "4c4c4544-005a-3910-804e-b7c04f463033",
+      "uuid": "0F61D142-C291-4770-A0C9-405520784D49"
     }
   },
   "domain": "example.com",
-  "facterversion": "4.2.2",
+  "facterversion": "4.2.13",
   "filesystems": "xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
@@ -60,12 +57,6 @@
   "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
-  "hypervisors": {
-    "virtualbox": {
-      "revision": "145957",
-      "version": "6.1.26"
-    }
-  },
   "id": "root",
   "identity": {
     "gid": 0,
@@ -74,61 +65,77 @@
     "uid": 0,
     "user": "root"
   },
-  "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
-  "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
-  "ipaddress6_eth1": "fe80::a00:27ff:fe47:4e7b",
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.109.1.2",
+  "ipaddress6": "fe80::546f:86ff:fe55:c7",
+  "ipaddress6_eth0": "fe80::546f:86ff:fe55:c7",
   "ipaddress6_lo": "::1",
-  "ipaddress_eth0": "10.0.2.15",
-  "ipaddress_eth1": "10.0.0.2",
+  "ipaddress_eth0": "10.109.1.2",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
   "kernelmajversion": "3.10",
-  "kernelrelease": "3.10.0-1127.el7.x86_64",
+  "kernelrelease": "3.10.0-1160.el7.x86_64",
   "kernelversion": "3.10.0",
   "load_averages": {
     "15m": 0.05,
-    "1m": 0.52,
-    "5m": 0.14
+    "1m": 0.05,
+    "5m": 0.03
   },
-  "lsbdistrelease": "7.8.2003",
+  "lsbdistrelease": "7.9",
   "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
-  "macaddress_eth0": "52:54:00:4d:77:d3",
-  "macaddress_eth1": "08:00:27:47:4e:7b",
-  "manufacturer": "innotek GmbH",
+  "lsbminordistrelease": "9",
+  "macaddress": "56:6f:86:55:00:c7",
+  "macaddress_eth0": "56:6f:86:55:00:c7",
+  "manufacturer": "oVirt",
   "memory": {
     "swap": {
-      "available": "2.00 GiB",
-      "available_bytes": 2146684928,
-      "capacity": "0.04%",
-      "total": "2.00 GiB",
-      "total_bytes": 2147479552,
-      "used": "776.00 KiB",
-      "used_bytes": 794624
+      "available": "4.00 GiB",
+      "available_bytes": 4294963200,
+      "capacity": "0.00%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
+      "used": "0 bytes",
+      "used_bytes": 0
     },
     "system": {
-      "available": "302.07 MiB",
-      "available_bytes": 316743680,
-      "capacity": "37.97%",
-      "total": "487.00 MiB",
-      "total_bytes": 510652416,
-      "used": "184.93 MiB",
-      "used_bytes": 193908736
+      "available": "6.96 GiB",
+      "available_bytes": 7476731904,
+      "capacity": "8.81%",
+      "total": "7.64 GiB",
+      "total_bytes": 8198971392,
+      "used": "688.78 MiB",
+      "used_bytes": 722239488
     }
   },
-  "memoryfree": "302.07 MiB",
-  "memoryfree_mb": 302.0703125,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
+  "memoryfree": "6.96 GiB",
+  "memoryfree_mb": 7130.3671875,
+  "memorysize": "7.64 GiB",
+  "memorysize_mb": 7819.1484375,
   "mountpoints": {
     "/": {
-      "available": "36.53 GiB",
-      "available_bytes": 39224406016,
-      "capacity": "8.63%",
+      "available": "33.39 GiB",
+      "available_bytes": 35856416768,
+      "capacity": "4.53%",
+      "device": "/dev/mapper/rhel_foo-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "34.98 GiB",
+      "size_bytes": 37558423552,
+      "used": "1.59 GiB",
+      "used_bytes": 1702006784
+    },
+    "/boot": {
+      "available": "864.45 MiB",
+      "available_bytes": 906436608,
+      "capacity": "14.75%",
       "device": "/dev/sda1",
       "filesystem": "xfs",
       "options": [
@@ -139,14 +146,14 @@
         "inode64",
         "noquota"
       ],
-      "size": "39.98 GiB",
-      "size_bytes": 42927656960,
-      "used": "3.45 GiB",
-      "used_bytes": 3703250944
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "149.55 MiB",
+      "used_bytes": 156819456
     },
     "/dev": {
-      "available": "236.16 MiB",
-      "available_bytes": 247627776,
+      "available": "3.81 GiB",
+      "available_bytes": 4087246848,
       "capacity": "0%",
       "device": "devtmpfs",
       "filesystem": "devtmpfs",
@@ -154,12 +161,12 @@
         "rw",
         "seclabel",
         "nosuid",
-        "size=241824k",
-        "nr_inodes=60456",
+        "size=3991452k",
+        "nr_inodes=997863",
         "mode=755"
       ],
-      "size": "236.16 MiB",
-      "size_bytes": 247627776,
+      "size": "3.81 GiB",
+      "size_bytes": 4087246848,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -217,8 +224,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "243.50 MiB",
-      "available_bytes": 255324160,
+      "available": "3.82 GiB",
+      "available_bytes": 4099485696,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -228,15 +235,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "243.50 MiB",
-      "size_bytes": 255324160,
+      "size": "3.82 GiB",
+      "size_bytes": 4099485696,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "239.04 MiB",
-      "available_bytes": 250654720,
-      "capacity": "1.83%",
+      "available": "3.81 GiB",
+      "available_bytes": 4090372096,
+      "capacity": "0.22%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -246,14 +253,14 @@
         "nodev",
         "mode=755"
       ],
-      "size": "243.50 MiB",
-      "size_bytes": 255324160,
-      "used": "4.45 MiB",
-      "used_bytes": 4669440
+      "size": "3.82 GiB",
+      "size_bytes": 4099485696,
+      "used": "8.69 MiB",
+      "used_bytes": 9113600
     },
-    "/run/user/1000": {
-      "available": "48.70 MiB",
-      "available_bytes": 51068928,
+    "/run/user/0": {
+      "available": "781.92 MiB",
+      "available_bytes": 819900416,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -263,19 +270,17 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=49872k",
-        "mode=700",
-        "uid=1000",
-        "gid=1000"
+        "size=800684k",
+        "mode=700"
       ],
-      "size": "48.70 MiB",
-      "size_bytes": 51068928,
+      "size": "781.92 MiB",
+      "size_bytes": 819900416,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "243.50 MiB",
-      "available_bytes": 255324160,
+      "available": "3.82 GiB",
+      "available_bytes": 4099485696,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -287,78 +292,27 @@
         "noexec",
         "mode=755"
       ],
-      "size": "243.50 MiB",
-      "size_bytes": 255324160,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "376.89 GiB",
-      "available_bytes": 404683227136,
-      "capacity": "16.04%",
-      "device": "10.0.0.1:/System/Volumes/Data/Users/jacobmw/git/facterdb/facts",
-      "filesystem": "nfs",
-      "options": [
-        "rw",
-        "relatime",
-        "vers=3",
-        "rsize=8192",
-        "wsize=8192",
-        "namlen=255",
-        "hard",
-        "proto=udp",
-        "timeo=11",
-        "retrans=3",
-        "sec=sys",
-        "mountaddr=10.0.0.1",
-        "mountvers=3",
-        "mountport=814",
-        "mountproto=udp",
-        "local_lock=none",
-        "addr=10.0.0.1"
-      ],
-      "size": "465.63 GiB",
-      "size_bytes": 499963174912,
-      "used": "71.99 GiB",
-      "used_bytes": 77294583808
-    },
-    "/var/lib/nfs/rpc_pipefs": {
-      "available": "0 bytes",
-      "available_bytes": 0,
-      "capacity": "100%",
-      "device": "sunrpc",
-      "filesystem": "rpc_pipefs",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "0 bytes",
-      "size_bytes": 0,
+      "size": "3.82 GiB",
+      "size_bytes": 4099485696,
       "used": "0 bytes",
       "used_bytes": 0
     }
   },
   "mtu_eth0": 1500,
-  "mtu_eth1": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
   "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
-  "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
-  "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
+  "network": "10.109.1.0",
   "network6": "fe80::",
   "network6_eth0": "fe80::",
-  "network6_eth1": "fe80::",
   "network6_lo": "::1",
-  "network_eth0": "10.0.2.0",
-  "network_eth1": "10.0.0.0",
+  "network_eth0": "10.109.1.0",
   "network_lo": "127.0.0.0",
   "networking": {
-    "dhcp": "10.0.2.2",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -366,60 +320,29 @@
       "eth0": {
         "bindings": [
           {
-            "address": "10.0.2.15",
+            "address": "10.109.1.2",
             "netmask": "255.255.255.0",
-            "network": "10.0.2.0"
+            "network": "10.109.1.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::5054:ff:fe4d:77d3",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::",
-            "scope6": "link",
+            "address": "fe80::546f:86ff:fe55:c7",
             "flags": [
               "permanent"
-            ]
+            ],
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
           }
         ],
-        "dhcp": "10.0.2.2",
-        "ip": "10.0.2.15",
-        "ip6": "fe80::5054:ff:fe4d:77d3",
-        "mac": "52:54:00:4d:77:d3",
+        "ip": "10.109.1.2",
+        "ip6": "fe80::546f:86ff:fe55:c7",
+        "mac": "56:6f:86:55:00:c7",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.2.0",
-        "network6": "fe80::",
-        "scope6": "link"
-      },
-      "eth1": {
-        "bindings": [
-          {
-            "address": "10.0.0.2",
-            "netmask": "255.255.255.0",
-            "network": "10.0.0.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::a00:27ff:fe47:4e7b",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::",
-            "scope6": "link",
-            "flags": [
-              "permanent"
-            ]
-          }
-        ],
-        "dhcp": "192.168.56.100",
-        "ip": "10.0.0.2",
-        "ip6": "fe80::a00:27ff:fe47:4e7b",
-        "mac": "08:00:27:47:4e:7b",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.0.0",
+        "network": "10.109.1.0",
         "network6": "fe80::",
         "scope6": "link"
       },
@@ -434,12 +357,12 @@
         "bindings6": [
           {
             "address": "::1",
-            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-            "network": "::1",
-            "scope6": "host",
             "flags": [
               "permanent"
-            ]
+            ],
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host"
           }
         ],
         "ip": "127.0.0.1",
@@ -452,39 +375,39 @@
         "scope6": "host"
       }
     },
-    "ip": "10.0.2.15",
-    "ip6": "fe80::5054:ff:fe4d:77d3",
-    "mac": "52:54:00:4d:77:d3",
+    "ip": "10.109.1.2",
+    "ip6": "fe80::546f:86ff:fe55:c7",
+    "mac": "56:6f:86:55:00:c7",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
-    "network": "10.0.2.0",
+    "network": "10.109.1.0",
     "network6": "fe80::",
     "primary": "eth0",
     "scope6": "link"
   },
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
+  "operatingsystemrelease": "7.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
-      "codename": "Core",
-      "description": "RedHat Linux release 7.8.2003 (Core)",
-      "id": "RedHat",
+      "codename": "Maipo",
+      "description": "Red Hat Enterprise Linux Server release 7.9 (Maipo)",
+      "id": "RedHatEnterpriseServer",
       "release": {
-        "full": "7.8.2003",
+        "full": "7.9",
         "major": "7",
-        "minor": "8"
+        "minor": "9"
       }
     },
     "family": "RedHat",
     "hardware": "x86_64",
     "name": "RedHat",
     "release": {
-      "full": "7.8.2003",
+      "full": "7.9",
       "major": "7",
-      "minor": "8"
+      "minor": "9"
     },
     "selinux": {
       "config_mode": "enforcing",
@@ -497,42 +420,62 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/sda1": {
+    "/dev/mapper/rhel_foo-root": {
       "filesystem": "xfs",
       "mount": "/",
-      "size": "40.00 GiB",
-      "size_bytes": 42948624384,
-      "uuid": "1c419d6c-5064-4a2b-953c-05b2c67edb15"
+      "size": "35.00 GiB",
+      "size_bytes": 37576769536,
+      "uuid": "5364d35e-993d-4976-ae52-eb2e8cb864dc"
+    },
+    "/dev/mapper/rhel_foo-swap": {
+      "filesystem": "swap",
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "b49104e8-5ed3-4703-afdc-19346e377c31"
+    },
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "c2b6da47-9244-417c-a7bd-52f0072d743e"
+    },
+    "/dev/sda2": {
+      "filesystem": "LVM2_member",
+      "size": "39.00 GiB",
+      "size_bytes": 41874882560,
+      "uuid": "4jFd0J-z3h9-IroY-WmOM-oFlZ-P3or-Aiov4c"
     }
   },
-  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
-  "processorcount": 1,
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/opt/puppetlabs/bin:/sbin",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel Xeon Processor (Cascadelake)",
+  "processor1": "Intel Xeon Processor (Cascadelake)",
+  "processorcount": 2,
   "processors": {
     "cores": 1,
-    "count": 1,
+    "count": 2,
     "isa": "x86_64",
     "models": [
-      "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz"
+      "Intel Xeon Processor (Cascadelake)",
+      "Intel Xeon Processor (Cascadelake)"
     ],
-    "physicalcount": 1,
-    "speed": "2.59 GHz",
+    "physicalcount": 2,
+    "speed": "2.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
-  "puppetversion": "7.9.0",
+  "productname": "RHEL",
+  "puppetversion": "7.20.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-    "version": "2.7.3"
+    "version": "2.7.6"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
+  "rubyversion": "2.7.6",
   "scope6": "link",
   "scope6_eth0": "link",
-  "scope6_eth1": "link",
   "scope6_lo": "host",
   "selinux": true,
   "selinux_config_mode": "enforcing",
@@ -540,54 +483,54 @@
   "selinux_current_mode": "enforcing",
   "selinux_enforced": true,
   "selinux_policyversion": "31",
-  "serialnumber": "0",
+  "serialnumber": "4c4c4544-005a-3910-804e-b7c04f463033",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 33c7f87ab06c1844b6d764aacbe9c3bd28fba34d",
-        "sha256": "SSHFP 3 2 55e0b64334b7317ddbc426f73b5a1f6d55b9b66fc0ac20ffc3ac4acf4d17787b"
+        "sha1": "SSHFP 3 1 04aa31dede587de25b5c03561b8d54a6e4ec38b9",
+        "sha256": "SSHFP 3 2 4dbeea59f9cb0efb99a3b31ace49591973009f553dba10a296628307155e2bb8"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBK0I9tmr+wzrGKYmc5aaI07KpRfxCM+eDjtFfguCD7hKeD3LOD5IO6irhYtjABBfZCJmTCs0U68Bc8LkHCAWvYw=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM6xo43pbD1egp2zXfTSH/ivhmNDRIae6d1a0dtZaYM0KfD1jvGGNEmoOWyhK0Z0rqSJYQS9pV6xwqimxvPdM90=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 ae86105117d5c84add050f97f9d1462b3bfc2052",
-        "sha256": "SSHFP 4 2 a512469b3965893ec5a4e97a0f8ec7a91c801e9529f65c36266329dc780cb802"
+        "sha1": "SSHFP 4 1 a71f8f1e8326d22b4a728b41b4b00069ca8c7aea",
+        "sha256": "SSHFP 4 2 ca8c4eca5e7db1d094a4bf9e82ebe2e6c54e83a1b690d9f78be23690a3c46095"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPN8lwO1NEbc8edFMobrXmXs+HlR92o+broz/rhpW0Hs",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIAuIm96JOI+qPIEF+ZDIOpelqXyvoM2ss/Gi4E1kEYCA",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 6e38fb13522239c8d538d4e10b11e6f42f0e62d3",
-        "sha256": "SSHFP 1 2 d0c146d1206a64545ca299357f9e36354b9e857648bf6db005a0ee33cb2a865a"
+        "sha1": "SSHFP 1 1 03e0a93ac6d943ec2d7c226776bb41823d99b61f",
+        "sha256": "SSHFP 1 2 66b19bc00765c5c17e299391715284dd6e9ba1cb80eb33ad2af57a802aae363f"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCtfS7WPA7hSK9zPT7rGHXPVD6dDchTWFTKWwTilrC/Fgh2sfpl3sux2ZKqdZwwDvtBPrPV4BLc32+fzM9vKaW2EEu83Z+W/oFJr6VWpLBSjAMQE+iX68YTXObdRJSrG/w2vAaPiXAmljzGp2/d801XzLQpXLkYOvWSVtDfL4Koqy8uy6ZsJ+4BlvSf6vU2L8L2FQENhyZqgWKAggrR5NWz5eNrEY1cr/2ZqtZEVbQMABs/XEo6dBkDe7k38flRWkXXhbZ9y/sSu25ygiMHBmVOkbs+A0IYPkCFyUqPtPpjLR97yoY+r9hbC47bV7pDTF0hyTylVEFq4l6UwEdJFqMF",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC19Ip7e4AL7p/m/1A3uj4St1jMycFGY3RIj/mDjnU5DmQ14jCLIySsGmSgez+KBwcNiAeHvdUV4eSQs46XvsJ3eXy+pUnS+rYv1udulukWG23lkFf1VpNsx73Z9LtbgqvkVwTp6eafX0kek3CdAQG6P5D7hm1dhUFc2Dhdp8y2vhvSEAUIvXKKEiY5odiUhZQxKSAURjbK+ayci08ZQQtnrkG2sXT+nI2dH1EEoMVMGqS0Zux86V5MHkliqB7ChuUpOFrcBHOS1fnz8CSmTDycTK9rr4hvos40Jk+uksICW2hV+5HnkGjWEuw2bPT4Www76kD1qOCuMeiB43HEr94l",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBK0I9tmr+wzrGKYmc5aaI07KpRfxCM+eDjtFfguCD7hKeD3LOD5IO6irhYtjABBfZCJmTCs0U68Bc8LkHCAWvYw=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPN8lwO1NEbc8edFMobrXmXs+HlR92o+broz/rhpW0Hs",
-  "sshfp_ecdsa": "SSHFP 3 1 33c7f87ab06c1844b6d764aacbe9c3bd28fba34d\nSSHFP 3 2 55e0b64334b7317ddbc426f73b5a1f6d55b9b66fc0ac20ffc3ac4acf4d17787b",
-  "sshfp_ed25519": "SSHFP 4 1 ae86105117d5c84add050f97f9d1462b3bfc2052\nSSHFP 4 2 a512469b3965893ec5a4e97a0f8ec7a91c801e9529f65c36266329dc780cb802",
-  "sshfp_rsa": "SSHFP 1 1 6e38fb13522239c8d538d4e10b11e6f42f0e62d3\nSSHFP 1 2 d0c146d1206a64545ca299357f9e36354b9e857648bf6db005a0ee33cb2a865a",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCtfS7WPA7hSK9zPT7rGHXPVD6dDchTWFTKWwTilrC/Fgh2sfpl3sux2ZKqdZwwDvtBPrPV4BLc32+fzM9vKaW2EEu83Z+W/oFJr6VWpLBSjAMQE+iX68YTXObdRJSrG/w2vAaPiXAmljzGp2/d801XzLQpXLkYOvWSVtDfL4Koqy8uy6ZsJ+4BlvSf6vU2L8L2FQENhyZqgWKAggrR5NWz5eNrEY1cr/2ZqtZEVbQMABs/XEo6dBkDe7k38flRWkXXhbZ9y/sSu25ygiMHBmVOkbs+A0IYPkCFyUqPtPpjLR97yoY+r9hbC47bV7pDTF0hyTylVEFq4l6UwEdJFqMF",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM6xo43pbD1egp2zXfTSH/ivhmNDRIae6d1a0dtZaYM0KfD1jvGGNEmoOWyhK0Z0rqSJYQS9pV6xwqimxvPdM90=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIAuIm96JOI+qPIEF+ZDIOpelqXyvoM2ss/Gi4E1kEYCA",
+  "sshfp_ecdsa": "SSHFP 3 1 04aa31dede587de25b5c03561b8d54a6e4ec38b9\nSSHFP 3 2 4dbeea59f9cb0efb99a3b31ace49591973009f553dba10a296628307155e2bb8",
+  "sshfp_ed25519": "SSHFP 4 1 a71f8f1e8326d22b4a728b41b4b00069ca8c7aea\nSSHFP 4 2 ca8c4eca5e7db1d094a4bf9e82ebe2e6c54e83a1b690d9f78be23690a3c46095",
+  "sshfp_rsa": "SSHFP 1 1 03e0a93ac6d943ec2d7c226776bb41823d99b61f\nSSHFP 1 2 66b19bc00765c5c17e299391715284dd6e9ba1cb80eb33ad2af57a802aae363f",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC19Ip7e4AL7p/m/1A3uj4St1jMycFGY3RIj/mDjnU5DmQ14jCLIySsGmSgez+KBwcNiAeHvdUV4eSQs46XvsJ3eXy+pUnS+rYv1udulukWG23lkFf1VpNsx73Z9LtbgqvkVwTp6eafX0kek3CdAQG6P5D7hm1dhUFc2Dhdp8y2vhvSEAUIvXKKEiY5odiUhZQxKSAURjbK+ayci08ZQQtnrkG2sXT+nI2dH1EEoMVMGqS0Zux86V5MHkliqB7ChuUpOFrcBHOS1fnz8CSmTDycTK9rr4hvos40Jk+uksICW2hV+5HnkGjWEuw2bPT4Www76kD1qOCuMeiB43HEr94l",
+  "swapfree": "4.00 GiB",
+  "swapfree_mb": 4095.99609375,
+  "swapsize": "4.00 GiB",
+  "swapsize_mb": 4095.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 77,
-    "uptime": "0:01 hours"
+    "seconds": 2058,
+    "uptime": "0:34 hours"
   },
-  "timezone": "UTC",
-  "uptime": "0:01 hours",
+  "timezone": "EDT",
+  "uptime": "0:34 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 77,
-  "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2",
-  "virtual": "virtualbox"
+  "uptime_seconds": 2058,
+  "uuid": "0F61D142-C291-4770-A0C9-405520784D49",
+  "virtual": "ovirt"
 }

--- a/facts/4.2/redhat-8-x86_64.facts
+++ b/facts/4.2/redhat-8-x86_64.facts
@@ -1,56 +1,55 @@
 {
-  "aio_agent_version": "7.12.0",
+  "aio_agent_version": "7.20.0",
   "architecture": "x86_64",
   "augeas": {
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
+  "augeasversion": "1.13.0",
+  "bios_release_date": "04/01/2014",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "1.14.0-1.el8s",
+  "blockdevice_sda_model": "QEMU HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "QEMU",
   "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
+  "boardmanufacturer": "Red Hat",
+  "boardproductname": "RHEL-AV",
   "chassistype": "Other",
   "dhcp_servers": {
-    "system": null
+    "system": ""
   },
   "disks": {
     "sda": {
-      "model": "VBOX HARDDISK",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "model": "QEMU HARDDISK",
+      "serial": "c16b1e54-944d-40da-b9c1-e5062d90b206",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
-      "vendor": "ATA"
+      "vendor": "QEMU"
     }
   },
   "dmi": {
     "bios": {
-      "release_date": "12/01/2006",
-      "vendor": "innotek GmbH",
-      "version": "VirtualBox"
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "1.14.0-1.el8s"
     },
     "board": {
-      "manufacturer": "Oracle Corporation",
-      "product": "VirtualBox",
-      "serial_number": "0"
+      "manufacturer": "Red Hat",
+      "product": "RHEL-AV"
     },
     "chassis": {
       "type": "Other"
     },
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "oVirt",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0",
-      "uuid": "27961108-1973-4660-a1b0-938050051403"
+      "name": "RHEL",
+      "serial_number": "4c4c4544-005a-3910-804e-b7c04f463033",
+      "uuid": "0f61d142-c291-4770-a0c9-405520784d49"
     }
   },
   "domain": "example.com",
-  "facterversion": "4.2.5",
+  "facterversion": "4.2.13",
   "filesystems": "xfs",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
@@ -59,10 +58,7 @@
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
-    "virtualbox": {
-      "revision": "145957",
-      "version": "6.1.26"
-    }
+    "kvm": {}
   },
   "id": "root",
   "identity": {
@@ -72,56 +68,59 @@
     "uid": 0,
     "user": "root"
   },
-  "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress_eth0": "10.0.2.15",
+  "interfaces": "enp1s0,lo",
+  "ipaddress": "10.109.1.2",
+  "ipaddress6": "fe80::546f:86ff:fe55:c7",
+  "ipaddress6_enp1s0": "fe80::546f:86ff:fe55:c7",
+  "ipaddress6_lo": "::1",
+  "ipaddress_enp1s0": "10.109.1.2",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
   "kernelmajversion": "4.18",
-  "kernelrelease": "4.18.0-305.el8.x86_64",
+  "kernelrelease": "4.18.0-372.9.1.el8.x86_64",
   "kernelversion": "4.18.0",
   "load_averages": {
-    "15m": 0.37,
-    "1m": 1.56,
-    "5m": 0.89
+    "15m": 0.08,
+    "1m": 0.12,
+    "5m": 0.16
   },
-  "lsbdistrelease": "8.4",
+  "lsbdistrelease": "8.6",
   "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:75:c4:9b",
-  "macaddress_eth0": "08:00:27:75:c4:9b",
-  "manufacturer": "innotek GmbH",
+  "lsbminordistrelease": "6",
+  "macaddress": "56:6f:86:55:00:c7",
+  "macaddress_enp1s0": "56:6f:86:55:00:c7",
+  "manufacturer": "oVirt",
   "memory": {
     "swap": {
-      "available": "2.06 GiB",
-      "available_bytes": 2210394112,
+      "available": "4.00 GiB",
+      "available_bytes": 4294963200,
       "capacity": "0.00%",
-      "total": "2.06 GiB",
-      "total_bytes": 2210394112,
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.35 GiB",
-      "available_bytes": 1450811392,
-      "capacity": "23.86%",
-      "total": "1.77 GiB",
-      "total_bytes": 1905377280,
-      "used": "433.51 MiB",
-      "used_bytes": 454565888
+      "available": "6.53 GiB",
+      "available_bytes": 7008133120,
+      "capacity": "13.88%",
+      "total": "7.58 GiB",
+      "total_bytes": 8137707520,
+      "used": "1.05 GiB",
+      "used_bytes": 1129574400
     }
   },
-  "memoryfree": "1.35 GiB",
-  "memoryfree_mb": 1383.6015625,
-  "memorysize": "1.77 GiB",
-  "memorysize_mb": 1817.109375,
+  "memoryfree": "6.53 GiB",
+  "memoryfree_mb": 6683.4765625,
+  "memorysize": "7.58 GiB",
+  "memorysize_mb": 7760.72265625,
   "mountpoints": {
     "/": {
-      "available": "67.34 GiB",
-      "available_bytes": 72310030336,
-      "capacity": "3.75%",
-      "device": "/dev/mapper/rhel_rhel8-root",
+      "available": "29.81 GiB",
+      "available_bytes": 32010956800,
+      "capacity": "14.77%",
+      "device": "/dev/mapper/rhel_foo-root",
       "filesystem": "xfs",
       "options": [
         "rw",
@@ -133,15 +132,15 @@
         "logbsize=32k",
         "noquota"
       ],
-      "size": "69.97 GiB",
-      "size_bytes": 75125227520,
-      "used": "2.62 GiB",
-      "used_bytes": 2815197184
+      "size": "34.98 GiB",
+      "size_bytes": 37558423552,
+      "used": "5.17 GiB",
+      "used_bytes": 5547466752
     },
     "/boot": {
-      "available": "823.84 MiB",
-      "available_bytes": 863862784,
-      "capacity": "18.75%",
+      "available": "760.22 MiB",
+      "available_bytes": 797151232,
+      "capacity": "25.03%",
       "device": "/dev/sda1",
       "filesystem": "xfs",
       "options": [
@@ -156,12 +155,12 @@
       ],
       "size": "1014.00 MiB",
       "size_bytes": 1063256064,
-      "used": "190.16 MiB",
-      "used_bytes": 199393280
+      "used": "253.78 MiB",
+      "used_bytes": 266104832
     },
     "/dev": {
-      "available": "890.11 MiB",
-      "available_bytes": 933351424,
+      "available": "3.76 GiB",
+      "available_bytes": 4037820416,
       "capacity": "0%",
       "device": "devtmpfs",
       "filesystem": "devtmpfs",
@@ -169,12 +168,12 @@
         "rw",
         "seclabel",
         "nosuid",
-        "size=911476k",
-        "nr_inodes=227869",
+        "size=3943184k",
+        "nr_inodes=985796",
         "mode=755"
       ],
-      "size": "890.11 MiB",
-      "size_bytes": 933351424,
+      "size": "3.76 GiB",
+      "size_bytes": 4037820416,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -233,8 +232,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "908.55 MiB",
-      "available_bytes": 952688640,
+      "available": "3.79 GiB",
+      "available_bytes": 4068851712,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -244,15 +243,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
+      "size": "3.79 GiB",
+      "size_bytes": 4068851712,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "892.16 MiB",
-      "available_bytes": 935493632,
-      "capacity": "1.80%",
+      "available": "3.78 GiB",
+      "available_bytes": 4058472448,
+      "capacity": "0.26%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -262,14 +261,14 @@
         "nodev",
         "mode=755"
       ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
-      "used": "16.40 MiB",
-      "used_bytes": 17195008
+      "size": "3.79 GiB",
+      "size_bytes": 4068851712,
+      "used": "9.90 MiB",
+      "used_bytes": 10379264
     },
-    "/run/user/1000": {
-      "available": "181.71 MiB",
-      "available_bytes": 190537728,
+    "/run/user/0": {
+      "available": "776.07 MiB",
+      "available_bytes": 813768704,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -279,19 +278,39 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=186072k",
-        "mode=700",
-        "uid=1000",
-        "gid=1000"
+        "size=794696k",
+        "mode=700"
       ],
-      "size": "181.71 MiB",
-      "size_bytes": 190537728,
+      "size": "776.07 MiB",
+      "size_bytes": 813768704,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/run/user/976": {
+      "available": "776.05 MiB",
+      "available_bytes": 813744128,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=794696k",
+        "mode=700",
+        "uid=976",
+        "gid=975"
+      ],
+      "size": "776.07 MiB",
+      "size_bytes": 813768704,
+      "used": "24.00 KiB",
+      "used_bytes": 24576
+    },
     "/sys/fs/cgroup": {
-      "available": "908.55 MiB",
-      "available_bytes": 952688640,
+      "available": "3.79 GiB",
+      "available_bytes": 4068851712,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -303,57 +322,74 @@
         "noexec",
         "mode=755"
       ],
-      "size": "908.55 MiB",
-      "size_bytes": 952688640,
+      "size": "3.79 GiB",
+      "size_bytes": 4068851712,
       "used": "0 bytes",
       "used_bytes": 0
     },
-    "/vagrant": {
-      "available": "1.68 TiB",
-      "available_bytes": 1851170643968,
-      "capacity": "7.43%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
       "options": [
         "rw",
-        "nodev",
-        "relatime",
-        "iocharset=utf8",
-        "uid=1000",
-        "gid=1000"
+        "relatime"
       ],
-      "size": "1.82 TiB",
-      "size_bytes": 1999738298368,
-      "used": "138.36 GiB",
-      "used_bytes": 148567654400
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
     }
   },
-  "mtu_eth0": 1500,
+  "mtu_enp1s0": 1500,
   "mtu_lo": 65536,
   "netmask": "255.255.255.0",
-  "netmask_eth0": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp1s0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_enp1s0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network_eth0": "10.0.2.0",
+  "network": "10.109.1.0",
+  "network6": "fe80::",
+  "network6_enp1s0": "fe80::",
+  "network6_lo": "::1",
+  "network_enp1s0": "10.109.1.0",
   "network_lo": "127.0.0.0",
   "networking": {
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "eth0": {
+      "enp1s0": {
         "bindings": [
           {
-            "address": "10.0.2.15",
+            "address": "10.109.1.2",
             "netmask": "255.255.255.0",
-            "network": "10.0.2.0"
+            "network": "10.109.1.0"
           }
         ],
-        "ip": "10.0.2.15",
-        "mac": "08:00:27:75:c4:9b",
+        "bindings6": [
+          {
+            "address": "fe80::546f:86ff:fe55:c7",
+            "flags": [
+              "permanent"
+            ],
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "ip": "10.109.1.2",
+        "ip6": "fe80::546f:86ff:fe55:c7",
+        "mac": "56:6f:86:55:00:c7",
         "mtu": 1500,
         "netmask": "255.255.255.0",
-        "network": "10.0.2.0"
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.109.1.0",
+        "network6": "fe80::",
+        "scope6": "link"
       },
       "lo": {
         "bindings": [
@@ -363,41 +399,60 @@
             "network": "127.0.0.0"
           }
         ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "flags": [
+              "permanent"
+            ],
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host"
+          }
+        ],
         "ip": "127.0.0.1",
+        "ip6": "::1",
         "mtu": 65536,
         "netmask": "255.0.0.0",
-        "network": "127.0.0.0"
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
       }
     },
-    "ip": "10.0.2.15",
-    "mac": "08:00:27:75:c4:9b",
+    "ip": "10.109.1.2",
+    "ip6": "fe80::546f:86ff:fe55:c7",
+    "mac": "56:6f:86:55:00:c7",
     "mtu": 1500,
     "netmask": "255.255.255.0",
-    "network": "10.0.2.0",
-    "primary": "eth0"
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.109.1.0",
+    "network6": "fe80::",
+    "primary": "enp1s0",
+    "scope6": "link"
   },
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
+  "operatingsystemrelease": "8.6",
   "os": {
     "architecture": "x86_64",
     "distro": {
       "codename": "Ootpa",
-      "description": "Red Hat Enterprise Linux release 8.4 (Ootpa)",
+      "description": "Red Hat Enterprise Linux release 8.6 (Ootpa)",
       "id": "RedHatEnterprise",
       "release": {
-        "full": "8.4",
+        "full": "8.6",
         "major": "8",
-        "minor": "4"
+        "minor": "6"
       }
     },
     "family": "RedHat",
     "hardware": "x86_64",
     "name": "RedHat",
     "release": {
-      "full": "8.4",
+      "full": "8.6",
       "major": "8",
-      "minor": "4"
+      "minor": "6"
     },
     "selinux": {
       "config_mode": "enforcing",
@@ -410,116 +465,119 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/rhel_rhel8-root": {
+    "/dev/mapper/rhel_foo-root": {
       "filesystem": "xfs",
       "mount": "/",
-      "size": "70.00 GiB",
-      "size_bytes": 75161927680,
-      "uuid": "aff90eef-5284-45bb-b8e7-b7eb6041f432"
+      "size": "35.00 GiB",
+      "size_bytes": 37576769536,
+      "uuid": "aaaba216-0d05-4f65-bb16-a8373ccfe789"
     },
-    "/dev/mapper/rhel_rhel8-swap": {
+    "/dev/mapper/rhel_foo-swap": {
       "filesystem": "swap",
-      "size": "2.06 GiB",
-      "size_bytes": 2210398208,
-      "uuid": "5b20229a-5202-4cb8-bb1c-cf3d2e5e1e4c"
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "c91d8ba2-11f9-4ecf-9698-997ff3291025"
     },
     "/dev/sda1": {
       "filesystem": "xfs",
       "mount": "/boot",
-      "partuuid": "18628db8-01",
+      "partuuid": "a8d17e92-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "68ac9249-ebc1-4c53-8991-17bd52dc4135"
+      "uuid": "40989bf4-d0d4-49d4-837f-607d45ae1f51"
     },
     "/dev/sda2": {
       "filesystem": "LVM2_member",
-      "partuuid": "18628db8-02",
-      "size": "127.00 GiB",
-      "size_bytes": 136364163072,
-      "uuid": "9x9cKz-OdFp-R1be-hG92-xZ35-Wb9d-rlv9qt"
+      "partuuid": "a8d17e92-02",
+      "size": "39.00 GiB",
+      "size_bytes": 41874882560,
+      "uuid": "fTOkZt-rLad-Zrb9-Vzyt-oLpY-Z3xO-vWEuhA"
     }
   },
-  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/opt/puppetlabs/bin:/sbin",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel Xeon Processor (Cascadelake)",
+  "processor1": "Intel Xeon Processor (Cascadelake)",
   "processorcount": 2,
   "processors": {
-    "cores": 2,
+    "cores": 1,
     "count": 2,
     "isa": "x86_64",
     "models": [
-      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz",
-      "11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz"
+      "Intel Xeon Processor (Cascadelake)",
+      "Intel Xeon Processor (Cascadelake)"
     ],
-    "physicalcount": 1,
-    "speed": "3.00 GHz",
+    "physicalcount": 2,
+    "speed": "2.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
-  "puppetversion": "7.12.0",
+  "productname": "RHEL",
+  "puppetversion": "7.20.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-    "version": "2.7.3"
+    "version": "2.7.6"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
+  "rubyversion": "2.7.6",
+  "scope6": "link",
+  "scope6_enp1s0": "link",
+  "scope6_lo": "host",
   "selinux": true,
   "selinux_config_mode": "enforcing",
   "selinux_config_policy": "targeted",
   "selinux_current_mode": "enforcing",
   "selinux_enforced": true,
   "selinux_policyversion": "33",
-  "serialnumber": "0",
+  "serialnumber": "4c4c4544-005a-3910-804e-b7c04f463033",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992",
-        "sha256": "SSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1"
+        "sha1": "SSHFP 3 1 de4c09dfeb96f07fa02b51885ff60aab914674f4",
+        "sha256": "SSHFP 3 2 b3fb88521c91ed2ff947df170e23fdd13667e1e259d40fb5a4c0ef860dfb79f6"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLembOFLZUod2WsgQPxJ8HPe/LeKTkCqJWmUx8M2F2ag81IznE1WXsB05E3kffc7oSoWxrfL9NWwwacTmyG0Dsc=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c",
-        "sha256": "SSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc"
+        "sha1": "SSHFP 4 1 0337a67ce814f68d3669ec0c418682f9440c243e",
+        "sha256": "SSHFP 4 2 7f4a1f0aad3a4a83fda20ee6664ba78d9e800fa4d214868db925c44adaa59048"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAICM8L8mCMK/bOFgPQmu1EXx+YqEwEVY8h3v8rRKi92Vp",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e",
-        "sha256": "SSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7"
+        "sha1": "SSHFP 1 1 93ffda53fbfa08056e6492b2809d5fecb1bec3b7",
+        "sha256": "SSHFP 1 2 f23cabe93affd5689b03d587311c2633a33b24c35dc8f4fce61ce79af5463699"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDhQVi3SskjL4caHEUp2aeHlqJgntIKvaynwp7drqRUPZzscvggsSG4W3hTcnjkX6uvyHfPj8hQ/PKOI0NP1214ut33iz/fgo9upVmiom+OBjfqj6+2xTT1lPCh84FHB/cDwgcQe586d9O6BQYUBi4lIC+JdoE12J1zecZwWDGdVXd8TkVXRIs70JHRdWv+xGXCYPNQOgSZq6pk83FwZZ+Sy467hqUFNbvljriimx4zbacyPBNOOWBVTjmfCcfxTxqKBJMlylGYBolN6x4a8dT7hFSv8mJEvvlGcZiQy3LE6rbIH+n2i2euh2L/6m7XwLbm2ZdIKHCn04lfSwHVFCZKB0TG5sLASmweBNTI3XXtAc2Os7UzYnxClNDAGKNBRb/EM1GDi+9avkBWiZgoHS9Kls9LXmz0o4OOOnPZFiio/ud6ld01YGCcdo9GnThMDDfGLRCrdNhbHrpA0BGxpnAQ9OqpwPiSuWI79J0JRu8T7+Xh6oPa62rQOIFOGI7PBFE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL63b3Wl7tcB11HYNeuIF9hhXh//rJ3Ur/ZmRXvH3ZAt8brxh8/CQGdAmPBDliXPpp0ErLHRv7usmg10UE4JtB8=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPnHpH/SE/6p+IFFlF0jCRig7WNiUx1ovjPOAVtFSumF",
-  "sshfp_ecdsa": "SSHFP 3 1 7a2f8e562d9688a1bf87f6ca06d3901c5ec85992\nSSHFP 3 2 b51bdb2e635dbcaf7cf1409a9cc498473b86adffd148e01d8e5f24dc146369c1",
-  "sshfp_ed25519": "SSHFP 4 1 e667b547448fd4e20ddb499bfc1054b1f860fe2c\nSSHFP 4 2 47de76c8bcc43273e9e125e92d7573c3826d09c5f2df8c8763638b20cb198bbc",
-  "sshfp_rsa": "SSHFP 1 1 d9e243cde0cd3949b6ea677ad377f635e1b95c8e\nSSHFP 1 2 0a3bae9e74713e6781acdd8812da85fc7c794c7c81d2ee9448fee510ac3255e7",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCeoOv3jowZ6yXJyKBVFt8+d16R1O1RUwCrPJCnnpSLeKctMQu1dx44llrhKpK2eUBahH1JFJHkG3uoJjGPf9sAPylpS59RkX7bFgfsuXcNM9GzZeCaJt61i/dFzzyC4qyyDuXGCqjs6TNzWIAgu0qJkM0uhp1M0mKanieoelnOw18jlY5g4F8YR8IklIRv6W41cmoKeS/+VsL9nFfT1YZRL0xozDIbMNjRcYSaZxFZ8JhqdD6VFcnMFM+uoo5GAImGBA22QF93WJSSdZHelXu0QUuthKNth4l+W/Ag6kW920TIQZsUzI+yQitSFBUkG7qm4ey4rA5VKql8pDXW332pf+TiLq6On0LGtFDf4q4MqMOYpdfjAhitIYnC2CzNTfWkQfaqE8lxMdedAd+6cr1XdBkcC2y1D+OtbNIpdyBTxxM14hCvICkegZIjqTRG1vBgerzzbtxapc5rNHqaq4MZqN/FhwPNw4sWfz6uGVlIYImRdrwxy93PLRV1BVB8nXE=",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2107.99609375,
-  "swapsize": "2.06 GiB",
-  "swapsize_mb": 2107.99609375,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLembOFLZUod2WsgQPxJ8HPe/LeKTkCqJWmUx8M2F2ag81IznE1WXsB05E3kffc7oSoWxrfL9NWwwacTmyG0Dsc=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAICM8L8mCMK/bOFgPQmu1EXx+YqEwEVY8h3v8rRKi92Vp",
+  "sshfp_ecdsa": "SSHFP 3 1 de4c09dfeb96f07fa02b51885ff60aab914674f4\nSSHFP 3 2 b3fb88521c91ed2ff947df170e23fdd13667e1e259d40fb5a4c0ef860dfb79f6",
+  "sshfp_ed25519": "SSHFP 4 1 0337a67ce814f68d3669ec0c418682f9440c243e\nSSHFP 4 2 7f4a1f0aad3a4a83fda20ee6664ba78d9e800fa4d214868db925c44adaa59048",
+  "sshfp_rsa": "SSHFP 1 1 93ffda53fbfa08056e6492b2809d5fecb1bec3b7\nSSHFP 1 2 f23cabe93affd5689b03d587311c2633a33b24c35dc8f4fce61ce79af5463699",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDhQVi3SskjL4caHEUp2aeHlqJgntIKvaynwp7drqRUPZzscvggsSG4W3hTcnjkX6uvyHfPj8hQ/PKOI0NP1214ut33iz/fgo9upVmiom+OBjfqj6+2xTT1lPCh84FHB/cDwgcQe586d9O6BQYUBi4lIC+JdoE12J1zecZwWDGdVXd8TkVXRIs70JHRdWv+xGXCYPNQOgSZq6pk83FwZZ+Sy467hqUFNbvljriimx4zbacyPBNOOWBVTjmfCcfxTxqKBJMlylGYBolN6x4a8dT7hFSv8mJEvvlGcZiQy3LE6rbIH+n2i2euh2L/6m7XwLbm2ZdIKHCn04lfSwHVFCZKB0TG5sLASmweBNTI3XXtAc2Os7UzYnxClNDAGKNBRb/EM1GDi+9avkBWiZgoHS9Kls9LXmz0o4OOOnPZFiio/ud6ld01YGCcdo9GnThMDDfGLRCrdNhbHrpA0BGxpnAQ9OqpwPiSuWI79J0JRu8T7+Xh6oPa62rQOIFOGI7PBFE=",
+  "swapfree": "4.00 GiB",
+  "swapfree_mb": 4095.99609375,
+  "swapsize": "4.00 GiB",
+  "swapsize_mb": 4095.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 242,
-    "uptime": "0:04 hours"
+    "seconds": 211,
+    "uptime": "0:03 hours"
   },
-  "timezone": "UTC",
-  "uptime": "0:04 hours",
+  "timezone": "EDT",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 242,
-  "uuid": "27961108-1973-4660-a1b0-938050051403",
-  "virtual": "virtualbox"
+  "uptime_seconds": 211,
+  "uuid": "0f61d142-c291-4770-a0c9-405520784d49",
+  "virtual": "ovirt"
 }

--- a/facts/4.2/redhat-9-x86_64.facts
+++ b/facts/4.2/redhat-9-x86_64.facts
@@ -1,96 +1,338 @@
 {
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo",
+  "aio_agent_version": "7.20.0",
   "architecture": "x86_64",
   "augeas": {
-    "version": "1.12.0"
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
+  "bios_release_date": "04/01/2014",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "1.14.0-1.el8s",
+  "blockdevice_sda_model": "QEMU HARDDISK",
+  "blockdevice_sda_size": 53687091200,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Red Hat",
+  "boardproductname": "RHEL-AV",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": ""
   },
   "disks": {
-    "sr0": {
-      "model": "QEMU DVD-ROM",
-      "size": "364.00 KiB",
-      "size_bytes": 372736,
+    "sda": {
+      "model": "QEMU HARDDISK",
+      "serial": "343434ef-0947-46e1-9",
+      "size": "50.00 GiB",
+      "size_bytes": 53687091200,
       "type": "hdd",
-      "vendor": "QEMU"
-    },
-    "vda": {
-      "size": "93.13 GiB",
-      "size_bytes": 100000000000,
-      "type": "hdd",
-      "vendor": "0x1af4"
-    },
-    "vdb": {
-      "size": "4.66 GiB",
-      "size_bytes": 5000000512,
-      "type": "hdd",
-      "vendor": "0x1af4"
+      "vendor": "ATA"
     }
   },
   "dmi": {
     "bios": {
       "release_date": "04/01/2014",
       "vendor": "SeaBIOS",
-      "version": "1.14.0-2.fc34"
+      "version": "1.14.0-1.el8s"
+    },
+    "board": {
+      "manufacturer": "Red Hat",
+      "product": "RHEL-AV"
     },
     "chassis": {
       "type": "Other"
     },
-    "manufacturer": "QEMU",
+    "manufacturer": "oVirt",
     "product": {
-      "name": "Standard PC (i440FX + PIIX, 1996)"
+      "name": "RHEL",
+      "serial_number": "4c4c4544-005a-3910-804e-c2c04f463033",
+      "uuid": "536136e6-b2f3-4572-a692-5135cac51798"
     }
   },
-  "facterversion": "4.2.2",
-  "filesystems": "iso9660,xfs",
+  "domain": "example.com",
+  "facterversion": "4.2.13",
+  "filesystems": "xfs",
   "fips_enabled": false,
-  "gem_version": "~> 4.2.0",
+  "fqdn": "foo.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
+  "id": "root",
   "identity": {
-    "gid": 1000,
-    "group": "stack",
-    "privileged": false,
-    "uid": 1000,
-    "user": "stack"
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
   },
+  "interfaces": "enp1s0,lo",
   "ipaddress": "10.109.1.2",
-  "is_virtual": false,
+  "ipaddress6": "fe80::546f:86ff:fe55:cd",
+  "ipaddress6_enp1s0": "fe80::546f:86ff:fe55:cd",
+  "ipaddress6_lo": "::1",
+  "ipaddress_enp1s0": "10.109.1.2",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.13",
-  "kernelrelease": "5.13.0-0.rc2.19.el9.x86_64",
-  "kernelversion": "5.13.0",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.0-70.13.1.el9_0.x86_64",
+  "kernelversion": "5.14.0",
   "load_averages": {
-    "15m": 0.26,
-    "1m": 0.68,
-    "5m": 0.39
+    "15m": 0.01,
+    "1m": 0.08,
+    "5m": 0.05
   },
+  "lsbdistrelease": "9.0",
+  "lsbmajdistrelease": "9",
+  "lsbminordistrelease": "0",
+  "macaddress": "56:6f:86:55:00:cd",
+  "macaddress_enp1s0": "56:6f:86:55:00:cd",
+  "manufacturer": "oVirt",
   "memory": {
     "swap": {
-      "available": "1.00 GiB",
-      "available_bytes": 1073737728,
+      "available": "3.95 GiB",
+      "available_bytes": 4236242944,
       "capacity": "0.00%",
-      "total": "1.00 GiB",
-      "total_bytes": 1073737728,
+      "total": "3.95 GiB",
+      "total_bytes": 4236242944,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "15.05 GiB",
-      "available_bytes": 16163000320,
-      "capacity": "3.67%",
-      "total": "15.63 GiB",
-      "total_bytes": 16778706944,
-      "used": "587.18 MiB",
-      "used_bytes": 615706624
+      "available": "3.10 GiB",
+      "available_bytes": 3333201920,
+      "capacity": "14.55%",
+      "total": "3.63 GiB",
+      "total_bytes": 3900858368,
+      "used": "541.36 MiB",
+      "used_bytes": 567656448
     }
   },
+  "memoryfree": "3.10 GiB",
+  "memoryfree_mb": 3178.7890625,
+  "memorysize": "3.63 GiB",
+  "memorysize_mb": 3720.1484375,
+  "mountpoints": {
+    "/": {
+      "available": "43.64 GiB",
+      "available_bytes": 46856982528,
+      "capacity": "3.09%",
+      "device": "/dev/mapper/rhel_foo-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "45.03 GiB",
+      "size_bytes": 48349290496,
+      "used": "1.39 GiB",
+      "used_bytes": 1492307968
+    },
+    "/boot": {
+      "available": "817.75 MiB",
+      "available_bytes": 857473024,
+      "capacity": "19.35%",
+      "device": "/dev/sda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "196.25 MiB",
+      "used_bytes": 205783040
+    },
+    "/dev": {
+      "available": "1.80 GiB",
+      "available_bytes": 1929818112,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=1884588k",
+        "nr_inodes=471147",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "1.80 GiB",
+      "size_bytes": 1929818112,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.82 GiB",
+      "available_bytes": 1950429184,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "1.82 GiB",
+      "size_bytes": 1950429184,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "735.43 MiB",
+      "available_bytes": 771153920,
+      "capacity": "1.16%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=761888k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "744.03 MiB",
+      "size_bytes": 780173312,
+      "used": "8.60 MiB",
+      "used_bytes": 9019392
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/0": {
+      "available": "372.01 MiB",
+      "available_bytes": 390082560,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=380940k",
+        "nr_inodes=95235",
+        "mode=700",
+        "inode64"
+      ],
+      "size": "372.01 MiB",
+      "size_bytes": 390082560,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_enp1s0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp1s0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_enp1s0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.109.1.0",
+  "network6": "fe80::",
+  "network6_enp1s0": "fe80::",
+  "network6_lo": "::1",
+  "network_enp1s0": "10.109.1.0",
+  "network_lo": "127.0.0.0",
   "networking": {
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "ens3": {
+      "enp1s0": {
         "bindings": [
           {
             "address": "10.109.1.2",
@@ -100,51 +342,22 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::5054:ff:fe0a:d226",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::",
-            "scope6": "link",
+            "address": "fe80::546f:86ff:fe55:cd",
             "flags": [
               "permanent"
-            ]
+            ],
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
           }
         ],
         "ip": "10.109.1.2",
-        "ip6": "fe80::5054:ff:fe0a:d226",
-        "mac": "52:54:00:0a:d2:26",
+        "ip6": "fe80::546f:86ff:fe55:cd",
+        "mac": "56:6f:86:55:00:cd",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.109.1.0",
-        "network6": "fe80::",
-        "scope6": "link"
-      },
-      "ens4": {
-        "bindings": [
-          {
-            "address": "192.168.24.3",
-            "netmask": "255.255.255.0",
-            "network": "192.168.24.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::e30f:7713:f64d:c054",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::",
-            "scope6": "link",
-            "flags": [
-              "permanent"
-            ]
-          }
-        ],
-        "ip": "192.168.24.3",
-        "ip6": "fe80::e30f:7713:f64d:c054",
-        "mac": "52:54:00:6a:d9:ff",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "192.168.24.0",
         "network6": "fe80::",
         "scope6": "link"
       },
@@ -159,12 +372,12 @@
         "bindings6": [
           {
             "address": "::1",
-            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-            "network": "::1",
-            "scope6": "host",
             "flags": [
               "permanent"
-            ]
+            ],
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host"
           }
         ],
         "ip": "127.0.0.1",
@@ -178,35 +391,38 @@
       }
     },
     "ip": "10.109.1.2",
-    "ip6": "fe80::5054:ff:fe0a:d226",
-    "mac": "52:54:00:0a:d2:26",
+    "ip6": "fe80::546f:86ff:fe55:cd",
+    "mac": "56:6f:86:55:00:cd",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.109.1.0",
     "network6": "fe80::",
-    "primary": "ens3",
+    "primary": "enp1s0",
     "scope6": "link"
   },
   "operatingsystem": "RedHat",
   "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
+  "operatingsystemrelease": "9.0",
   "os": {
     "architecture": "x86_64",
     "distro": {
-      "description": "RedHat Stream release 9",
-      "id": "RedHatStream",
+      "codename": "Plow",
+      "description": "Red Hat Enterprise Linux release 9.0 (Plow)",
+      "id": "RedHatEnterprise",
       "release": {
-        "full": "9",
-        "major": "9"
+        "full": "9.0",
+        "major": "9",
+        "minor": "0"
       }
     },
     "family": "RedHat",
     "hardware": "x86_64",
     "name": "RedHat",
     "release": {
-      "full": "9",
-      "major": "9"
+      "full": "9.0",
+      "major": "9",
+      "minor": "0"
     },
     "selinux": {
       "config_mode": "enforcing",
@@ -219,84 +435,119 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/vda1": {
-      "size": "1.00 MiB",
-      "size_bytes": 1048576
-    },
-    "/dev/vda2": {
+    "/dev/mapper/rhel_foo-root": {
       "filesystem": "xfs",
-      "partuuid": "c12991b3-b38e-4cf8-aca6-53a5b3ea3b50",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "724c150d-ce51-495e-b81f-aee3c084a9bf"
+      "mount": "/",
+      "size": "45.05 GiB",
+      "size_bytes": 48372908032,
+      "uuid": "d6fde836-a6bd-4483-a2cb-988c6fa5000d"
     },
-    "/dev/vda3": {
+    "/dev/mapper/rhel_foo-swap": {
       "filesystem": "swap",
-      "partuuid": "dc30e25d-d70c-4203-92ee-e5d474433548",
+      "size": "3.95 GiB",
+      "size_bytes": 4236247040,
+      "uuid": "fc19cffd-eb45-44e1-8638-27277ecf09ad"
+    },
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "partuuid": "5f9c8fd4-01",
       "size": "1.00 GiB",
       "size_bytes": 1073741824,
-      "uuid": "8532f532-60cd-4cc5-b0b3-f3f0a3a5343d"
+      "uuid": "11461330-945c-4981-9cf2-0d6c8a077e00"
     },
-    "/dev/vda4": {
-      "filesystem": "xfs",
-      "partuuid": "97b86013-ec9f-4176-9c07-8fdd3d28003e",
-      "size": "91.13 GiB",
-      "size_bytes": 97850402304,
-      "uuid": "571a3472-e7c0-4f89-8890-af74c2aed4ea"
+    "/dev/sda2": {
+      "filesystem": "LVM2_member",
+      "partuuid": "5f9c8fd4-02",
+      "size": "49.00 GiB",
+      "size_bytes": 52612300800,
+      "uuid": "Ot4GW9-2G1O-ogZt-Gqgp-XkYm-A48Q-Voh1MM"
     }
   },
-  "path": "/home/stack/facterdb/facts/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/home/stack/.local/bin:/home/stack/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin",
+  "path": "/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/sbin",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel Xeon Processor (Cascadelake)",
+  "processor1": "Intel Xeon Processor (Cascadelake)",
+  "processorcount": 2,
   "processors": {
     "cores": 1,
-    "count": 4,
+    "count": 2,
     "isa": "x86_64",
     "models": [
-      "AMD Opteron(tm) Processor 6376",
-      "AMD Opteron(tm) Processor 6376",
-      "AMD Opteron(tm) Processor 6376",
-      "AMD Opteron(tm) Processor 6376"
+      "Intel Xeon Processor (Cascadelake)",
+      "Intel Xeon Processor (Cascadelake)"
     ],
-    "physicalcount": 4,
-    "speed": "2.30 GHz",
+    "physicalcount": 2,
+    "speed": "2.19 GHz",
     "threads": 1
   },
+  "productname": "RHEL",
+  "puppetversion": "7.20.0",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.0.1"
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+    "version": "2.7.6"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
+  "rubyversion": "2.7.6",
+  "scope6": "link",
+  "scope6_enp1s0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "serialnumber": "4c4c4544-005a-3910-804e-c2c04f463033",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 01965981be711d14d09243a4f4f8066a73590bd6",
-        "sha256": "SSHFP 3 2 f3467199746fbb547c9791ae1d22325c3c08562063b78ada6501044fcc395343"
+        "sha1": "SSHFP 3 1 b524fa90d09057a48f9dbc80534a043c6003c8db",
+        "sha256": "SSHFP 3 2 93da7f04d7beb5db344ec826da2524e0e884c707cf295d66a3004a65fc73e1eb"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJueKsWqIw0wOXNkQxS4oz1BgGWynCJ+LCARJkJKwPyVNl8pVxHkuhKvgjlNaM5+j+7EzvNolztoUlb9F6YpMmc=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBckYGb0l5L6yAaLcglc5IrFOnAcxrSx0kcSDj6NjMMd7FVH82XiRy4cEVReSgEQLKMYh3xeumAuBgkrQd/eQ/Q=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 2b4f0187c0ef8d874fbb47ffefbe3b9c336aa00e",
-        "sha256": "SSHFP 4 2 f9ba2faa6fc99b1efbf355a4699c054b21e4cfb2192d42eafd62e902c0426005"
+        "sha1": "SSHFP 4 1 a687644de06a706266eb057d128ce4ddb06536ed",
+        "sha256": "SSHFP 4 2 5a9c6c51790b6be0244c6d76f16d0a0d3e80d383887776274d34b9ac865f060e"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIH3oYudPTnii27GMd7ocHbIrNYpQUMi9YESufVhwOzk6",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHUnAYt6w9b8kekPV8aW1BAYG1IE8weGx/XuWrwZXXO2",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 c4f5f764a14cebbd395e88740e5b25e8333a1f5e",
-        "sha256": "SSHFP 1 2 a1d0269c1cd821312ca68f00c8ae486660998be9bdde20df7d1446b57ca9977f"
+        "sha1": "SSHFP 1 1 d974c75f2300f3cb652d26297899bce348c83f50",
+        "sha256": "SSHFP 1 2 1e17840f4cf897d2d2393bb17724cfade017cd3dd9718a4c622bc9921003b4c3"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC2JVk4nsrwLkfBayUpVA8HpVtfSfFG1rbDsiK90XVLr3b4drf0Sr14pPTZBVVOs5KSMER2E40t6drYcCqK/k8KtcVtQ30jNLYVSSoIf8YBELdZlITdUDdHkIMAhmNH5VDTy6CTP0bC+7ysJQokLRoNy7ftOIhTbdfkIjXhNiKCqVCHvLUzKN1ubhXtJrhLGlIevNmHeDI/hvEOsNDjbXHoG/t+DnpcC/oKhvAn0XL+VMLq6T4iIadja5t+kBBs04Dw9kJP6zfrMcP83tQC/dsMkY3q+g/n41jkNv6cjvxGZz2UpLC0yel+ezjTxfPeMugvmzkghb/EdINPnAubQHeUqStHhnhC/9x23FgoJJy9OB/YwG4zc2HKgr2haOOidlLw3ST3/FdJDUbi5c/gU+BL6is40OlZzWWDQX/sVjRNyYF9OP9licQ65cdsoHfEn3z1sITiqlgPYxcPUByOWJIJrSLaApScotP9hHqqxIIm59TRwijJi4NFwKc6ou6FFJU=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCz+TXIaqcKUx4xK5SzdV43ixenm/6m2TRQ6GQwHloZkgkqBiQQ1j2ZWNC9qiNdVinTiUYpuMjs4g/bv7IUvFSHUr6cIhedX76RsBUnOL10Y9Gy15bs6FC8eZysloL9HfS3vVL893xuc6Um0h1E3k3tsCtVJIcCDiYG0/eAA7bEtQQG/hpuUOkLB/3ttyqDJbwjkZirfdveor/CXp8HeupTIS+CKdW28Pk4/1ToZF89fGWKG551Vq8C4fn4bXhNpLeqlkLrAD9aaRGvp4DFd3SQuN3n8N3ODNPcDVRTbmG1re2wS7hNi2jmkDrgPddUMF8ZkrTreeNp+SLFohy7SxhtRJQZId37rvM4ZOJvpRe8jLdt3tbirZzDR9HMnP5wucswdHHtvdy/OkbEQrAB4Bi+52nPg5AOeVJdEcPzUNnob776J2pAxtIMcOUEQuF0fP/BYdFzpM2sDmDLpYU5itN9n6NZhnAR30dmteftofWjEAf7jgZ/d2yQtdi0e0mu2MU=",
       "type": "ssh-rsa"
     }
   },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBckYGb0l5L6yAaLcglc5IrFOnAcxrSx0kcSDj6NjMMd7FVH82XiRy4cEVReSgEQLKMYh3xeumAuBgkrQd/eQ/Q=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIHUnAYt6w9b8kekPV8aW1BAYG1IE8weGx/XuWrwZXXO2",
+  "sshfp_ecdsa": "SSHFP 3 1 b524fa90d09057a48f9dbc80534a043c6003c8db\nSSHFP 3 2 93da7f04d7beb5db344ec826da2524e0e884c707cf295d66a3004a65fc73e1eb",
+  "sshfp_ed25519": "SSHFP 4 1 a687644de06a706266eb057d128ce4ddb06536ed\nSSHFP 4 2 5a9c6c51790b6be0244c6d76f16d0a0d3e80d383887776274d34b9ac865f060e",
+  "sshfp_rsa": "SSHFP 1 1 d974c75f2300f3cb652d26297899bce348c83f50\nSSHFP 1 2 1e17840f4cf897d2d2393bb17724cfade017cd3dd9718a4c622bc9921003b4c3",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCz+TXIaqcKUx4xK5SzdV43ixenm/6m2TRQ6GQwHloZkgkqBiQQ1j2ZWNC9qiNdVinTiUYpuMjs4g/bv7IUvFSHUr6cIhedX76RsBUnOL10Y9Gy15bs6FC8eZysloL9HfS3vVL893xuc6Um0h1E3k3tsCtVJIcCDiYG0/eAA7bEtQQG/hpuUOkLB/3ttyqDJbwjkZirfdveor/CXp8HeupTIS+CKdW28Pk4/1ToZF89fGWKG551Vq8C4fn4bXhNpLeqlkLrAD9aaRGvp4DFd3SQuN3n8N3ODNPcDVRTbmG1re2wS7hNi2jmkDrgPddUMF8ZkrTreeNp+SLFohy7SxhtRJQZId37rvM4ZOJvpRe8jLdt3tbirZzDR9HMnP5wucswdHHtvdy/OkbEQrAB4Bi+52nPg5AOeVJdEcPzUNnob776J2pAxtIMcOUEQuF0fP/BYdFzpM2sDmDLpYU5itN9n6NZhnAR30dmteftofWjEAf7jgZ/d2yQtdi0e0mu2MU=",
+  "swapfree": "3.95 GiB",
+  "swapfree_mb": 4039.99609375,
+  "swapsize": "3.95 GiB",
+  "swapsize_mb": 4039.99609375,
   "system_uptime": {
     "days": 0,
-    "hours": 23,
-    "seconds": 83681,
-    "uptime": "23:14 hours"
+    "hours": 0,
+    "seconds": 689,
+    "uptime": "0:11 hours"
   },
-  "timezone": "EDT",
-  "virtual": "physical"
+  "timezone": "UTC",
+  "uptime": "0:11 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 689,
+  "uuid": "536136e6-b2f3-4572-a692-5135cac51798",
+  "virtual": "ovirt"
 }


### PR DESCRIPTION
Current fact file for redhat-9 seems to have been made using a CentOS system as template. However this does not properly reflect a Red Hat 9 system. Most important change in this is adding *os.distro.release.minor* and *os.release.minor* and  updating *operatingsystemrelease*, *os.distro.release.full*, and *os.release.full* to match the values for a Red Hat 9 system.

Took the opportunity to update codename, description and id to match Red Hat too.

Found this issue when adding support for EL9 in a class where it worked for previous versions of EL.