### PR TITLE
Remove Legacy Facts

### DIFF
--- a/bin/legacy-facts-striper
+++ b/bin/legacy-facts-striper
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+# This list of legacy fact was obtained from the facter source code:
+# grep --no-filename -r ALIASES' =' lib | sed -Ee "s/^ *ALIASES = ('|%w\\[)//" -e "s/('|].freeze)\$//" | tr ' ' '\n' | sort | uniq
+LEGACY_FACTS = %w[
+  architecture
+  augeasversion
+  bios_release_date
+  bios_vendor
+  bios_version
+  blockdevice_.*_model
+  blockdevice_.*_size
+  blockdevice_.*_vendor
+  blockdevices
+  boardassettag
+  boardmanufacturer
+  boardproductname
+  boardserialnumber
+  chassisassettag
+  chassistype
+  domain
+  fqdn
+  gid
+  hardwareisa
+  hardwaremodel
+  hostname
+  id
+  ipaddress
+  ipaddress6
+  lsbdistcodename
+  lsbdistdescription
+  lsbdistid
+  lsbdistrelease
+  lsbmajdistrelease
+  lsbminordistrelease
+  lsbrelease
+  macaddress
+  macosx_buildversion
+  macosx_productname
+  macosx_productversion
+  macosx_productversion_major
+  macosx_productversion_minor
+  manufacturer
+  memoryfree
+  memoryfree_mb
+  memorysize
+  memorysize_mb
+  netmask
+  netmask6
+  network
+  network6
+  operatingsystem
+  operatingsystemmajrelease
+  operatingsystemrelease
+  osfamily
+  physicalprocessorcount
+  processor\d+
+  processorcount
+  productname
+  rubyplatform
+  rubysitedir
+  rubyversion
+  scope6
+  selinux
+  selinux_config_mode
+  selinux_config_policy
+  selinux_current_mode
+  selinux_enforced
+  selinux_policyversion
+  serialnumber
+  sp_boot_mode
+  sp_boot_rom_version
+  sp_boot_volume
+  sp_cpu_type
+  sp_current_processor_speed
+  sp_kernel_version
+  sp_l2_cache_core
+  sp_l3_cache
+  sp_local_host_name
+  sp_machine_model
+  sp_machine_name
+  sp_number_processors
+  sp_os_version
+  sp_packages
+  sp_physical_memory
+  sp_platform_uuid
+  sp_secure_vm
+  sp_serial_number
+  sp_smc_version_system
+  sp_uptime
+  sp_user_name
+  swapencrypted
+  swapfree
+  swapfree_mb
+  swapsize
+  swapsize_mb
+  system32
+  uptime
+  uptime_days
+  uptime_hours
+  uptime_seconds
+  uuid
+  windows_display_version
+  windows_edition_id
+  windows_installation_type
+  windows_product_name
+  windows_release_id
+  xendomains
+  zonename
+].map { |re| Regexp.new("\\A#{re}\\z") }
+
+if ARGV.empty?
+  warn "usage: #{$PROGRAM_NAME} facts..."
+  exit(1)
+end
+
+ARGV.each do |filename|
+  puts filename
+  facts = JSON.parse(File.read(filename))
+  facts.delete_if do |key|
+    LEGACY_FACTS.any? { |legacy_fact| key.match(legacy_fact) }
+  end
+  File.write(filename, "#{JSON.pretty_generate(facts)}\n")
+end

--- a/facts/4.0/almalinux-8-x86_64.facts
+++ b/facts/4.0/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.25.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "5745b281-2bd4-ce4b-a939-1135318c2c1e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:febf:d499",
   "ipaddress6_enp0s3": "fe80::a00:27ff:febf:d499",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.3,
     "5m": 0.06
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:bf:d4:99",
   "macaddress_enp0s3": "08:00:27:bf:d4:99",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.95 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 317276160
     }
   },
-  "memoryfree": "667.27 MiB",
-  "memoryfree_mb": 667.27,
-  "memorysize": "969.85 MiB",
-  "memorysize_mb": 969.85,
   "mountpoints": {
     "/": {
       "available": "15.62 GiB",
@@ -328,14 +297,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -408,9 +373,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -440,7 +402,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -459,9 +420,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
@@ -471,25 +429,13 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.9"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -522,10 +468,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e40909316cd34fe2b817dc08daf6603b5901b570\nSSHFP 4 2 355f7e9113f9f39ecbf0ebf5f03cf1b0b6ec9922888d4bce4762d8d39a5cab57",
   "sshfp_rsa": "SSHFP 1 1 e6ae57027741d8a85964a5172c9ec0a8c069271f\nSSHFP 1 2 30a48581cd638faacc948e2ae7c764b1f78f610402e691b316407a2e5b432e38",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCh+rhVbl+hWvDqzjXGUKHIVpqjP2tXEBFmmPYcT0ySilb5fP8TGnox2/5dvVf7/F0wKcqeherhHMjhZGbira9CGIWhMIwKTSPskVSxLRM3hXoXHGckXu0dD7M0Jk6z3lII1SOLZQshXgkPZwwkwli13RcQOO5Uv8Z+cm/1C1gn/mqLyQQM1Z3gXMd82dtrq2Ujv7FW5ehVjcIujn4mcKp4L9OR5bB0tx9QKoCT8DX5HZZQXQjbXiWLw9VrWAx8greOSgkr9jGoz4QJlCok0sSJ9ashA9Xe6+/X1CYocHvkNFA4M9ot0tZfCntfDFkFxVjrPHOpWETYgwltuIPu9F/14W32Mh8Z9CBVpsFMlviojlNiddUGv2Jdh4IYfs6AN5V0SLcUH3CkEKiNGWNzpPbc4YAUpgfqDZrgZi1sbm2dhRvSNP9TN3d/eEcJU+0JzKJD5x6O3MXs/eWhqmIUkHa/BuLF4mRj3Ncd/HqJ/4+YNFGO3ONSuRrLqj1gBKuDqOE=",
-  "swapfree": "1.95 GiB",
-  "swapfree_mb": 2000.0,
-  "swapsize": "1.95 GiB",
-  "swapsize_mb": 2000.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -533,10 +475,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 26,
-  "uuid": "5745b281-2bd4-ce4b-a939-1135318c2c1e",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/almalinux-9-x86_64.facts
+++ b/facts/4.0/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.17.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "590c38ef-f707-8c42-9289-5d5f2c1402af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "150636",
       "version": "6.1.34"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe00:788a",
   "ipaddress6_enp0s3": "fe80::a00:27ff:fe00:788a",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.43,
     "5m": 0.11
   },
-  "lsbdistrelease": "9.0",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:00:78:8a",
   "macaddress_enp0s3": "08:00:27:00:78:8a",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "645.66 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 330227712
     }
   },
-  "memoryfree": "645.66 MiB",
-  "memoryfree_mb": 645.66,
-  "memorysize": "960.59 MiB",
-  "memorysize_mb": 960.59,
   "mountpoints": {
     "/": {
       "available": "17.97 GiB",
@@ -310,14 +279,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -390,9 +355,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.0",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -422,7 +384,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "368a572a-a18a-429d-9c34-bf804a222ac5",
@@ -439,9 +400,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
@@ -451,25 +409,13 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -509,10 +455,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 47,
-  "uuid": "590c38ef-f707-8c42-9289-5d5f2c1402af",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/centos-7-x86_64.facts
+++ b/facts/4.0/centos-7-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "selinux": false,
-  "ipaddress": "192.168.0.1",
-  "operatingsystem": "CentOS",
-  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "CentOS",
@@ -630,7 +626,9 @@
     "sshd": "/var/empty/sshd"
   },
   "prometheus_alert_manager_running": false,
-  "who2bug": [],
+  "who2bug": [
+
+  ],
   "classification": {
     "hostname": "live-pulp",
     "parts": [
@@ -667,14 +665,24 @@
   "selinux_python_command": "python",
   "is_pe": false,
   "pe_patch": {
-    "package_updates": [],
+    "package_updates": [
+
+    ],
     "package_update_count": 0,
-    "missing_update_kbs": [],
-    "security_package_updates": [],
+    "missing_update_kbs": [
+
+    ],
+    "security_package_updates": [
+
+    ],
     "security_package_update_count": 0,
-    "blackouts": {},
-    "pinned_packages": [],
-    "last_run": {},
+    "blackouts": {
+    },
+    "pinned_packages": [
+
+    ],
+    "last_run": {
+    },
     "patch_group": "",
     "reboot_override": "default",
     "reboots": {
@@ -686,9 +694,8 @@
       "security_update_file": "Security update file not found, update information invalid"
     },
     "blocked": false,
-    "blocked_reasons": []
-  },
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo"
+    "blocked_reasons": [
+
+    ]
+  }
 }

--- a/facts/4.0/centos-8-x86_64.facts
+++ b/facts/4.0/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.5.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "4d8cb64e-7a3a-da45-90e9-0f06f70d24f3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "iso9660,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "159484",
       "version": "7.0.12"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe6d:c543",
   "ipaddress6_eth0": "fe80::5054:ff:fe6d:c543",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,11 +67,7 @@
     "1m": 2.23,
     "5m": 1.11
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:6d:c5:43",
   "macaddress_eth0": "52:54:00:6d:c5:43",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -114,10 +88,6 @@
       "used_bytes": 170106880
     }
   },
-  "memoryfree": "296.59 MiB",
-  "memoryfree_mb": 296.59,
-  "memorysize": "458.81 MiB",
-  "memorysize_mb": 458.81,
   "mountpoints": {
     "/": {
       "available": "5.48 GiB",
@@ -307,14 +277,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -387,9 +353,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -416,7 +379,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -428,9 +390,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
@@ -440,26 +399,14 @@
     "physicalcount": 1,
     "speed": "3.19 GHz"
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.5.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -492,10 +439,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9a51cfd8c2315360abd30c423c0f20a6d73c8218\nSSHFP 4 2 d5d65cbc3efcbfa5f572f0769157d690ffbe2c9253eeea8a2bfe7af35e4d6a3a",
   "sshfp_rsa": "SSHFP 1 1 cf695b0a9094467072fe24ca60f98509192288bf\nSSHFP 1 2 7a6774ea63d4aa301ef57611bb7b2c1a55918037aadd6566fea8675de435cbd8",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCsL2n/oKH9+g1mt1XYrWPAuvXGM7bAdUu4WAX5DwR8xzgUruTiB7gSbhpRpC0rhbzVk0o5a3Qd1+3KeHGURZlzJ1ihf9tSkjN4GU0RaWaYzmAHEZgtwgZ20c3ZLWUe6dTaQouD3UOXpuDpiiK2fWhCle6/TEYPUsKgD7vMMQpxIDVjIp7O3IRqubD0/Ir6HWAczBA9XjW0rGSRbVPWgOuGOA+e+BZY8YP3no/7rWE8dsM+v51+fbP8plblUqxejnbk5n9XvqsQ+SI8vvJuuXUK6++EfRXpooCJAJX9ipGLk3hKWHkUuUNNoxwq9u33KJA8/nZESq+q99coc70EdWV9rAzuuxl4ZBVHK9lZQacG8ovL/f8mqIxcMwgyyXK3kVEXlR7g5+kTeoBPZjnfPj/bFpr6iGicK6fvZvkpDRddaqN0aVbC2HcSU+RElApjm2D1WiZye0EZhaibB2gbs9zxAwk0v7F2K6kmEtPzEElf3uGhf2UbhNsd5X0OFzXiz60=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.79,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -503,10 +446,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 219,
-  "uuid": "4d8cb64e-7a3a-da45-90e9-0f06f70d24f3",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/debian-11-x86_64.facts
+++ b/facts/4.0/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.12.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "1d6dc67d-078b-024a-8ab9-0ed88dc5212d"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe0e:e67a",
   "ipaddress6_eth0": "fe80::a00:27ff:fe0e:e67a",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,15 +69,7 @@
     "1m": 0.44,
     "5m": 0.11
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.1",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "1",
-  "macaddress": "08:00:27:0e:e6:7a",
   "macaddress_eth0": "08:00:27:0e:e6:7a",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.69 GiB",
@@ -111,10 +81,6 @@
       "used_bytes": 263458816
     }
   },
-  "memoryfree": "1.69 GiB",
-  "memoryfree_mb": 1731.49,
-  "memorysize": "1.94 GiB",
-  "memorysize_mb": 1982.74,
   "mountpoints": {
     "/": {
       "available": "16.78 GiB",
@@ -304,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -386,9 +348,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.1",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -413,7 +372,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -426,10 +384,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
@@ -440,20 +394,13 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -503,10 +450,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 73,
-  "uuid": "1d6dc67d-078b-024a-8ab9-0ed88dc5212d",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/freebsd-11-x86_64.facts
+++ b/facts/4.0/freebsd-11-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "11",
@@ -51,8 +39,6 @@
     "1m": 0.638671875,
     "5m": 0.16796875
   },
-  "macaddress": "08:00:27:a3:ff:85",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 538894336
     }
   },
-  "memoryfree": "471.61 MiB",
-  "memoryfree_mb": 471.61,
-  "memorysize": "985.54 MiB",
-  "memorysize_mb": 985.54,
   "mountpoints": {
     "/": {
       "available": "58.77 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 90112
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -361,9 +341,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.4-RELEASE-p9",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -377,7 +354,6 @@
       "patchlevel": "9"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -399,9 +375,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -411,16 +384,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd11",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.3"
   },
-  "rubyplatform": "amd64-freebsd11",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.3",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -453,11 +421,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ab7c9e209f87f4e8321b13c6481482dda6fa34d9\nSSHFP 4 2 d934ba8e9c55d0794218dc3c8728f1c09bdd407eac8e8df3990e086678f0d131",
   "sshfp_rsa": "SSHFP 1 1 90f05081e454c2f9bc5b81a46c2c1214605481b4\nSSHFP 1 2 6ebeb0740f993885cbf7bb1d0beefde048614ae657f10a60aa8abbb4e11b5a70",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCsFz4abAckdE8cmgMTW7/yptOhJaIi7D/LqAZOhUdbv+xS4ZDICwyhG3z68SPDjEZqqWjj2Vbqujhzas/Ld/MlvMhlbiM8yonPDJ/on+tKHzjLQEb4SM52skdiFiCnDzQhKCgtTVgOZFtGZz7tM6PCvPAmJsedEVP14ueXam/G7m33hyGd8L3eZirGJTnVZDWItKvokqHmSRmC0qAJqd3llqdCPHqsWMrmwJAPgrC3gRXMAhkbM6XshayHa4pZC24PP/lfb4kqBDfLyUzl5hoWXGPpFUXZXZevZNgp7Jk99NqgTAixUpmYrNgo4Fw1Nuy8FdD4UoY7PWgTHTZVetTp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -465,11 +428,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 46,
-  "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.0/freebsd-12-x86_64.facts
+++ b/facts/4.0/freebsd-12-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "12",
@@ -51,8 +39,6 @@
     "1m": 0.51513671875,
     "5m": 0.13720703125
   },
-  "macaddress": "08:00:27:cc:5d:60",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 451911680
     }
   },
-  "memoryfree": "551.57 MiB",
-  "memoryfree_mb": 551.57,
-  "memorysize": "982.54 MiB",
-  "memorysize_mb": 982.54,
   "mountpoints": {
     "/": {
       "available": "58.50 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -361,9 +341,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.2-RELEASE-p6",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -377,7 +354,6 @@
       "patchlevel": "6"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -399,9 +375,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -411,16 +384,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd12",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd12",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -453,11 +421,6 @@
   "sshfp_ed25519": "SSHFP 4 1 aaedcc84b12a9ee5858d1d57396209b5478e4460\nSSHFP 4 2 dd536bc7ec52cb2b42ba56c7fa0e1ca050a476f35fa600a8a09152c0f08bd92c",
   "sshfp_rsa": "SSHFP 1 1 d25c836cfde179592f943b2f0683ec4cb9ea1df6\nSSHFP 1 2 1a3730ad9a5898dcb501c23f8fae567a1c8f8d703924d631bc357af0f1a79f9f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC6BdnKic9BQ4waex+wmaoLHLX2RUXuSVi/ZP9FJz+GrcaZAHsM50dF1zybjgQiKqxMsVBtjntIsYiN1hVXyWHfTNbwpb7mdMlkgZusAIZwTIk1+08oa2U2Btv3D5x/l/sZrliMWHHqH2nFa4W0dwYTmpFugFE/HZDYlnGdU/15BF1jMpr2wMj0xN4KYCmhwQy2J8DKQlbKKNgoKm24ryDYTGyU3X73GkYqMHlucU3sl3d1aQW8unQ7y3F3gOlmyikw6G9inb+LqeZGqlejb6azAm/juyFamE1h3WA3l7O3HIwGdE5QQ82cotkxTlxLMBlxVg8zIwXEqJLTRhy6iWlp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -465,11 +428,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 46,
-  "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.0/freebsd-13-x86_64.facts
+++ b/facts/4.0/freebsd-13-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "13",
@@ -51,8 +39,6 @@
     "1m": 0.39501953125,
     "5m": 0.3662109375
   },
-  "macaddress": "08:00:27:37:c2:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 394223616
     }
   },
-  "memoryfree": "608.52 MiB",
-  "memoryfree_mb": 608.52,
-  "memorysize": "984.48 MiB",
-  "memorysize_mb": 984.48,
   "mountpoints": {
     "/": {
       "available": "58.48 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -361,9 +341,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.0-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -376,7 +353,6 @@
       "minor": "0"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -398,9 +374,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/root/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -410,16 +383,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -452,11 +420,6 @@
   "sshfp_ed25519": "SSHFP 4 1 882c76c1ba285d186b53bb6e2a6ead8e960cc951\nSSHFP 4 2 fd302981dcc80d537e25eca6399a36a9c7a39d2a0656555e15e5f35bad0d678e",
   "sshfp_rsa": "SSHFP 1 1 a95edf0f08db96e27bcb0fd27428304fb0883037\nSSHFP 1 2 5dc90d4febda1dd40bc062d360bf104d36e482ea81a2bb68f83e140f5d0ac484",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCvTUsmTLlYzmSFQBalEC6yoI2nHsROPn6sUXXOAClXC9jwA52cP/InDscEnK6ubdiY4bivlXfZNJJdjqVWiv3E8wG8M8i7S2g7JcfF7615/L9w5GA7qwneCNUtwhIdwiYptCzxctkftwLmGKfWOZw7alvt7ebzPJjuw7KBKGBxOhG8oDaMmnTWRO2JjuR1bpMxbCj2NCGAe+ZTcwJfqtrVKBGZM2A+/ZqVqMHR5lYCj6lRUyOFKxa0OmkFt9MXAkJra11lqd+LcyI9PdcMom9UicLhv91HXxwuET4IHoUxvusr8L1ZP7iBKjH68kBSdpOhdXoqokOXqzWc/kYAdbdd",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 21,
@@ -464,11 +427,6 @@
     "uptime": "21:18 hours"
   },
   "timezone": "UTC",
-  "uptime": "21:18 hours",
-  "uptime_days": 0,
-  "uptime_hours": 21,
-  "uptime_seconds": 76703,
-  "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.0/opensuse-15-x86_64.facts
+++ b/facts/4.0/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "149290",
       "version": "6.1.32"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_eth0": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.78,
     "5m": 0.25
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:4d:d2:f8",
   "macaddress_eth0": "08:00:27:4d:d2:f8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "705.50 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 269512704
     }
   },
-  "memoryfree": "705.50 MiB",
-  "memoryfree_mb": 705.5,
-  "memorysize": "962.53 MiB",
-  "memorysize_mb": 962.53,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -322,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -402,9 +367,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -429,7 +391,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -442,9 +403,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "x86_64",
@@ -454,20 +412,13 @@
     "physicalcount": 1,
     "speed": "1.70 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -517,10 +468,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 110,
-  "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/oraclelinux-7-x86_64.facts
+++ b/facts/4.0/oraclelinux-7-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "selinux": false,
-  "ipaddress": "192.168.0.1",
-  "operatingsystem": "OracleLinux",
-  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "OracleLinux",
@@ -630,7 +626,9 @@
     "sshd": "/var/empty/sshd"
   },
   "prometheus_alert_manager_running": false,
-  "who2bug": [],
+  "who2bug": [
+
+  ],
   "classification": {
     "hostname": "live-pulp",
     "parts": [
@@ -667,14 +665,24 @@
   "selinux_python_command": "python",
   "is_pe": false,
   "pe_patch": {
-    "package_updates": [],
+    "package_updates": [
+
+    ],
     "package_update_count": 0,
-    "missing_update_kbs": [],
-    "security_package_updates": [],
+    "missing_update_kbs": [
+
+    ],
+    "security_package_updates": [
+
+    ],
     "security_package_update_count": 0,
-    "blackouts": {},
-    "pinned_packages": [],
-    "last_run": {},
+    "blackouts": {
+    },
+    "pinned_packages": [
+
+    ],
+    "last_run": {
+    },
     "patch_group": "",
     "reboot_override": "default",
     "reboots": {
@@ -686,9 +694,8 @@
       "security_update_file": "Security update file not found, update information invalid"
     },
     "blocked": false,
-    "blocked_reasons": []
-  },
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo"
+    "blocked_reasons": [
+
+    ]
+  }
 }

--- a/facts/4.0/redhat-7-x86_64.facts
+++ b/facts/4.0/redhat-7-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "selinux": false,
-  "ipaddress": "192.168.0.1",
-  "operatingsystem": "RedHat",
-  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "RedHat",
@@ -630,7 +626,9 @@
     "sshd": "/var/empty/sshd"
   },
   "prometheus_alert_manager_running": false,
-  "who2bug": [],
+  "who2bug": [
+
+  ],
   "classification": {
     "hostname": "live-pulp",
     "parts": [
@@ -667,14 +665,24 @@
   "selinux_python_command": "python",
   "is_pe": false,
   "pe_patch": {
-    "package_updates": [],
+    "package_updates": [
+
+    ],
     "package_update_count": 0,
-    "missing_update_kbs": [],
-    "security_package_updates": [],
+    "missing_update_kbs": [
+
+    ],
+    "security_package_updates": [
+
+    ],
     "security_package_update_count": 0,
-    "blackouts": {},
-    "pinned_packages": [],
-    "last_run": {},
+    "blackouts": {
+    },
+    "pinned_packages": [
+
+    ],
+    "last_run": {
+    },
     "patch_group": "",
     "reboot_override": "default",
     "reboots": {
@@ -686,9 +694,8 @@
       "security_update_file": "Security update file not found, update information invalid"
     },
     "blocked": false,
-    "blocked_reasons": []
-  },
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo"
+    "blocked_reasons": [
+
+    ]
+  }
 }

--- a/facts/4.0/redhat-8-x86_64.facts
+++ b/facts/4.0/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.5.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "2f00a6bd-43f5-8448-a9c9-c32a4c2d8545"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,12 +67,7 @@
     "1m": 0.44,
     "5m": 0.12
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -115,10 +88,6 @@
       "used_bytes": 479281152
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1309.29,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36,
   "mountpoints": {
     "/": {
       "available": "67.07 GiB",
@@ -333,14 +302,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -445,7 +407,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -477,10 +438,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -491,26 +448,14 @@
     "physicalcount": 1,
     "speed": "3.20 GHz"
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.5.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -543,10 +488,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5fd0ea2f89c4074f18f624824d37129e3ed77aed\nSSHFP 4 2 d8ae12689abe03176bebab53e2c718fa23a809868efe5e30aeb07ea50c15dc23",
   "sshfp_rsa": "SSHFP 1 1 3694b6c0a343d0417442df9f3a4c0c54ce1d3e58\nSSHFP 1 2 97c2fa9a52292600314446dff18e89f492a64d480572287da118080b8120c73a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC288c7+tBkGTWwOkGkHFevzdXvvR7o+GyI+0t/lLmQNfMc6ukL4EEyy9qdlrT9exe6SoOSK9KJY3Sd9gL+ChaHJuyn+oNChUd0w/mimWtfLt63jLRscRe47b8L4KC/+x8zrRxTeCszxTdk9ey4MIKxOYMDysQUOGmuaNJboAM7wy/Cv4rXTA6X8H3WOqMIK6ZO8+WpHIPzMUHgSKQPMFSKwEcZMLht1dCa3XnjWrt2Uae8goRwtJyUrqe2ozAN7iAGCodPptDUHxU57cFzxoz9Z2+e5pWexyQyCL5zJM7DYUxESje7ME6L1wFN2svEmgVjcqP6iJqKtqNJp4oE0Q2pMG3zwIm5TuKGrcJVOdzcva7GSXv4Z6O19f95Rhg2huFEuzeZu0iEo/3ZFq0y7kczSjZZb207PJywAj4zOXqNERNjMKWeSV/DUyLOKuXjauyao8AYC/oC646ReFN/nlJUMZdWRU8eW3HRkrh2NmJ4r278uoU4+v10/hJjke73+Ac=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2088.0,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2088.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -554,10 +495,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 54,
-  "uuid": "2f00a6bd-43f5-8448-a9c9-c32a4c2d8545",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/rocky-8-x86_64.facts
+++ b/facts/4.0/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.25.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,7 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
@@ -87,12 +66,7 @@
     "1m": 0.57,
     "5m": 0.14
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:0e:f4:43",
   "macaddress_eth0": "08:00:27:0e:f4:43",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.06 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 447795200
     }
   },
-  "memoryfree": "1.36 GiB",
-  "memoryfree_mb": 1390.05,
-  "memorysize": "1.77 GiB",
-  "memorysize_mb": 1817.1,
   "mountpoints": {
     "/": {
       "available": "67.37 GiB",
@@ -331,10 +301,8 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
   "network_eth0": "10.0.2.0",
   "network_lo": "127.0.0.0",
   "networking": {
@@ -379,9 +347,6 @@
     "network": "10.0.2.0",
     "primary": "eth0"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -411,7 +376,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rl_rocky8-root": {
       "filesystem": "xfs",
@@ -443,10 +407,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -457,22 +417,11 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.9"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -505,10 +454,6 @@
   "sshfp_ed25519": "SSHFP 4 1 b8839b8751bfb04ec06ea3e98fd999c8763d2a33\nSSHFP 4 2 b512c5ce3e72c8b3020c33e81cd615a9439f354a89e6defc58d5b10e7cbcfeca",
   "sshfp_rsa": "SSHFP 1 1 cd8d4912f84ec6bd32608ea58d2ca0768673cdbe\nSSHFP 1 2 5be1f47956e15951b50119fd92fdf14877ebd20fff1b61982198bc08b59ca4ac",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDKUNpj8dEfGscp8DOcU8562dhk0oojQyLJqS9+oj/zezjKbarVtnNYeviVa+2OgNUl1HGxPhLL9hVvptN+bJI9mqsVadGDuuQQ3eZc0cTylkI5zshmi2oj42Vi/HI8b1Df8WhLLoLNmiyPF89k2KCuLgaO1NTdEG5jd9gA6+60JkdF0vy+DbKhAaDzQ8WcsllGv8kB9UHtPZq3zlojVC0DNoO8uQWftRs/GzTk31O88F4jB6hdoBVWLEfOMfO6IhMwFQ68w9cYD+jbDwf8FfsRQJoRjlw8wgUIaZRWPg9Tsd9QzmUrMocj+p+TruHutYcoxczsvOWbcli73sxsuugMEx6zA+nIkggY4tTyFlYj7fohvbUflxz/9NOaFo9pRm+jbkwYwYlnD8VWRYAMTA36DhIZpuO49RyatGiMRyQ1alWZxDAP7FadF84fJLagLC2SxLwXLGNyohAs9bqgV7m/G21HJmP7UuN8RtwDW5S/9ToL8d8m50Ezm581vv3Rit0=",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2108.0,
-  "swapsize": "2.06 GiB",
-  "swapsize_mb": 2108.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -516,10 +461,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 60,
-  "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/rocky-9-x86_64.facts
+++ b/facts/4.0/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.17.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "d40b12a5-4669-c749-8c81-605cd53293f2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "154048",
       "version": "6.1.40"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.65,
     "5m": 0.16
   },
-  "lsbdistrelease": "9.1",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "1",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 504803328
     }
   },
-  "memoryfree": "7.28 GiB",
-  "memoryfree_mb": 7455.71,
-  "memorysize": "7.75 GiB",
-  "memorysize_mb": 7937.13,
   "mountpoints": {
     "/": {
       "available": "4.37 GiB",
@@ -380,14 +349,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -460,9 +425,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.1",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -492,7 +454,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -532,10 +493,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -546,25 +503,13 @@
     "physicalcount": 1,
     "speed": "3.18 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -597,10 +542,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8681c8063b0f1ccd7bfdb3bd468d73de4adc1ceb\nSSHFP 4 2 11c28cf8112fbb38a9f4220dd595b69ac6408183968b00cda9a3f5109d6107f5",
   "sshfp_rsa": "SSHFP 1 1 84279cc5bc2be250d3a75663c13595054bab348b\nSSHFP 1 2 45195f9947c56a14f653e2b09f94050baa964a4a333203ab6889dd2b764468a0",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDUe1ePbUoHCPKMP7PSo8a+szdlyP0xeTU9MQ5TV90yu1wgmHrtx8FJPMMUOX6Au5lnhXb8ohwkrfovbe8H3wYYOhi+C5Uzt4p8QBuAfOm04mDKeUs+e8Ku9TsHukCwaeGNWajtdPBwCD8YOMgw1TbAjuILxvUDjbbc7QII6N5JJknahvctwzo6tkWDaBQU8kFKhNqDAoCgIgrSfCDsW740Ke3rAPnweSZfVeiskHMIU+lCIIKfyPzobooUAeqXGCw9m0kZc3jRqbEZALTZMfx6uNPTKs0xAwMIHYxt//iYQ4whtw+/v64smJToyi4EWvq43ul7FxcgE6Du21yCkqdeG8zpggW79k7+ul2g46e3hqolJGJVlZRA6qQXJOMu0TmMofdgFuxUgjBietjQiazxy3wt3oAj4HE3y/bCyZjcdJwzdq7kDs54ptyQStw3pT5cza8e7iIkuvfY3qaGfIsLXsGAG9NG+NBBGLZA3FblW+X/CZDohZMTWD21Xnokvls=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -608,10 +549,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 53,
-  "uuid": "d40b12a5-4669-c749-8c81-605cd53293f2",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/scientific-7-x86_64.facts
+++ b/facts/4.0/scientific-7-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "selinux": false,
-  "ipaddress": "192.168.0.1",
-  "operatingsystem": "Scientific",
-  "osfamily": "RedHat",
   "os": {
     "family": "RedHat",
     "name": "Scientific",
@@ -630,7 +626,9 @@
     "sshd": "/var/empty/sshd"
   },
   "prometheus_alert_manager_running": false,
-  "who2bug": [],
+  "who2bug": [
+
+  ],
   "classification": {
     "hostname": "live-pulp",
     "parts": [
@@ -667,14 +665,24 @@
   "selinux_python_command": "python",
   "is_pe": false,
   "pe_patch": {
-    "package_updates": [],
+    "package_updates": [
+
+    ],
     "package_update_count": 0,
-    "missing_update_kbs": [],
-    "security_package_updates": [],
+    "missing_update_kbs": [
+
+    ],
+    "security_package_updates": [
+
+    ],
     "security_package_update_count": 0,
-    "blackouts": {},
-    "pinned_packages": [],
-    "last_run": {},
+    "blackouts": {
+    },
+    "pinned_packages": [
+
+    ],
+    "last_run": {
+    },
     "patch_group": "",
     "reboot_override": "default",
     "reboots": {
@@ -686,9 +694,8 @@
       "security_update_file": "Security update file not found, update information invalid"
     },
     "blocked": false,
-    "blocked_reasons": []
-  },
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo"
+    "blocked_reasons": [
+
+    ]
+  }
 }

--- a/facts/4.0/solaris-11-sun4v.facts
+++ b/facts/4.0/solaris-11-sun4v.facts
@@ -1,5 +1,4 @@
 {
-  "ipaddress": "192.168.0.1",
   "is_virtual": true,
   "solaris_zones": {
     "current": "global",
@@ -22,8 +21,6 @@
   },
   "facterversion": "4.0.52",
   "timezone": "PST",
-  "operatingsystem": "Solaris",
-  "osfamily": "Solaris",
   "os": {
     "name": "Solaris",
     "hardware": "sun4v",
@@ -574,9 +571,6 @@
   "puppetserver_installed": false,
   "context": "",
   "pip_version": "6.0.8",
-  "domain": "example.com",
   "ldom_domainname": "foo",
-  "fqdn": "foo.example.com",
-  "hostname": "foo",
   "ldom_domain_name": "foo"
 }

--- a/facts/4.0/ubuntu-18.04-x86_64.facts
+++ b/facts/4.0/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.5.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_enp0s3": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.69,
     "5m": 0.23
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:98:b5:2c:07:4e",
   "macaddress_enp0s3": "02:98:b5:2c:07:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "683.07 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 316502016
     }
   },
-  "memoryfree": "683.07 MiB",
-  "memoryfree_mb": 683.07,
-  "memorysize": "984.91 MiB",
-  "memorysize_mb": 984.91,
   "mountpoints": {
     "/": {
       "available": "37.25 GiB",
@@ -342,14 +306,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -424,9 +384,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -449,7 +406,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -462,10 +418,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -476,21 +428,14 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.5.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -540,10 +485,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 78,
-  "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/ubuntu-20.04-x86_64.facts
+++ b/facts/4.0/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.5.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_enp0s3": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.69,
     "5m": 0.19
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.3 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:6b:e6:b4:03:6e",
   "macaddress_enp0s3": "02:6b:e6:b4:03:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "601.50 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 397963264
     }
   },
-  "memoryfree": "601.50 MiB",
-  "memoryfree_mb": 601.5,
-  "memorysize": "981.03 MiB",
-  "memorysize_mb": 981.03,
   "mountpoints": {
     "/": {
       "available": "37.09 GiB",
@@ -411,14 +375,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -493,9 +453,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -518,7 +475,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -552,10 +508,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -566,21 +518,14 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.5.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -630,10 +575,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 57,
-  "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/ubuntu-21.04-x86_64.facts
+++ b/facts/4.0/ubuntu-21.04-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_enp0s3": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.89,
     "5m": 0.28
   },
-  "lsbdistcodename": "hirsute",
-  "lsbdistdescription": "Ubuntu 21.04",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.04",
-  "lsbmajdistrelease": "21.04",
-  "macaddress": "02:d5:9c:f7:3e:c1",
   "macaddress_enp0s3": "02:d5:9c:f7:3e:c1",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "627.48 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 361238528
     }
   },
-  "memoryfree": "627.48 MiB",
-  "memoryfree_mb": 627.48,
-  "memorysize": "971.98 MiB",
-  "memorysize_mb": 971.98,
   "mountpoints": {
     "/": {
       "available": "36.85 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -501,9 +461,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.04",
-  "operatingsystemrelease": "21.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -526,7 +483,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -560,10 +516,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -574,20 +526,13 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -637,10 +582,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 79,
-  "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b",
   "virtual": "virtualbox"
 }

--- a/facts/4.0/ubuntu-21.10-x86_64.facts
+++ b/facts/4.0/ubuntu-21.10-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.0.52",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.0.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_enp0s3": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.81,
     "5m": 0.24
   },
-  "lsbdistcodename": "impish",
-  "lsbdistdescription": "Ubuntu 21.10",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.10",
-  "lsbmajdistrelease": "21.10",
-  "macaddress": "02:7c:78:8b:f3:35",
   "macaddress_enp0s3": "02:7c:78:8b:f3:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "628.57 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 359333888
     }
   },
-  "memoryfree": "628.57 MiB",
-  "memoryfree_mb": 628.57,
-  "memorysize": "971.26 MiB",
-  "memorysize_mb": 971.26,
   "mountpoints": {
     "/": {
       "available": "36.63 GiB",
@@ -397,14 +361,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -479,9 +439,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.10",
-  "operatingsystemrelease": "21.10",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -504,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -538,10 +494,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x86_64",
@@ -552,20 +504,13 @@
     "physicalcount": 1,
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.4"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.4",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -615,10 +560,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 78,
-  "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/almalinux-8-x86_64.facts
+++ b/facts/4.1/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.25.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "5745b281-2bd4-ce4b-a939-1135318c2c1e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:febf:d499",
   "ipaddress6_enp0s3": "fe80::a00:27ff:febf:d499",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.83,
     "5m": 0.3
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:bf:d4:99",
   "macaddress_enp0s3": "08:00:27:bf:d4:99",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.95 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 369807360
     }
   },
-  "memoryfree": "617.18 MiB",
-  "memoryfree_mb": 617.17578125,
-  "memorysize": "969.85 MiB",
-  "memorysize_mb": 969.8515625,
   "mountpoints": {
     "/": {
       "available": "15.56 GiB",
@@ -328,14 +297,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -408,9 +373,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -440,7 +402,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -459,9 +420,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -473,25 +431,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.9"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -524,10 +470,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e40909316cd34fe2b817dc08daf6603b5901b570\nSSHFP 4 2 355f7e9113f9f39ecbf0ebf5f03cf1b0b6ec9922888d4bce4762d8d39a5cab57",
   "sshfp_rsa": "SSHFP 1 1 e6ae57027741d8a85964a5172c9ec0a8c069271f\nSSHFP 1 2 30a48581cd638faacc948e2ae7c764b1f78f610402e691b316407a2e5b432e38",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCh+rhVbl+hWvDqzjXGUKHIVpqjP2tXEBFmmPYcT0ySilb5fP8TGnox2/5dvVf7/F0wKcqeherhHMjhZGbira9CGIWhMIwKTSPskVSxLRM3hXoXHGckXu0dD7M0Jk6z3lII1SOLZQshXgkPZwwkwli13RcQOO5Uv8Z+cm/1C1gn/mqLyQQM1Z3gXMd82dtrq2Ujv7FW5ehVjcIujn4mcKp4L9OR5bB0tx9QKoCT8DX5HZZQXQjbXiWLw9VrWAx8greOSgkr9jGoz4QJlCok0sSJ9ashA9Xe6+/X1CYocHvkNFA4M9ot0tZfCntfDFkFxVjrPHOpWETYgwltuIPu9F/14W32Mh8Z9CBVpsFMlviojlNiddUGv2Jdh4IYfs6AN5V0SLcUH3CkEKiNGWNzpPbc4YAUpgfqDZrgZi1sbm2dhRvSNP9TN3d/eEcJU+0JzKJD5x6O3MXs/eWhqmIUkHa/BuLF4mRj3Ncd/HqJ/4+YNFGO3ONSuRrLqj1gBKuDqOE=",
-  "swapfree": "1.95 GiB",
-  "swapfree_mb": 1999.234375,
-  "swapsize": "1.95 GiB",
-  "swapsize_mb": 1999.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -535,10 +477,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 68,
-  "uuid": "5745b281-2bd4-ce4b-a939-1135318c2c1e",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/almalinux-9-x86_64.facts
+++ b/facts/4.1/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.17.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "590c38ef-f707-8c42-9289-5d5f2c1402af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "150636",
       "version": "6.1.34"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe00:788a",
   "ipaddress6_enp0s3": "fe80::a00:27ff:fe00:788a",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.43,
     "5m": 0.11
   },
-  "lsbdistrelease": "9.0",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:00:78:8a",
   "macaddress_enp0s3": "08:00:27:00:78:8a",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "643.50 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 332496896
     }
   },
-  "memoryfree": "643.50 MiB",
-  "memoryfree_mb": 643.49609375,
-  "memorysize": "960.59 MiB",
-  "memorysize_mb": 960.58984375,
   "mountpoints": {
     "/": {
       "available": "17.95 GiB",
@@ -310,14 +279,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -390,9 +355,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.0",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -422,7 +384,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "368a572a-a18a-429d-9c34-bf804a222ac5",
@@ -439,9 +400,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -453,25 +411,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -511,10 +457,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 49,
-  "uuid": "590c38ef-f707-8c42-9289-5d5f2c1402af",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/centos-7-x86_64.facts
+++ b/facts/4.1/centos-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.6.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,22 +37,15 @@
       "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:febc:824c",
   "ipaddress6_lo": "::1",
@@ -92,13 +70,8 @@
     "1m": 0.92,
     "5m": 0.22
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:bc:82:4c",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -119,10 +92,6 @@
       "used_bytes": 186658816
     }
   },
-  "memoryfree": "308.98 MiB",
-  "memoryfree_mb": 308.984375,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.47 GiB",
@@ -340,16 +309,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -452,9 +417,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -484,7 +446,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -495,9 +456,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -509,27 +467,15 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -562,10 +508,6 @@
   "sshfp_ed25519": "SSHFP 4 1 c7dc9219798ee1d0781307f9f2d928be40f7c56b\nSSHFP 4 2 fc9078b55611fee68a52197cc99a44ead6f43272ffe36fadf7c15fe3571c6644",
   "sshfp_rsa": "SSHFP 1 1 979ee2b3de8a6845741abec79f2a10b4a716545d\nSSHFP 1 2 b6d48705149c9da9d3502fd6e144a8edddf7a6260a4623075231a4a0461637ce",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDNGBlzNJ4Sh8ezy03xB7ogfs9nonlHUNhCvRhKrjmbVg5bQUOOmabmGZ3hfMIIMBrvM0Zw42NUAB2aDzYGDHOTXz3ucxDAXJwXPkUyKSPnSgfVOfC9D3fbJoJOblYu0MrcX2rdgUl7J+zpBuaJ66aP1oCdJ+LU5DksEmBPwJJHYEdnPjA9CrI7COTnsewTTMr9AGQLRSbltiDYLLGSfS4TsvHFCKDFf7mKFzFPxSJKfwZVwvO4FeTjBCt//nkE/B7pmBT6l4DLk1U89nTADoGDTMmfdFWmiZrPj80Aavg8OUtCpc+9DDMCq5VVFErwHBwgn/GBfi7C13cdaXNYXz89",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2044.73828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -573,10 +515,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 85,
-  "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/centos-8-x86_64.facts
+++ b/facts/4.1/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.6.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "4d8cb64e-7a3a-da45-90e9-0f06f70d24f3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "iso9660,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "159484",
       "version": "7.0.12"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe6d:c543",
   "ipaddress6_eth0": "fe80::5054:ff:fe6d:c543",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,11 +67,7 @@
     "1m": 2.11,
     "5m": 1.14
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:6d:c5:43",
   "macaddress_eth0": "52:54:00:6d:c5:43",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -114,10 +88,6 @@
       "used_bytes": 164204544
     }
   },
-  "memoryfree": "302.21 MiB",
-  "memoryfree_mb": 302.21484375,
-  "memorysize": "458.81 MiB",
-  "memorysize_mb": 458.8125,
   "mountpoints": {
     "/": {
       "available": "5.48 GiB",
@@ -307,14 +277,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -387,9 +353,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -416,7 +379,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -428,9 +390,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -442,26 +401,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -494,10 +441,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9a51cfd8c2315360abd30c423c0f20a6d73c8218\nSSHFP 4 2 d5d65cbc3efcbfa5f572f0769157d690ffbe2c9253eeea8a2bfe7af35e4d6a3a",
   "sshfp_rsa": "SSHFP 1 1 cf695b0a9094467072fe24ca60f98509192288bf\nSSHFP 1 2 7a6774ea63d4aa301ef57611bb7b2c1a55918037aadd6566fea8675de435cbd8",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCsL2n/oKH9+g1mt1XYrWPAuvXGM7bAdUu4WAX5DwR8xzgUruTiB7gSbhpRpC0rhbzVk0o5a3Qd1+3KeHGURZlzJ1ihf9tSkjN4GU0RaWaYzmAHEZgtwgZ20c3ZLWUe6dTaQouD3UOXpuDpiiK2fWhCle6/TEYPUsKgD7vMMQpxIDVjIp7O3IRqubD0/Ir6HWAczBA9XjW0rGSRbVPWgOuGOA+e+BZY8YP3no/7rWE8dsM+v51+fbP8plblUqxejnbk5n9XvqsQ+SI8vvJuuXUK6++EfRXpooCJAJX9ipGLk3hKWHkUuUNNoxwq9u33KJA8/nZESq+q99coc70EdWV9rAzuuxl4ZBVHK9lZQacG8ovL/f8mqIxcMwgyyXK3kVEXlR7g5+kTeoBPZjnfPj/bFpr6iGicK6fvZvkpDRddaqN0aVbC2HcSU+RElApjm2D1WiZye0EZhaibB2gbs9zxAwk0v7F2K6kmEtPzEElf3uGhf2UbhNsd5X0OFzXiz60=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.22265625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -505,10 +448,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 230,
-  "uuid": "4d8cb64e-7a3a-da45-90e9-0f06f70d24f3",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/debian-11-x86_64.facts
+++ b/facts/4.1/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.12.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "1d6dc67d-078b-024a-8ab9-0ed88dc5212d"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe0e:e67a",
   "ipaddress6_eth0": "fe80::a00:27ff:fe0e:e67a",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,15 +69,7 @@
     "1m": 0.48,
     "5m": 0.13
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.1",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "1",
-  "macaddress": "08:00:27:0e:e6:7a",
   "macaddress_eth0": "08:00:27:0e:e6:7a",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.69 GiB",
@@ -111,10 +81,6 @@
       "used_bytes": 263102464
     }
   },
-  "memoryfree": "1.69 GiB",
-  "memoryfree_mb": 1731.828125,
-  "memorysize": "1.94 GiB",
-  "memorysize_mb": 1982.7421875,
   "mountpoints": {
     "/": {
       "available": "16.77 GiB",
@@ -304,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -386,9 +348,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.1",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -413,7 +372,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -426,10 +384,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -442,20 +396,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -505,10 +452,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 75,
-  "uuid": "1d6dc67d-078b-024a-8ab9-0ed88dc5212d",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/freebsd-11-x86_64.facts
+++ b/facts/4.1/freebsd-11-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "11",
@@ -51,8 +39,6 @@
     "1m": 0.638671875,
     "5m": 0.16796875
   },
-  "macaddress": "08:00:27:a3:ff:85",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 539017216
     }
   },
-  "memoryfree": "471.50 MiB",
-  "memoryfree_mb": 471.49609375,
-  "memorysize": "985.54 MiB",
-  "memorysize_mb": 985.54296875,
   "mountpoints": {
     "/": {
       "available": "58.77 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 90112
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +340,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.4-RELEASE-p9",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -376,7 +353,6 @@
       "patchlevel": "9"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -398,9 +374,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -410,16 +383,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd11",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.3"
   },
-  "rubyplatform": "amd64-freebsd11",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.3",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -452,11 +420,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ab7c9e209f87f4e8321b13c6481482dda6fa34d9\nSSHFP 4 2 d934ba8e9c55d0794218dc3c8728f1c09bdd407eac8e8df3990e086678f0d131",
   "sshfp_rsa": "SSHFP 1 1 90f05081e454c2f9bc5b81a46c2c1214605481b4\nSSHFP 1 2 6ebeb0740f993885cbf7bb1d0beefde048614ae657f10a60aa8abbb4e11b5a70",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCsFz4abAckdE8cmgMTW7/yptOhJaIi7D/LqAZOhUdbv+xS4ZDICwyhG3z68SPDjEZqqWjj2Vbqujhzas/Ld/MlvMhlbiM8yonPDJ/on+tKHzjLQEb4SM52skdiFiCnDzQhKCgtTVgOZFtGZz7tM6PCvPAmJsedEVP14ueXam/G7m33hyGd8L3eZirGJTnVZDWItKvokqHmSRmC0qAJqd3llqdCPHqsWMrmwJAPgrC3gRXMAhkbM6XshayHa4pZC24PP/lfb4kqBDfLyUzl5hoWXGPpFUXZXZevZNgp7Jk99NqgTAixUpmYrNgo4Fw1Nuy8FdD4UoY7PWgTHTZVetTp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -464,11 +427,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 48,
-  "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.1/freebsd-12-x86_64.facts
+++ b/facts/4.1/freebsd-12-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "12",
@@ -51,8 +39,6 @@
     "1m": 0.5537109375,
     "5m": 0.1513671875
   },
-  "macaddress": "08:00:27:cc:5d:60",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 452284416
     }
   },
-  "memoryfree": "551.21 MiB",
-  "memoryfree_mb": 551.2109375,
-  "memorysize": "982.54 MiB",
-  "memorysize_mb": 982.54296875,
   "mountpoints": {
     "/": {
       "available": "58.50 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +340,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.2-RELEASE-p6",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -376,7 +353,6 @@
       "patchlevel": "6"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -398,9 +374,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -410,16 +383,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd12",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd12",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -452,11 +420,6 @@
   "sshfp_ed25519": "SSHFP 4 1 aaedcc84b12a9ee5858d1d57396209b5478e4460\nSSHFP 4 2 dd536bc7ec52cb2b42ba56c7fa0e1ca050a476f35fa600a8a09152c0f08bd92c",
   "sshfp_rsa": "SSHFP 1 1 d25c836cfde179592f943b2f0683ec4cb9ea1df6\nSSHFP 1 2 1a3730ad9a5898dcb501c23f8fae567a1c8f8d703924d631bc357af0f1a79f9f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC6BdnKic9BQ4waex+wmaoLHLX2RUXuSVi/ZP9FJz+GrcaZAHsM50dF1zybjgQiKqxMsVBtjntIsYiN1hVXyWHfTNbwpb7mdMlkgZusAIZwTIk1+08oa2U2Btv3D5x/l/sZrliMWHHqH2nFa4W0dwYTmpFugFE/HZDYlnGdU/15BF1jMpr2wMj0xN4KYCmhwQy2J8DKQlbKKNgoKm24ryDYTGyU3X73GkYqMHlucU3sl3d1aQW8unQ7y3F3gOlmyikw6G9inb+LqeZGqlejb6azAm/juyFamE1h3WA3l7O3HIwGdE5QQ82cotkxTlxLMBlxVg8zIwXEqJLTRhy6iWlp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -464,11 +427,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 49,
-  "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.1/freebsd-13-x86_64.facts
+++ b/facts/4.1/freebsd-13-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "13",
@@ -51,8 +39,6 @@
     "1m": 0.39501953125,
     "5m": 0.3662109375
   },
-  "macaddress": "08:00:27:37:c2:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 339726336
     }
   },
-  "memoryfree": "660.50 MiB",
-  "memoryfree_mb": 660.49609375,
-  "memorysize": "984.48 MiB",
-  "memorysize_mb": 984.484375,
   "mountpoints": {
     "/": {
       "available": "58.48 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +340,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.0-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -375,7 +352,6 @@
       "minor": "0"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -397,9 +373,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/root/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -409,16 +382,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -451,11 +419,6 @@
   "sshfp_ed25519": "SSHFP 4 1 882c76c1ba285d186b53bb6e2a6ead8e960cc951\nSSHFP 4 2 fd302981dcc80d537e25eca6399a36a9c7a39d2a0656555e15e5f35bad0d678e",
   "sshfp_rsa": "SSHFP 1 1 a95edf0f08db96e27bcb0fd27428304fb0883037\nSSHFP 1 2 5dc90d4febda1dd40bc062d360bf104d36e482ea81a2bb68f83e140f5d0ac484",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCvTUsmTLlYzmSFQBalEC6yoI2nHsROPn6sUXXOAClXC9jwA52cP/InDscEnK6ubdiY4bivlXfZNJJdjqVWiv3E8wG8M8i7S2g7JcfF7615/L9w5GA7qwneCNUtwhIdwiYptCzxctkftwLmGKfWOZw7alvt7ebzPJjuw7KBKGBxOhG8oDaMmnTWRO2JjuR1bpMxbCj2NCGAe+ZTcwJfqtrVKBGZM2A+/ZqVqMHR5lYCj6lRUyOFKxa0OmkFt9MXAkJra11lqd+LcyI9PdcMom9UicLhv91HXxwuET4IHoUxvusr8L1ZP7iBKjH68kBSdpOhdXoqokOXqzWc/kYAdbdd",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 21,
@@ -463,11 +426,6 @@
     "uptime": "21:18 hours"
   },
   "timezone": "UTC",
-  "uptime": "21:18 hours",
-  "uptime_days": 0,
-  "uptime_hours": 21,
-  "uptime_seconds": 76705,
-  "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.1/opensuse-15-x86_64.facts
+++ b/facts/4.1/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "149290",
       "version": "6.1.32"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_eth0": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.72,
     "5m": 0.25
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:4d:d2:f8",
   "macaddress_eth0": "08:00:27:4d:d2:f8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "704.48 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 270585856
     }
   },
-  "memoryfree": "704.48 MiB",
-  "memoryfree_mb": 704.4765625,
-  "memorysize": "962.53 MiB",
-  "memorysize_mb": 962.52734375,
   "mountpoints": {
     "/": {
       "available": "37.65 GiB",
@@ -322,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -402,9 +367,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -429,7 +391,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -442,9 +403,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -456,20 +414,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -519,10 +470,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 112,
-  "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/redhat-8-x86_64.facts
+++ b/facts/4.1/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.6.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "2f00a6bd-43f5-8448-a9c9-c32a4c2d8545"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,12 +67,7 @@
     "1m": 0.63,
     "5m": 0.18
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -115,10 +88,6 @@
       "used_bytes": 476090368
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1312.328125,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "67.06 GiB",
@@ -333,14 +302,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -445,7 +407,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -477,10 +438,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,26 +450,14 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -545,10 +490,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5fd0ea2f89c4074f18f624824d37129e3ed77aed\nSSHFP 4 2 d8ae12689abe03176bebab53e2c718fa23a809868efe5e30aeb07ea50c15dc23",
   "sshfp_rsa": "SSHFP 1 1 3694b6c0a343d0417442df9f3a4c0c54ce1d3e58\nSSHFP 1 2 97c2fa9a52292600314446dff18e89f492a64d480572287da118080b8120c73a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC288c7+tBkGTWwOkGkHFevzdXvvR7o+GyI+0t/lLmQNfMc6ukL4EEyy9qdlrT9exe6SoOSK9KJY3Sd9gL+ChaHJuyn+oNChUd0w/mimWtfLt63jLRscRe47b8L4KC/+x8zrRxTeCszxTdk9ey4MIKxOYMDysQUOGmuaNJboAM7wy/Cv4rXTA6X8H3WOqMIK6ZO8+WpHIPzMUHgSKQPMFSKwEcZMLht1dCa3XnjWrt2Uae8goRwtJyUrqe2ozAN7iAGCodPptDUHxU57cFzxoz9Z2+e5pWexyQyCL5zJM7DYUxESje7ME6L1wFN2svEmgVjcqP6iJqKtqNJp4oE0Q2pMG3zwIm5TuKGrcJVOdzcva7GSXv4Z6O19f95Rhg2huFEuzeZu0iEo/3ZFq0y7kczSjZZb207PJywAj4zOXqNERNjMKWeSV/DUyLOKuXjauyao8AYC/oC646ReFN/nlJUMZdWRU8eW3HRkrh2NmJ4r278uoU4+v10/hJjke73+Ac=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -556,10 +497,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 68,
-  "uuid": "2f00a6bd-43f5-8448-a9c9-c32a4c2d8545",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/rocky-8-x86_64.facts
+++ b/facts/4.1/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.25.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,7 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
@@ -87,12 +66,7 @@
     "1m": 0.53,
     "5m": 0.14
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:0e:f4:43",
   "macaddress_eth0": "08:00:27:0e:f4:43",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.06 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 449454080
     }
   },
-  "memoryfree": "1.36 GiB",
-  "memoryfree_mb": 1388.46875,
-  "memorysize": "1.77 GiB",
-  "memorysize_mb": 1817.1015625,
   "mountpoints": {
     "/": {
       "available": "67.35 GiB",
@@ -331,10 +301,8 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
   "network_eth0": "10.0.2.0",
   "network_lo": "127.0.0.0",
   "networking": {
@@ -378,9 +346,6 @@
     "network": "10.0.2.0",
     "primary": "eth0"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -410,7 +375,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rl_rocky8-root": {
       "filesystem": "xfs",
@@ -442,10 +406,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -458,22 +418,11 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.9"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -506,10 +455,6 @@
   "sshfp_ed25519": "SSHFP 4 1 b8839b8751bfb04ec06ea3e98fd999c8763d2a33\nSSHFP 4 2 b512c5ce3e72c8b3020c33e81cd615a9439f354a89e6defc58d5b10e7cbcfeca",
   "sshfp_rsa": "SSHFP 1 1 cd8d4912f84ec6bd32608ea58d2ca0768673cdbe\nSSHFP 1 2 5be1f47956e15951b50119fd92fdf14877ebd20fff1b61982198bc08b59ca4ac",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDKUNpj8dEfGscp8DOcU8562dhk0oojQyLJqS9+oj/zezjKbarVtnNYeviVa+2OgNUl1HGxPhLL9hVvptN+bJI9mqsVadGDuuQQ3eZc0cTylkI5zshmi2oj42Vi/HI8b1Df8WhLLoLNmiyPF89k2KCuLgaO1NTdEG5jd9gA6+60JkdF0vy+DbKhAaDzQ8WcsllGv8kB9UHtPZq3zlojVC0DNoO8uQWftRs/GzTk31O88F4jB6hdoBVWLEfOMfO6IhMwFQ68w9cYD+jbDwf8FfsRQJoRjlw8wgUIaZRWPg9Tsd9QzmUrMocj+p+TruHutYcoxczsvOWbcli73sxsuugMEx6zA+nIkggY4tTyFlYj7fohvbUflxz/9NOaFo9pRm+jbkwYwYlnD8VWRYAMTA36DhIZpuO49RyatGiMRyQ1alWZxDAP7FadF84fJLagLC2SxLwXLGNyohAs9bqgV7m/G21HJmP7UuN8RtwDW5S/9ToL8d8m50Ezm581vv3Rit0=",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2107.99609375,
-  "swapsize": "2.06 GiB",
-  "swapsize_mb": 2107.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -517,10 +462,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 62,
-  "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/rocky-9-x86_64.facts
+++ b/facts/4.1/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.17.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "d40b12a5-4669-c749-8c81-605cd53293f2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "154048",
       "version": "6.1.40"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.65,
     "5m": 0.16
   },
-  "lsbdistrelease": "9.1",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "1",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 506159104
     }
   },
-  "memoryfree": "7.28 GiB",
-  "memoryfree_mb": 7454.41796875,
-  "memorysize": "7.75 GiB",
-  "memorysize_mb": 7937.12890625,
   "mountpoints": {
     "/": {
       "available": "4.35 GiB",
@@ -380,14 +349,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -460,9 +425,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.1",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -492,7 +454,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -532,10 +493,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -548,25 +505,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -599,10 +544,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8681c8063b0f1ccd7bfdb3bd468d73de4adc1ceb\nSSHFP 4 2 11c28cf8112fbb38a9f4220dd595b69ac6408183968b00cda9a3f5109d6107f5",
   "sshfp_rsa": "SSHFP 1 1 84279cc5bc2be250d3a75663c13595054bab348b\nSSHFP 1 2 45195f9947c56a14f653e2b09f94050baa964a4a333203ab6889dd2b764468a0",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDUe1ePbUoHCPKMP7PSo8a+szdlyP0xeTU9MQ5TV90yu1wgmHrtx8FJPMMUOX6Au5lnhXb8ohwkrfovbe8H3wYYOhi+C5Uzt4p8QBuAfOm04mDKeUs+e8Ku9TsHukCwaeGNWajtdPBwCD8YOMgw1TbAjuILxvUDjbbc7QII6N5JJknahvctwzo6tkWDaBQU8kFKhNqDAoCgIgrSfCDsW740Ke3rAPnweSZfVeiskHMIU+lCIIKfyPzobooUAeqXGCw9m0kZc3jRqbEZALTZMfx6uNPTKs0xAwMIHYxt//iYQ4whtw+/v64smJToyi4EWvq43ul7FxcgE6Du21yCkqdeG8zpggW79k7+ul2g46e3hqolJGJVlZRA6qQXJOMu0TmMofdgFuxUgjBietjQiazxy3wt3oAj4HE3y/bCyZjcdJwzdq7kDs54ptyQStw3pT5cza8e7iIkuvfY3qaGfIsLXsGAG9NG+NBBGLZA3FblW+X/CZDohZMTWD21Xnokvls=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -610,10 +551,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 54,
-  "uuid": "d40b12a5-4669-c749-8c81-605cd53293f2",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/ubuntu-18.04-x86_64.facts
+++ b/facts/4.1/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.6.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_enp0s3": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.81,
     "5m": 0.28
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:98:b5:2c:07:4e",
   "macaddress_enp0s3": "02:98:b5:2c:07:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "680.19 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 319524864
     }
   },
-  "memoryfree": "680.19 MiB",
-  "memoryfree_mb": 680.19140625,
-  "memorysize": "984.91 MiB",
-  "memorysize_mb": 984.9140625,
   "mountpoints": {
     "/": {
       "available": "37.23 GiB",
@@ -342,14 +306,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -424,9 +384,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -449,7 +406,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -462,10 +418,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -478,21 +430,14 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -542,10 +487,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 86,
-  "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/ubuntu-20.04-x86_64.facts
+++ b/facts/4.1/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.6.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_enp0s3": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.71,
     "5m": 0.2
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.3 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:6b:e6:b4:03:6e",
   "macaddress_enp0s3": "02:6b:e6:b4:03:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "597.10 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 402575360
     }
   },
-  "memoryfree": "597.10 MiB",
-  "memoryfree_mb": 597.1015625,
-  "memorysize": "981.03 MiB",
-  "memorysize_mb": 981.02734375,
   "mountpoints": {
     "/": {
       "available": "37.07 GiB",
@@ -411,14 +375,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -493,9 +453,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -518,7 +475,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -552,10 +508,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -568,21 +520,14 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.6.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -632,10 +577,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 65,
-  "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/ubuntu-21.04-x86_64.facts
+++ b/facts/4.1/ubuntu-21.04-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_enp0s3": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.9,
     "5m": 0.29
   },
-  "lsbdistcodename": "hirsute",
-  "lsbdistdescription": "Ubuntu 21.04",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.04",
-  "lsbmajdistrelease": "21.04",
-  "macaddress": "02:d5:9c:f7:3e:c1",
   "macaddress_enp0s3": "02:d5:9c:f7:3e:c1",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "626.36 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 362409984
     }
   },
-  "memoryfree": "626.36 MiB",
-  "memoryfree_mb": 626.36328125,
-  "memorysize": "971.98 MiB",
-  "memorysize_mb": 971.984375,
   "mountpoints": {
     "/": {
       "available": "36.85 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -501,9 +461,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.04",
-  "operatingsystemrelease": "21.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -526,7 +483,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -560,10 +516,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -576,20 +528,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -639,10 +584,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 82,
-  "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b",
   "virtual": "virtualbox"
 }

--- a/facts/4.1/ubuntu-21.10-x86_64.facts
+++ b/facts/4.1/ubuntu-21.10-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.1.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.1.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_enp0s3": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.82,
     "5m": 0.26
   },
-  "lsbdistcodename": "impish",
-  "lsbdistdescription": "Ubuntu 21.10",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.10",
-  "lsbmajdistrelease": "21.10",
-  "macaddress": "02:7c:78:8b:f3:35",
   "macaddress_enp0s3": "02:7c:78:8b:f3:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "628.17 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 359759872
     }
   },
-  "memoryfree": "628.17 MiB",
-  "memoryfree_mb": 628.16796875,
-  "memorysize": "971.26 MiB",
-  "memorysize_mb": 971.26171875,
   "mountpoints": {
     "/": {
       "available": "36.62 GiB",
@@ -397,14 +361,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -479,9 +439,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.10",
-  "operatingsystemrelease": "21.10",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -504,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -538,10 +494,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -554,20 +506,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.4"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.4",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -617,10 +562,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 81,
-  "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/almalinux-8-x86_64.facts
+++ b/facts/4.2/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 2.08,
     "5m": 1.61
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "583.36 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 385105920
     }
   },
-  "memoryfree": "583.36 MiB",
-  "memoryfree_mb": 583.35546875,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.21 GiB",
@@ -319,14 +288,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -405,9 +370,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -437,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -449,9 +410,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -463,26 +421,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -522,10 +468,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 390,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/almalinux-9-x86_64.facts
+++ b/facts/4.2/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.08,
     "5m": 0.56
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "559.92 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 404049920
     }
   },
-  "memoryfree": "559.92 MiB",
-  "memoryfree_mb": 559.921875,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.58 GiB",
@@ -412,14 +381,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -498,9 +463,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -530,7 +492,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -567,9 +528,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -581,26 +539,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -640,10 +586,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 147,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/amazon-2022-x86_64.facts
+++ b/facts/4.2/amazon-2022-x86_64.facts
@@ -1,11 +1,4 @@
 {
-  "selinux": false,
-  "hostname": "foo",
-  "operatingsystem": "Amazon",
-  "osfamily": "RedHat",
-  "fqdn": "foo.example.com",
-  "domain": "example.com",
-  "ipaddress": "172.17.0.7",
   "os": {
     "distro": {
       "description": "Amazon Linux release 2022 (Amazon Linux)",

--- a/facts/4.2/archlinux-x86_64.facts
+++ b/facts/4.2/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,9 +69,7 @@
     "1m": 1.01,
     "5m": 0.37
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -114,10 +90,6 @@
       "used_bytes": 324034560
     }
   },
-  "memoryfree": "656.21 MiB",
-  "memoryfree_mb": 656.20703125,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.85 GiB",
@@ -336,14 +308,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -424,7 +392,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -449,7 +416,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -477,10 +443,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,20 +455,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -539,10 +494,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -550,10 +501,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 103,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/centos-7-x86_64.facts
+++ b/facts/4.2/centos-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.9.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "eth1": "192.168.56.100",
@@ -51,22 +38,15 @@
       "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "145957",
       "version": "6.1.26"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:fe47:4e7b",
   "ipaddress6_lo": "::1",
@@ -93,13 +71,8 @@
     "1m": 0.52,
     "5m": 0.14
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:47:4e:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -120,10 +93,6 @@
       "used_bytes": 193908736
     }
   },
-  "memoryfree": "302.07 MiB",
-  "memoryfree_mb": 302.0703125,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.53 GiB",
@@ -341,16 +310,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -463,9 +428,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -495,7 +457,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -506,9 +467,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -520,27 +478,15 @@
     "speed": "2.59 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.9.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -573,10 +519,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ae86105117d5c84add050f97f9d1462b3bfc2052\nSSHFP 4 2 a512469b3965893ec5a4e97a0f8ec7a91c801e9529f65c36266329dc780cb802",
   "sshfp_rsa": "SSHFP 1 1 6e38fb13522239c8d538d4e10b11e6f42f0e62d3\nSSHFP 1 2 d0c146d1206a64545ca299357f9e36354b9e857648bf6db005a0ee33cb2a865a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCtfS7WPA7hSK9zPT7rGHXPVD6dDchTWFTKWwTilrC/Fgh2sfpl3sux2ZKqdZwwDvtBPrPV4BLc32+fzM9vKaW2EEu83Z+W/oFJr6VWpLBSjAMQE+iX68YTXObdRJSrG/w2vAaPiXAmljzGp2/d801XzLQpXLkYOvWSVtDfL4Koqy8uy6ZsJ+4BlvSf6vU2L8L2FQENhyZqgWKAggrR5NWz5eNrEY1cr/2ZqtZEVbQMABs/XEo6dBkDe7k38flRWkXXhbZ9y/sSu25ygiMHBmVOkbs+A0IYPkCFyUqPtPpjLR97yoY+r9hbC47bV7pDTF0hyTylVEFq4l6UwEdJFqMF",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -584,10 +526,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 77,
-  "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/centos-8-x86_64.facts
+++ b/facts/4.2/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 2.6,
     "5m": 2.41
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 169750528
     }
   },
-  "memoryfree": "296.89 MiB",
-  "memoryfree_mb": 296.890625,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.74 GiB",
@@ -308,14 +278,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -394,9 +360,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -423,7 +386,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -435,9 +397,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -449,26 +408,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -501,10 +448,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.87890625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -512,10 +455,5 @@
     "uptime": "0:08 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:08 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 511,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/centos-9-x86_64.facts
+++ b/facts/4.2/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,11 +66,7 @@
     "1m": 1.26,
     "5m": 0.7
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.99 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 145059840
     }
   },
-  "memoryfree": "319.54 MiB",
-  "memoryfree_mb": 319.54296875,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.79 GiB",
@@ -372,14 +342,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -458,9 +424,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -487,7 +450,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -499,9 +461,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -513,26 +472,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -565,10 +512,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.99 GiB",
-  "swapfree_mb": 2035.9140625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -576,10 +519,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 204,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/darwin-20-x86_64.facts
+++ b/facts/4.2/darwin-20-x86_64.facts
@@ -1,10 +1,8 @@
 {
   "aio_agent_version": "7.9.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
   "dhcp_servers": {
     "en0": "10.32.22.9",
     "system": "10.32.22.9"
@@ -14,15 +12,8 @@
       "name": "VMware7,1"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.2",
   "filesystems": "apfs,autofs,devfs,hfs,vmhgfs",
-  "fqdn": "foo.example.com",
-  "gid": "wheel",
-  "hardwareisa": "i386",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -31,8 +22,6 @@
     "user": "root"
   },
   "interfaces": "en0,gif0,lo0,stf0,utun0,utun1",
-  "ipaddress": "10.16.126.40",
-  "ipaddress6": "fe80::c7a:6793:cf7b:e887",
   "ipaddress6_en0": "fe80::c7a:6793:cf7b:e887",
   "ipaddress6_lo0": "::1",
   "ipaddress6_utun0": "fe80::5442:4f69:c81c:c1b5",
@@ -49,13 +38,7 @@
     "1m": 1.59,
     "5m": 1.65
   },
-  "macaddress": "00:50:56:9a:04:1d",
   "macaddress_en0": "00:50:56:9a:04:1d",
-  "macosx_buildversion": "20G80",
-  "macosx_productname": "macOS",
-  "macosx_productversion": "11.5.1",
-  "macosx_productversion_major": "11",
-  "macosx_productversion_minor": "5",
   "macosx_productversion_patch": "1",
   "memory": {
     "system": {
@@ -68,10 +51,6 @@
       "used_bytes": 4043390976
     }
   },
-  "memoryfree": "239.92 MiB",
-  "memoryfree_mb": 239.921875,
-  "memorysize": "4.00 GiB",
-  "memorysize_mb": 4096.0,
   "mountpoints": {
     "/": {
       "available": "62.12 GiB",
@@ -240,16 +219,12 @@
   "mtu_stf0": 1280,
   "mtu_utun0": 1380,
   "mtu_utun1": 2000,
-  "netmask": "255.255.240.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_en0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask6_utun0": "ffff:ffff:ffff:ffff::",
   "netmask6_utun1": "ffff:ffff:ffff:ffff::",
   "netmask_en0": "255.255.240.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.16.112.0",
-  "network6": "fe80::",
   "network6_en0": "fe80::",
   "network6_lo0": "::1",
   "network6_utun0": "fe80::",
@@ -368,9 +343,6 @@
     "primary": "en0",
     "scope6": "link"
   },
-  "operatingsystem": "Darwin",
-  "operatingsystemmajrelease": "20",
-  "operatingsystemrelease": "20.6.0",
   "os": {
     "architecture": "x86_64",
     "family": "Darwin",
@@ -392,12 +364,7 @@
       "minor": "6"
     }
   },
-  "osfamily": "Darwin",
   "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 2,
-  "processor0": "Intel(R) Xeon(R) CPU E5-1680 v2 @ 3.00GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-1680 v2 @ 3.00GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -410,41 +377,16 @@
     "speed": "2.86 GHz",
     "threads": 1
   },
-  "productname": "VMware7,1",
   "puppetversion": "7.9.0",
   "ruby": {
     "platform": "x86_64-darwin20",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-darwin20",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_en0": "link",
   "scope6_lo0": "host",
   "scope6_utun0": "link",
   "scope6_utun1": "link",
-  "sp_boot_mode": "Normal",
-  "sp_boot_volume": "Macintosh HD",
-  "sp_cpu_type": "Unknown",
-  "sp_current_processor_speed": "2.86 GHz",
-  "sp_kernel_version": "Darwin 20.6.0",
-  "sp_l2_cache_core": "256 KB",
-  "sp_l3_cache": "25 MB",
-  "sp_local_host_name": "foo",
-  "sp_machine_model": "VMware7,1",
-  "sp_machine_name": "Mac",
-  "sp_number_processors": "2",
-  "sp_os_version": "macOS 11.5.1 (20G80)",
-  "sp_packages": "1",
-  "sp_physical_memory": "4 GB",
-  "sp_platform_uuid": "421ADE05-1F2A-498A-DDE2-831055094890",
-  "sp_secure_vm": "Enabled",
-  "sp_serial_number": "VM6bYVNeAVLZ",
-  "sp_smc_version_system": "1.16f8",
-  "sp_uptime": "33 minutes",
-  "sp_user_name": "System Administrator (root)",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -516,9 +458,5 @@
     "uptime": "0:33 hours"
   },
   "timezone": "PDT",
-  "uptime": "0:33 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2002,
   "virtual": "vmware"
 }

--- a/facts/4.2/debian-11-x86_64.facts
+++ b/facts/4.2/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,15 +38,9 @@
       "uuid": "be037311-7594-41a5-8599-8496211026af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.95,
     "5m": 0.54
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "336.59 MiB",
@@ -113,10 +83,6 @@
       "used_bytes": 130625536
     }
   },
-  "memoryfree": "336.59 MiB",
-  "memoryfree_mb": 336.5859375,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "91.25 GiB",
@@ -303,14 +269,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -391,9 +353,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -418,7 +377,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -430,10 +388,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -446,21 +400,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -500,10 +447,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 233,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/debian-12-i386.facts
+++ b/facts/4.2/debian-12-i386.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "i386",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "i386",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.21,
     "5m": 0.08
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.63 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 314400768
     }
   },
-  "memoryfree": "1.63 GiB",
-  "memoryfree_mb": 1667.50390625,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "i386",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "i386-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "i386-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 362,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/debian-12-x86_64.facts
+++ b/facts/4.2/debian-12-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.21,
     "5m": 0.08
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.63 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 314400768
     }
   },
-  "memoryfree": "1.63 GiB",
-  "memoryfree_mb": 1667.50390625,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 362,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-36-x86_64.facts
+++ b/facts/4.2/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.2,
     "5m": 0.57
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 441339904
     }
   },
-  "memoryfree": "1.50 GiB",
-  "memoryfree_mb": 1532.84375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.99 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -470,10 +432,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -486,25 +444,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -537,10 +483,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -548,10 +490,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 214,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-37-x86_64.facts
+++ b/facts/4.2/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.99,
     "5m": 0.39
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 422039552
     }
   },
-  "memoryfree": "1.51 GiB",
-  "memoryfree_mb": 1550.9609375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.98 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -475,10 +437,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -491,25 +449,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -542,10 +488,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -553,10 +495,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 165,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-38-x86_64.facts
+++ b/facts/4.2/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.16,
     "5m": 0.44
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 321273856
     }
   },
-  "memoryfree": "1.61 GiB",
-  "memoryfree_mb": 1647.6015625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -439,14 +409,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -525,9 +491,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -555,7 +518,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -595,9 +557,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -609,25 +568,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -660,10 +607,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -671,10 +614,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 218,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-39-x86_64.facts
+++ b/facts/4.2/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.96,
     "5m": 0.42
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 334098432
     }
   },
-  "memoryfree": "1.60 GiB",
-  "memoryfree_mb": 1635.109375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.64 GiB",
@@ -362,14 +332,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -448,9 +414,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -478,7 +441,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -518,9 +480,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -532,25 +491,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -583,10 +530,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -594,10 +537,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 166,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/freebsd-11-x86_64.facts
+++ b/facts/4.2/freebsd-11-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,14 +20,7 @@
       "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.1",
-  "fqdn": "foo.example.com",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -39,7 +28,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "11",
@@ -50,8 +38,6 @@
     "1m": 0.39208984375,
     "5m": 0.10595703125
   },
-  "macaddress": "08:00:27:a3:ff:85",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -73,15 +59,9 @@
       "used_bytes": 478531584
     }
   },
-  "memoryfree": "529.18 MiB",
-  "memoryfree_mb": 529.1796875,
-  "memorysize": "985.54 MiB",
-  "memorysize_mb": 985.54296875,
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -144,9 +124,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.4-RELEASE-p9",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -160,7 +137,6 @@
       "patchlevel": "9"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -182,9 +158,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -194,16 +167,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd11",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.3"
   },
-  "rubyplatform": "amd64-freebsd11",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.3",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -236,11 +204,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ab7c9e209f87f4e8321b13c6481482dda6fa34d9\nSSHFP 4 2 d934ba8e9c55d0794218dc3c8728f1c09bdd407eac8e8df3990e086678f0d131",
   "sshfp_rsa": "SSHFP 1 1 90f05081e454c2f9bc5b81a46c2c1214605481b4\nSSHFP 1 2 6ebeb0740f993885cbf7bb1d0beefde048614ae657f10a60aa8abbb4e11b5a70",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCsFz4abAckdE8cmgMTW7/yptOhJaIi7D/LqAZOhUdbv+xS4ZDICwyhG3z68SPDjEZqqWjj2Vbqujhzas/Ld/MlvMhlbiM8yonPDJ/on+tKHzjLQEb4SM52skdiFiCnDzQhKCgtTVgOZFtGZz7tM6PCvPAmJsedEVP14ueXam/G7m33hyGd8L3eZirGJTnVZDWItKvokqHmSRmC0qAJqd3llqdCPHqsWMrmwJAPgrC3gRXMAhkbM6XshayHa4pZC24PP/lfb4kqBDfLyUzl5hoWXGPpFUXZXZevZNgp7Jk99NqgTAixUpmYrNgo4Fw1Nuy8FdD4UoY7PWgTHTZVetTp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -248,11 +211,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 35,
-  "uuid": "86720522-a1c2-9241-8bf9-db6de84a9d1a",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.2/freebsd-12-x86_64.facts
+++ b/facts/4.2/freebsd-12-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,14 +20,7 @@
       "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.4",
-  "fqdn": "foo.example.com",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -39,7 +28,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "12",
@@ -50,8 +38,6 @@
     "1m": 0.427734375,
     "5m": 0.1083984375
   },
-  "macaddress": "08:00:27:cc:5d:60",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -73,15 +59,9 @@
       "used_bytes": 364797952
     }
   },
-  "memoryfree": "634.64 MiB",
-  "memoryfree_mb": 634.64453125,
-  "memorysize": "982.54 MiB",
-  "memorysize_mb": 982.54296875,
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -144,9 +124,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.2-RELEASE-p6",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -160,7 +137,6 @@
       "patchlevel": "6"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -182,9 +158,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -194,16 +167,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd12",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd12",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -236,11 +204,6 @@
   "sshfp_ed25519": "SSHFP 4 1 aaedcc84b12a9ee5858d1d57396209b5478e4460\nSSHFP 4 2 dd536bc7ec52cb2b42ba56c7fa0e1ca050a476f35fa600a8a09152c0f08bd92c",
   "sshfp_rsa": "SSHFP 1 1 d25c836cfde179592f943b2f0683ec4cb9ea1df6\nSSHFP 1 2 1a3730ad9a5898dcb501c23f8fae567a1c8f8d703924d631bc357af0f1a79f9f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC6BdnKic9BQ4waex+wmaoLHLX2RUXuSVi/ZP9FJz+GrcaZAHsM50dF1zybjgQiKqxMsVBtjntIsYiN1hVXyWHfTNbwpb7mdMlkgZusAIZwTIk1+08oa2U2Btv3D5x/l/sZrliMWHHqH2nFa4W0dwYTmpFugFE/HZDYlnGdU/15BF1jMpr2wMj0xN4KYCmhwQy2J8DKQlbKKNgoKm24ryDYTGyU3X73GkYqMHlucU3sl3d1aQW8unQ7y3F3gOlmyikw6G9inb+LqeZGqlejb6azAm/juyFamE1h3WA3l7O3HIwGdE5QQ82cotkxTlxLMBlxVg8zIwXEqJLTRhy6iWlp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -248,11 +211,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 36,
-  "uuid": "e5fd407e-387d-0c42-bbe7-8dffde8abccb",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.2/freebsd-13-x86_64.facts
+++ b/facts/4.2/freebsd-13-x86_64.facts
@@ -1,8 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -24,15 +20,8 @@
       "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -40,7 +29,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "is_virtual": true,
   "kernel": "FreeBSD",
   "kernelmajversion": "13",
@@ -51,8 +39,6 @@
     "1m": 0.37158203125,
     "5m": 0.31982421875
   },
-  "macaddress": "08:00:27:37:c2:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -74,10 +60,6 @@
       "used_bytes": 361570304
     }
   },
-  "memoryfree": "639.66 MiB",
-  "memoryfree_mb": 639.6640625,
-  "memorysize": "984.48 MiB",
-  "memorysize_mb": 984.484375,
   "mountpoints": {
     "/": {
       "available": "58.49 GiB",
@@ -293,11 +275,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +340,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.0-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -375,7 +352,6 @@
       "minor": "0"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -397,9 +373,6 @@
     }
   },
   "path": "/usr/home/vagrant/vendor/bundler/ruby/2.7/bin:/opt/puppetlabs/puppet/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/root/bin",
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -409,16 +382,11 @@
     ],
     "speed": "3.79 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/2.7",
     "version": "2.7.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/2.7",
-  "rubyversion": "2.7.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -451,11 +419,6 @@
   "sshfp_ed25519": "SSHFP 4 1 882c76c1ba285d186b53bb6e2a6ead8e960cc951\nSSHFP 4 2 fd302981dcc80d537e25eca6399a36a9c7a39d2a0656555e15e5f35bad0d678e",
   "sshfp_rsa": "SSHFP 1 1 a95edf0f08db96e27bcb0fd27428304fb0883037\nSSHFP 1 2 5dc90d4febda1dd40bc062d360bf104d36e482ea81a2bb68f83e140f5d0ac484",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCvTUsmTLlYzmSFQBalEC6yoI2nHsROPn6sUXXOAClXC9jwA52cP/InDscEnK6ubdiY4bivlXfZNJJdjqVWiv3E8wG8M8i7S2g7JcfF7615/L9w5GA7qwneCNUtwhIdwiYptCzxctkftwLmGKfWOZw7alvt7ebzPJjuw7KBKGBxOhG8oDaMmnTWRO2JjuR1bpMxbCj2NCGAe+ZTcwJfqtrVKBGZM2A+/ZqVqMHR5lYCj6lRUyOFKxa0OmkFt9MXAkJra11lqd+LcyI9PdcMom9UicLhv91HXxwuET4IHoUxvusr8L1ZP7iBKjH68kBSdpOhdXoqokOXqzWc/kYAdbdd",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -463,11 +426,6 @@
     "uptime": "0:18 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:18 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1114,
-  "uuid": "dc77188a-5cf2-e84a-9c9b-0cb604ae8808",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.2/gentoo-2-x86_64.facts
+++ b/facts/4.2/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -48,23 +35,16 @@
       "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.14",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,16 +67,7 @@
     "1m": 0.72,
     "5m": 0.35
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -119,10 +88,6 @@
       "used_bytes": 336416768
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3589.09765625,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -292,14 +257,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -378,9 +339,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -406,7 +364,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -442,12 +399,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -462,20 +413,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -508,10 +452,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -519,10 +459,5 @@
     "uptime": "1:12 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:12 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4365,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/opensuse-15-x86_64.facts
+++ b/facts/4.2/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.7",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "149290",
       "version": "6.1.32"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_eth0": "fe80::a00:27ff:fe4d:d2f8",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.72,
     "5m": 0.25
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:4d:d2:f8",
   "macaddress_eth0": "08:00:27:4d:d2:f8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "705.05 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 269987840
     }
   },
-  "memoryfree": "705.05 MiB",
-  "memoryfree_mb": 705.046875,
-  "memorysize": "962.53 MiB",
-  "memorysize_mb": 962.52734375,
   "mountpoints": {
     "/": {
       "available": "37.65 GiB",
@@ -323,14 +292,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -409,9 +374,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +398,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -449,9 +410,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -463,20 +421,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -526,10 +477,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 114,
-  "uuid": "a8ec1623-c9b8-db4e-b101-da7ebea90526",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/oraclelinux-7-x86_64.facts
+++ b/facts/4.2/oraclelinux-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.9.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "eth1": "192.168.56.100",
@@ -51,22 +38,15 @@
       "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "145957",
       "version": "6.1.26"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:fe47:4e7b",
   "ipaddress6_lo": "::1",
@@ -93,13 +71,8 @@
     "1m": 0.52,
     "5m": 0.14
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:47:4e:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -120,10 +93,6 @@
       "used_bytes": 193908736
     }
   },
-  "memoryfree": "302.07 MiB",
-  "memoryfree_mb": 302.0703125,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.53 GiB",
@@ -341,16 +310,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -463,9 +428,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -495,7 +457,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -506,9 +467,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -520,27 +478,15 @@
     "speed": "2.59 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.9.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -573,10 +519,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ae86105117d5c84add050f97f9d1462b3bfc2052\nSSHFP 4 2 a512469b3965893ec5a4e97a0f8ec7a91c801e9529f65c36266329dc780cb802",
   "sshfp_rsa": "SSHFP 1 1 6e38fb13522239c8d538d4e10b11e6f42f0e62d3\nSSHFP 1 2 d0c146d1206a64545ca299357f9e36354b9e857648bf6db005a0ee33cb2a865a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCtfS7WPA7hSK9zPT7rGHXPVD6dDchTWFTKWwTilrC/Fgh2sfpl3sux2ZKqdZwwDvtBPrPV4BLc32+fzM9vKaW2EEu83Z+W/oFJr6VWpLBSjAMQE+iX68YTXObdRJSrG/w2vAaPiXAmljzGp2/d801XzLQpXLkYOvWSVtDfL4Koqy8uy6ZsJ+4BlvSf6vU2L8L2FQENhyZqgWKAggrR5NWz5eNrEY1cr/2ZqtZEVbQMABs/XEo6dBkDe7k38flRWkXXhbZ9y/sSu25ygiMHBmVOkbs+A0IYPkCFyUqPtPpjLR97yoY+r9hbC47bV7pDTF0hyTylVEFq4l6UwEdJFqMF",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -584,10 +526,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 77,
-  "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/oraclelinux-8-x86_64.facts
+++ b/facts/4.2/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.9.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "072c8742-dd4e-724c-908e-b998d8428e48"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "145957",
       "version": "6.1.26"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe27:8b50",
   "ipaddress6_eth0": "fe80::5054:ff:fe27:8b50",
   "ipaddress6_eth1": "fe80::a00:27ff:fef5:a22a",
   "ipaddress6_lo": "::1",
@@ -91,13 +69,8 @@
     "1m": 1.35,
     "5m": 0.36
   },
-  "lsbdistrelease": "8.3.2011",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "3",
-  "macaddress": "52:54:00:27:8b:50",
   "macaddress_eth0": "52:54:00:27:8b:50",
   "macaddress_eth1": "08:00:27:f5:a2:2a",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.98 GiB",
@@ -118,10 +91,6 @@
       "used_bytes": 231673856
     }
   },
-  "memoryfree": "244.27 MiB",
-  "memoryfree_mb": 244.26953125,
-  "memorysize": "465.21 MiB",
-  "memorysize_mb": 465.2109375,
   "mountpoints": {
     "/": {
       "available": "6.36 GiB",
@@ -342,16 +311,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -461,9 +426,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.3.2011",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -492,7 +454,6 @@
       "policy_version": "32"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -504,9 +465,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -518,27 +476,15 @@
     "speed": "2.59 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.9.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "32",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -571,10 +517,6 @@
   "sshfp_ed25519": "SSHFP 4 1 87eca5478bfc9a44fd622cf827b8d18a900d7d6e\nSSHFP 4 2 335e0e9b145ba57c0bb25848855ba9af343aefa47e73ca144432e20d185d0d9f",
   "sshfp_rsa": "SSHFP 1 1 0c5f3e6999ea831aa17d06d3be8b3207a22ba257\nSSHFP 1 2 4602b1a93d6fd23e71fa99ab58cdc2505437505225c4a98b74877fff7ff2b9c2",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9EAuhvc2stGDAXUSFUHA/E1VsEvJJdqLqy4kT5QVOdcjFDeqekbeRPug1E1fhp9x727TV3FUke2HCg0Kl/U6GoAs2w9EDxUpaWQtKJGVEGE+Qid8UVbjIjZSvD1DiqmgijSR9dwYtQma525sXyzqyc9PuA/eQej87yDd2FZOqUeny6Nnnkshe6c97FPW374JBZV0MBIxD8sMIIOgnyBYrmblhMvXdRUv7REm2xhPTveKwNUA9/ldXo3JPyazFHIpMuVX0qEoAxifEeZdUgmTvUa9GB+APmoVAayi7DT1BxTxVHHAJ8O4Ijg/yVDzvt9kTjNoWzo4i6JvDogVOhQjtvnFTAMwsQiCiUUPvy2mssAr6mLgr5veJvwKfnsZsNSflvjFU28b/oOoXoGz8b2p1sbZ0vYWaKh7MVz96ST0xGm6jtkd06/2gIf1ViPDwnAJ+68nLVzNDGOS2ds6TnkCtdILY92tBB9ob47Ye/E6dpkRMt2AXloZLnCO+BrWR1ME=",
-  "swapfree": "1.98 GiB",
-  "swapfree_mb": 2026.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -582,10 +524,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 252,
-  "uuid": "072c8742-dd4e-724c-908e-b998d8428e48",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/oraclelinux-9-x86_64.facts
+++ b/facts/4.2/oraclelinux-9-x86_64.facts
@@ -1,9 +1,4 @@
 {
-  "selinux": false,
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
-  "hostname": "foo",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
@@ -46,8 +41,6 @@
   "filesystems": "iso9660,xfs",
   "fips_enabled": false,
   "gem_version": "~> 4.2.0",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "identity": {
     "gid": 1000,
     "group": "stack",
@@ -55,7 +48,6 @@
     "uid": 1000,
     "user": "stack"
   },
-  "ipaddress": "10.109.1.2",
   "is_virtual": false,
   "kernel": "Linux",
   "kernelmajversion": "5.13",
@@ -189,9 +181,6 @@
     "primary": "ens3",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -218,7 +207,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/vda1": {
       "size": "1.00 MiB",

--- a/facts/4.2/popos-21.10-x86_64.facts
+++ b/facts/4.2/popos-21.10-x86_64.facts
@@ -1,23 +1,8 @@
 {
-  "selinux": false,
   "aio_agent_version": "7.12.1",
   "augeas": {
     "version": "1.12.0"
   },
-  "architecture": "amd64",
-  "augeasversion": "1.12.0",
-  "bios_release_date": "01/25/2021",
-  "bios_vendor": "American Megatrends International, LLC.",
-  "bios_version": "A.C0",
-  "blockdevice_nvme0n1_model": "Samsung SSD 980 PRO 2TB",
-  "blockdevice_nvme0n1_size": 2000398934016,
-  "blockdevices": "nvme0n1",
-  "boardassettag": "To be filled by O.E.M.",
-  "boardmanufacturer": "Micro-Star International Co., Ltd.",
-  "boardproductname": "MPG X570 GAMING PLUS (MS-7C37)",
-  "boardserialnumber": "01234567",
-  "chassisassettag": "To be filled by O.E.M.",
-  "chassistype": "Desktop",
   "disks": {
     "nvme0n1": {
       "model": "Samsung SSD 980 PRO 2TB",
@@ -49,15 +34,9 @@
       "uuid": "70587895-2a8a-7d1a-a956-d8bbc13e1281"
     }
   },
-  "domain": "example.com",
-  "fqdn": "foo.example.com",
   "facterversion": "4.2.5",
   "filesystems": "ext2,ext3,ext4,squashfs,vfat",
   "fips_enabled": false,
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -65,21 +44,11 @@
     "uid": 0,
     "user": "root"
   },
-  "id": "root",
-  "ipaddress": "192.168.0.52",
   "is_virtual": false,
   "kernel": "Linux",
   "kernelmajversion": "5.15",
   "kernelrelease": "5.15.5-76051505-generic",
   "kernelversion": "5.15.5",
-  "lsbdistcodename": "impish",
-  "lsbdistdescription": "Pop!_OS 21.10",
-  "lsbdistid": "Pop",
-  "lsbdistrelease": "21.10",
-  "lsbmajdistrelease": "21.10",
-  "macaddress": "52:54:00:0a:d2:26",
-  "netmask": "255.255.255.0",
-
   "load_averages": {
     "15m": 0.72,
     "1m": 0.51,
@@ -421,11 +390,6 @@
       "enabled": false
     }
   },
-  "operatingsystem": "Pop!_OS",
-  "operatingsystemmajrelease": "21.10",
-  "operatingsystemrelease": "21.10",
-  "osfamily": "Debian",
-
   "partitions": {
     "/dev/mapper/cryptswap": {
       "filesystem": "swap",

--- a/facts/4.2/redhat-7-x86_64.facts
+++ b/facts/4.2/redhat-7-x86_64.facts
@@ -1,20 +1,8 @@
 {
   "aio_agent_version": "7.20.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "04/01/2014",
-  "bios_vendor": "SeaBIOS",
-  "bios_version": "1.14.0-1.el8s",
-  "blockdevice_sda_model": "QEMU HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "QEMU",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Red Hat",
-  "boardproductname": "RHEL-AV",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": ""
   },
@@ -48,16 +36,9 @@
       "uuid": "0F61D142-C291-4770-A0C9-405520784D49"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.13",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -66,8 +47,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.109.1.2",
-  "ipaddress6": "fe80::546f:86ff:fe55:c7",
   "ipaddress6_eth0": "fe80::546f:86ff:fe55:c7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.109.1.2",
@@ -82,12 +61,7 @@
     "1m": 0.05,
     "5m": 0.03
   },
-  "lsbdistrelease": "7.9",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "9",
-  "macaddress": "56:6f:86:55:00:c7",
   "macaddress_eth0": "56:6f:86:55:00:c7",
-  "manufacturer": "oVirt",
   "memory": {
     "swap": {
       "available": "4.00 GiB",
@@ -108,10 +82,6 @@
       "used_bytes": 722239488
     }
   },
-  "memoryfree": "6.96 GiB",
-  "memoryfree_mb": 7130.3671875,
-  "memorysize": "7.64 GiB",
-  "memorysize_mb": 7819.1484375,
   "mountpoints": {
     "/": {
       "available": "33.39 GiB",
@@ -300,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.109.1.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.109.1.0",
@@ -386,9 +352,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -418,7 +381,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_foo-root": {
       "filesystem": "xfs",
@@ -448,10 +410,6 @@
     }
   },
   "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/opt/puppetlabs/bin:/sbin",
-  "physicalprocessorcount": 2,
-  "processor0": "Intel Xeon Processor (Cascadelake)",
-  "processor1": "Intel Xeon Processor (Cascadelake)",
-  "processorcount": 2,
   "processors": {
     "cores": 1,
     "count": 2,
@@ -464,26 +422,14 @@
     "speed": "2.19 GHz",
     "threads": 1
   },
-  "productname": "RHEL",
   "puppetversion": "7.20.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "4c4c4544-005a-3910-804e-b7c04f463033",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -516,10 +462,6 @@
   "sshfp_ed25519": "SSHFP 4 1 a71f8f1e8326d22b4a728b41b4b00069ca8c7aea\nSSHFP 4 2 ca8c4eca5e7db1d094a4bf9e82ebe2e6c54e83a1b690d9f78be23690a3c46095",
   "sshfp_rsa": "SSHFP 1 1 03e0a93ac6d943ec2d7c226776bb41823d99b61f\nSSHFP 1 2 66b19bc00765c5c17e299391715284dd6e9ba1cb80eb33ad2af57a802aae363f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC19Ip7e4AL7p/m/1A3uj4St1jMycFGY3RIj/mDjnU5DmQ14jCLIySsGmSgez+KBwcNiAeHvdUV4eSQs46XvsJ3eXy+pUnS+rYv1udulukWG23lkFf1VpNsx73Z9LtbgqvkVwTp6eafX0kek3CdAQG6P5D7hm1dhUFc2Dhdp8y2vhvSEAUIvXKKEiY5odiUhZQxKSAURjbK+ayci08ZQQtnrkG2sXT+nI2dH1EEoMVMGqS0Zux86V5MHkliqB7ChuUpOFrcBHOS1fnz8CSmTDycTK9rr4hvos40Jk+uksICW2hV+5HnkGjWEuw2bPT4Www76kD1qOCuMeiB43HEr94l",
-  "swapfree": "4.00 GiB",
-  "swapfree_mb": 4095.99609375,
-  "swapsize": "4.00 GiB",
-  "swapsize_mb": 4095.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -527,10 +469,5 @@
     "uptime": "0:34 hours"
   },
   "timezone": "EDT",
-  "uptime": "0:34 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2058,
-  "uuid": "0F61D142-C291-4770-A0C9-405520784D49",
   "virtual": "ovirt"
 }

--- a/facts/4.2/redhat-8-x86_64.facts
+++ b/facts/4.2/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.02,
     "5m": 0.82
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 484192256
     }
   },
-  "memoryfree": "1.27 GiB",
-  "memoryfree_mb": 1304.6015625,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "66.92 GiB",
@@ -334,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -420,9 +385,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -452,7 +414,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -484,10 +445,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -500,26 +457,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -552,10 +497,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -563,10 +504,5 @@
     "uptime": "0:08 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:08 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 517,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/redhat-9-x86_64.facts
+++ b/facts/4.2/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.95,
     "5m": 0.6
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 488714240
     }
   },
-  "memoryfree": "1.45 GiB",
-  "memoryfree_mb": 1489.65234375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.44 GiB",
@@ -385,14 +354,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -471,9 +436,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -503,7 +465,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -535,10 +496,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -551,26 +508,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -603,10 +548,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -614,10 +555,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 433,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/rocky-8-x86_64.facts
+++ b/facts/4.2/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "6.25.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,7 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
@@ -87,12 +66,7 @@
     "1m": 0.53,
     "5m": 0.14
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:0e:f4:43",
   "macaddress_eth0": "08:00:27:0e:f4:43",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.06 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 448069632
     }
   },
-  "memoryfree": "1.36 GiB",
-  "memoryfree_mb": 1389.7890625,
-  "memorysize": "1.77 GiB",
-  "memorysize_mb": 1817.1015625,
   "mountpoints": {
     "/": {
       "available": "67.35 GiB",
@@ -331,10 +301,8 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
   "network_eth0": "10.0.2.0",
   "network_lo": "127.0.0.0",
   "networking": {
@@ -378,9 +346,6 @@
     "network": "10.0.2.0",
     "primary": "eth0"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -410,7 +375,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rl_rocky8-root": {
       "filesystem": "xfs",
@@ -442,10 +406,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.5.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -458,22 +418,11 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.9"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
-  "rubyversion": "2.5.9",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -506,10 +455,6 @@
   "sshfp_ed25519": "SSHFP 4 1 b8839b8751bfb04ec06ea3e98fd999c8763d2a33\nSSHFP 4 2 b512c5ce3e72c8b3020c33e81cd615a9439f354a89e6defc58d5b10e7cbcfeca",
   "sshfp_rsa": "SSHFP 1 1 cd8d4912f84ec6bd32608ea58d2ca0768673cdbe\nSSHFP 1 2 5be1f47956e15951b50119fd92fdf14877ebd20fff1b61982198bc08b59ca4ac",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDKUNpj8dEfGscp8DOcU8562dhk0oojQyLJqS9+oj/zezjKbarVtnNYeviVa+2OgNUl1HGxPhLL9hVvptN+bJI9mqsVadGDuuQQ3eZc0cTylkI5zshmi2oj42Vi/HI8b1Df8WhLLoLNmiyPF89k2KCuLgaO1NTdEG5jd9gA6+60JkdF0vy+DbKhAaDzQ8WcsllGv8kB9UHtPZq3zlojVC0DNoO8uQWftRs/GzTk31O88F4jB6hdoBVWLEfOMfO6IhMwFQ68w9cYD+jbDwf8FfsRQJoRjlw8wgUIaZRWPg9Tsd9QzmUrMocj+p+TruHutYcoxczsvOWbcli73sxsuugMEx6zA+nIkggY4tTyFlYj7fohvbUflxz/9NOaFo9pRm+jbkwYwYlnD8VWRYAMTA36DhIZpuO49RyatGiMRyQ1alWZxDAP7FadF84fJLagLC2SxLwXLGNyohAs9bqgV7m/G21HJmP7UuN8RtwDW5S/9ToL8d8m50Ezm581vv3Rit0=",
-  "swapfree": "2.06 GiB",
-  "swapfree_mb": 2107.99609375,
-  "swapsize": "2.06 GiB",
-  "swapsize_mb": 2107.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -517,10 +462,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 63,
-  "uuid": "c516bc4f-051c-405f-8b90-2a54e35ef6ca",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/rocky-9-x86_64.facts
+++ b/facts/4.2/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.95,
     "5m": 0.59
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 543465472
     }
   },
-  "memoryfree": "7.25 GiB",
-  "memoryfree_mb": 7423.41796875,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.23 GiB",
@@ -441,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -527,9 +492,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -559,7 +521,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -599,10 +560,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -615,26 +572,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -667,10 +612,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -678,10 +619,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 244,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/scientific-7-x86_64.facts
+++ b/facts/4.2/scientific-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.9.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "eth1": "192.168.56.100",
@@ -51,22 +38,15 @@
       "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "145957",
       "version": "6.1.26"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:fe47:4e7b",
   "ipaddress6_lo": "::1",
@@ -93,13 +71,8 @@
     "1m": 0.52,
     "5m": 0.14
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:47:4e:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -120,10 +93,6 @@
       "used_bytes": 193908736
     }
   },
-  "memoryfree": "302.07 MiB",
-  "memoryfree_mb": 302.0703125,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.53 GiB",
@@ -341,16 +310,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -463,9 +428,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Scientific",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -495,7 +457,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -506,9 +467,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -520,27 +478,15 @@
     "speed": "2.59 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.9.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -573,10 +519,6 @@
   "sshfp_ed25519": "SSHFP 4 1 ae86105117d5c84add050f97f9d1462b3bfc2052\nSSHFP 4 2 a512469b3965893ec5a4e97a0f8ec7a91c801e9529f65c36266329dc780cb802",
   "sshfp_rsa": "SSHFP 1 1 6e38fb13522239c8d538d4e10b11e6f42f0e62d3\nSSHFP 1 2 d0c146d1206a64545ca299357f9e36354b9e857648bf6db005a0ee33cb2a865a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCtfS7WPA7hSK9zPT7rGHXPVD6dDchTWFTKWwTilrC/Fgh2sfpl3sux2ZKqdZwwDvtBPrPV4BLc32+fzM9vKaW2EEu83Z+W/oFJr6VWpLBSjAMQE+iX68YTXObdRJSrG/w2vAaPiXAmljzGp2/d801XzLQpXLkYOvWSVtDfL4Koqy8uy6ZsJ+4BlvSf6vU2L8L2FQENhyZqgWKAggrR5NWz5eNrEY1cr/2ZqtZEVbQMABs/XEo6dBkDe7k38flRWkXXhbZ9y/sSu25ygiMHBmVOkbs+A0IYPkCFyUqPtPpjLR97yoY+r9hbC47bV7pDTF0hyTylVEFq4l6UwEdJFqMF",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -584,10 +526,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 77,
-  "uuid": "AC7C38A5-F47A-7845-938B-4F58D3BC70D2",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/sles-12-x86_64.facts
+++ b/facts/4.2/sles-12-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,22 +36,15 @@
       "uuid": "59bfc18a-2cf6-ec44-acc7-f3faee31eede"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "154219",
       "version": "7.0.2"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::216:3eff:fe4b:de6e",
   "ipaddress6_eth0": "fe80::216:3eff:fe4b:de6e",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,12 +67,7 @@
     "1m": 0.09,
     "5m": 0.37
   },
-  "lsbdistrelease": "12.5",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "5",
-  "macaddress": "00:16:3e:4b:de:6e",
   "macaddress_eth0": "00:16:3e:4b:de:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "670.80 MiB",
@@ -106,10 +79,6 @@
       "used_bytes": 321261568
     }
   },
-  "memoryfree": "670.80 MiB",
-  "memoryfree_mb": 670.80078125,
-  "memorysize": "977.18 MiB",
-  "memorysize_mb": 977.1796875,
   "mountpoints": {
     "/": {
       "available": "37.96 GiB",
@@ -270,14 +239,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -356,9 +321,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "SLES",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.5",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -383,7 +345,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -396,9 +357,6 @@
     }
   },
   "path": "/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -410,21 +368,14 @@
     "speed": "2.40 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -474,10 +425,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "CET",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 233,
-  "uuid": "59bfc18a-2cf6-ec44-acc7-f3faee31eede",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/sles-15-x86_64.facts
+++ b/facts/4.2/sles-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.14.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,16 +36,10 @@
       "uuid": "28f5a061-6198-3d44-b145-564db5773d9c"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.7",
   "filesystems": "iso9660,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "149290",
@@ -67,7 +48,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -76,8 +56,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feff:ca7e",
   "ipaddress6_eth0": "fe80::a00:27ff:feff:ca7e",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -92,12 +70,7 @@
     "1m": 0.09,
     "5m": 0.04
   },
-  "lsbdistrelease": "15.2",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "2",
-  "macaddress": "08:00:27:ff:ca:7e",
   "macaddress_eth0": "08:00:27:ff:ca:7e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.84 GiB",
@@ -118,10 +91,6 @@
       "used_bytes": 457871360
     }
   },
-  "memoryfree": "3.41 GiB",
-  "memoryfree_mb": 3490.078125,
-  "memorysize": "3.83 GiB",
-  "memorysize_mb": 3926.73828125,
   "mountpoints": {
     "/": {
       "available": "13.31 GiB",
@@ -285,14 +254,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -371,9 +336,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "SLES",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.2",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -398,7 +360,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/mapper/system-root": {
       "filesystem": "xfs",
@@ -427,9 +388,6 @@
     }
   },
   "path": "/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i9-10910 CPU @ 3.60GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -441,21 +399,14 @@
     "speed": "3.60 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.14.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.5"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.5",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -498,10 +449,6 @@
   "sshfp_ed25519": "SSHFP 4 1 32d84298ffdf09b21b1d8ac2806696a7f5e497bb\nSSHFP 4 2 6dfda2ad46e1832f22602882b489fbf7b41199caa2db4029527dbd644457f270",
   "sshfp_rsa": "SSHFP 1 1 63a6a7e024f8666d678fcb26e22c2419542382b3\nSSHFP 1 2 ee6489cd46228e580f98c05f3d4ac265812d349390db9c0bcf1a478d86266ccf",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDsoGI0wWG4hafPkrv49+cfBhSh4e661pGnQA7XJHas2zmQeAjgh6XbR4WUwhmAtnPlwTgUpFBrdS80Nu1uQCpRb+8ZWaIILlIePTY8xoLaRBhaQBUxKwfmOCUzq+Cn7OEYjf8bXo3sAs+PqjsZd1v7t87EjZiiYYv3mJNaa4CX/YqE0dEgTS2oUYsd2VBNKpCoG2Mul6CdRWTP9Kq7dwzn2edRRqswrXcofzVfgXAzE3dGEjdRX++QXEuBBnSlhvEnlODH2UbeHtMSdZidYkdhOmxSY2JRPzlfWu93dOs8C8TBj0YM5V0hjxXx3sdsU7F+HM93YHkGPQsvldIBbc2pqdoaoYP75rHN9WXYxqXESvnpHiloaxSkyiXdWC9w73NOMboBKgf8Zuwn+HdYfkXOyRTJ0x4R59p87hTGZo7lZ0AgB3nZGHe6belIFPUcbJ//KsZk16GUaeePyNn/AS0CoXYR8+uSLdz40x5Fs+fxJcgtj5DFkt4d73Gt5jrCjyU=",
-  "swapfree": "3.84 GiB",
-  "swapfree_mb": 3927.99609375,
-  "swapsize": "3.84 GiB",
-  "swapsize_mb": 3927.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 4,
@@ -509,10 +456,5 @@
     "uptime": "4:20 hours"
   },
   "timezone": "CET",
-  "uptime": "4:20 hours",
-  "uptime_days": 0,
-  "uptime_hours": 4,
-  "uptime_seconds": 15612,
-  "uuid": "28f5a061-6198-3d44-b145-564db5773d9c",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-18.04-x86_64.facts
+++ b/facts/4.2/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.12.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_enp0s3": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.83,
     "5m": 0.29
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:98:b5:2c:07:4e",
   "macaddress_enp0s3": "02:98:b5:2c:07:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "682.39 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 317214720
     }
   },
-  "memoryfree": "682.39 MiB",
-  "memoryfree_mb": 682.39453125,
-  "memorysize": "984.91 MiB",
-  "memorysize_mb": 984.9140625,
   "mountpoints": {
     "/": {
       "available": "37.21 GiB",
@@ -342,14 +306,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -430,9 +390,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -455,7 +412,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -468,10 +424,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -484,21 +436,14 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.12.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -548,10 +493,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 93,
-  "uuid": "9D852FAC-0D7B-1940-92DF-1D2F91D9E969",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-20.04-x86_64.facts
+++ b/facts/4.2/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.12.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_enp0s3": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.68,
     "5m": 0.21
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.3 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:6b:e6:b4:03:6e",
   "macaddress_enp0s3": "02:6b:e6:b4:03:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "593.53 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 406323200
     }
   },
-  "memoryfree": "593.53 MiB",
-  "memoryfree_mb": 593.52734375,
-  "memorysize": "981.03 MiB",
-  "memorysize_mb": 981.02734375,
   "mountpoints": {
     "/": {
       "available": "37.05 GiB",
@@ -411,14 +375,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -499,9 +459,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -524,7 +481,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -558,10 +514,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -574,21 +526,14 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.12.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -638,10 +583,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 71,
-  "uuid": "ad03b728-d5f1-cb49-b1ed-b6a01d216d54",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-21.04-x86_64.facts
+++ b/facts/4.2/ubuntu-21.04-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_enp0s3": "fe80::d5:9cff:fef7:3ec1",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.9,
     "5m": 0.29
   },
-  "lsbdistcodename": "hirsute",
-  "lsbdistdescription": "Ubuntu 21.04",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.04",
-  "lsbmajdistrelease": "21.04",
-  "macaddress": "02:d5:9c:f7:3e:c1",
   "macaddress_enp0s3": "02:d5:9c:f7:3e:c1",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "626.16 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 362622976
     }
   },
-  "memoryfree": "626.16 MiB",
-  "memoryfree_mb": 626.16015625,
-  "memorysize": "971.98 MiB",
-  "memorysize_mb": 971.984375,
   "mountpoints": {
     "/": {
       "available": "36.85 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -507,9 +467,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.04",
-  "operatingsystemrelease": "21.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -532,7 +489,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -566,10 +522,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -582,20 +534,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -645,10 +590,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 85,
-  "uuid": "91097a23-f59c-1541-ae93-c81f30fcf57b",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-21.10-x86_64.facts
+++ b/facts/4.2/ubuntu-21.10-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.12.0"
   },
-  "augeasversion": "1.12.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.5",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "147628",
       "version": "6.1.28"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_enp0s3": "fe80::7c:78ff:fe8b:f335",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.82,
     "5m": 0.26
   },
-  "lsbdistcodename": "impish",
-  "lsbdistdescription": "Ubuntu 21.10",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "21.10",
-  "lsbmajdistrelease": "21.10",
-  "macaddress": "02:7c:78:8b:f3:35",
   "macaddress_enp0s3": "02:7c:78:8b:f3:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "627.80 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 360140800
     }
   },
-  "memoryfree": "627.80 MiB",
-  "memoryfree_mb": 627.8046875,
-  "memorysize": "971.26 MiB",
-  "memorysize_mb": 971.26171875,
   "mountpoints": {
     "/": {
       "available": "36.62 GiB",
@@ -397,14 +361,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -485,9 +445,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "21.10",
-  "operatingsystemrelease": "21.10",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -510,7 +467,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -544,10 +500,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/2.7.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processor1": "Intel(R) Core(TM) i7-9800X CPU @ 3.80GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -560,20 +512,13 @@
     "speed": "3.79 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/2.7.0",
     "version": "2.7.4"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/2.7.0",
-  "rubyversion": "2.7.4",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -623,10 +568,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 84,
-  "uuid": "62bbce6d-7b70-ec45-bbd1-12da9be38ac0",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-22.04-x86_64.facts
+++ b/facts/4.2/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.21.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.45,
     "5m": 0.58
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "529.76 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 448286720
     }
   },
-  "memoryfree": "529.76 MiB",
-  "memoryfree_mb": 529.7578125,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "36.68 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -507,9 +467,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -532,7 +489,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -566,10 +522,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -582,21 +534,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.21.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -636,10 +581,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 148,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/ubuntu-22.10-x86_64.facts
+++ b/facts/4.2/ubuntu-22.10-x86_64.facts
@@ -1,23 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -59,23 +43,16 @@
       "uuid": "56576925-f091-d649-8dce-cc1066334980"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.2.14",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.2.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "154048",
       "version": "6.1.40"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::31:a8ff:fedc:3a3",
   "ipaddress6_enp0s3": "fe80::31:a8ff:fedc:3a3",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.09,
     "5m": 0.03
   },
-  "lsbdistcodename": "kinetic",
-  "lsbdistdescription": "Ubuntu 22.10",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.10",
-  "lsbmajdistrelease": "22.10",
-  "macaddress": "02:31:a8:dc:03:a3",
   "macaddress_enp0s3": "02:31:a8:dc:03:a3",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "609.88 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 376328192
     }
   },
-  "memoryfree": "609.88 MiB",
-  "memoryfree_mb": 609.8828125,
-  "memorysize": "968.78 MiB",
-  "memorysize_mb": 968.77734375,
   "mountpoints": {
     "/": {
       "available": "36.65 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -507,9 +467,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.10",
-  "operatingsystemrelease": "22.10",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -532,7 +489,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1778.snap",
@@ -566,10 +522,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -582,20 +534,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.0.0",
     "version": "3.0.4"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.0.0",
-  "rubyversion": "3.0.4",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -645,10 +590,5 @@
     "uptime": "0:32 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:32 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1933,
-  "uuid": "56576925-f091-d649-8dce-cc1066334980",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/windows-10-x86_64.facts
+++ b/facts/4.2/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "234E5189-959F-43F3-BE51-A818A18354F7"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::e187:193f:cccc:ea5a",
   "ipaddress6_Ethernet": "fe80::e187:193f:cccc:ea5a",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "00:22:48:01:76:B8",
   "macaddress_Ethernet": "00:22:48:01:76:B8",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.34 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1779286016
     }
   },
-  "memoryfree": "14.34 GiB",
-  "memoryfree_mb": 14686.69140625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,19 +122,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0002-5440-6049-0873-5211-39",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,15 +135,5 @@
     "uptime": "0:23 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:23 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1412,
-  "uuid": "234E5189-959F-43F3-BE51-A818A18354F7",
-  "virtual": "hyperv",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "Professional",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Pro",
-  "windows_release_id": "22H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-11-x86_64.facts
+++ b/facts/4.2/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "60EA0624-6027-4B56-9183-E7E0C312E33C"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::4815:15b:4120:3d16",
   "ipaddress6_Ethernet": "fe80::4815:15b:4120:3d16",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22621",
   "kernelversion": "10.0.22621",
-  "macaddress": "00:0D:3A:0B:AC:E7",
   "macaddress_Ethernet": "00:0D:3A:0B:AC:E7",
-  "manufacturer": "Microsoft Corporation",
   "memory": {
     "system": {
       "available": "13.74 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 2429284352
     }
   },
-  "memoryfree": "13.74 GiB",
-  "memoryfree_mb": 14066.1328125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16382.87890625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,19 +122,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0006-9834-0092-5493-1525-98",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,15 +135,5 @@
     "uptime": "0:30 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:30 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1832,
-  "uuid": "60EA0624-6027-4B56-9183-E7E0C312E33C",
-  "virtual": "hyperv",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "Professional",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Pro",
-  "windows_release_id": "22H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2012 r2-x86_64.facts
+++ b/facts/4.2/windows-2012 r2-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "CAC18F94-DDEC-405A-BDCC-D01BF6CC0CC8"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::380c:6a87:de6f:d6e4",
   "ipaddress6_Ethernet": "fe80::380c:6a87:de6f:d6e4",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
-  "macaddress": "60:45:BD:D2:B8:1A",
   "macaddress_Ethernet": "60:45:BD:D2:B8:1A",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.95 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1126129664
     }
   },
-  "memoryfree": "14.95 GiB",
-  "memoryfree_mb": 15309.58984375,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012 R2",
-  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -131,11 +109,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -146,20 +120,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.18.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0014-6101-1653-5707-7791-62",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -167,13 +134,5 @@
     "uptime": "0:32 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:32 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1969,
-  "uuid": "CAC18F94-DDEC-405A-BDCC-D01BF6CC0CC8",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 R2 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2012-x86_64.facts
+++ b/facts/4.2/windows-2012-x86_64.facts
@@ -1,7 +1,6 @@
 {
   "aio_agent_build": "7.18.0",
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "archive_windir": "C:\\ProgramData\\staging",
   "common_appdata": "C:\\ProgramData",
   "dhcp_servers": {
@@ -16,26 +15,18 @@
       "uuid": "DE64580B-B3E1-4451-AB65-705E12BA082D"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::c2f:2423:856f:d5cf",
   "ipaddress6_Ethernet": "fe80::c2f:2423:856f:d5cf",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_pe": false,
@@ -44,9 +35,7 @@
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
-  "macaddress": "60:45:BD:C1:B9:87",
   "macaddress_Ethernet": "60:45:BD:C1:B9:87",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.57 GiB",
@@ -58,17 +47,9 @@
       "used_bytes": 1535807488
     }
   },
-  "memoryfree": "14.57 GiB",
-  "memoryfree_mb": 14918.890625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -116,9 +97,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012",
-  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,7 +113,6 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin",
   "pe_patch": {
     "blackouts": {
@@ -143,18 +120,23 @@
     "block_patching_on_warnings": "false",
     "blocked": false,
     "blocked_reasons": [
+
     ],
     "last_run": {
     },
     "missing_security_kbs": [
+
     ],
     "missing_update_kbs": [
+
     ],
     "package_update_count": 0,
     "package_updates": [
+
     ],
     "patch_group": "",
     "pinned_packages": [
+
     ],
     "reboot_override": "default",
     "reboots": {
@@ -162,16 +144,14 @@
     },
     "security_package_update_count": 0,
     "security_package_updates": [
+
     ],
     "warnings": {
       "security_update_file": "Security update file not found, update information invalid",
       "update_file": "Update file not found, update information invalid"
     }
   },
-  "physicalprocessorcount": 1,
   "platform_symlink_writable": false,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -182,7 +162,6 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppet_files_dir_present": false,
   "puppet_inventory_metadata": {
     "packages": {
@@ -196,13 +175,7 @@
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0016-0250-3018-1376-8366-89",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -210,13 +183,5 @@
     "uptime": "1:13 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "1:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4436,
-  "uuid": "DE64580B-B3E1-4451-AB65-705E12BA082D",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2016-core-x86_64.facts
+++ b/facts/4.2/windows-2016-core-x86_64.facts
@@ -1,7 +1,6 @@
 {
   "aio_agent_build": "7.18.0",
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "archive_windir": "C:\\ProgramData\\staging",
   "common_appdata": "C:\\ProgramData",
   "dhcp_servers": {
@@ -16,26 +15,18 @@
       "uuid": "062DFF7A-1871-4492-A90D-8F6ADCFCEAE4"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::d0ab:ec73:5f0f:a182",
   "ipaddress6_Ethernet": "fe80::d0ab:ec73:5f0f:a182",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_pe": false,
@@ -44,9 +35,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "00:22:48:43:98:E6",
   "macaddress_Ethernet": "00:22:48:43:98:E6",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.33 GiB",
@@ -58,17 +47,9 @@
       "used_bytes": 1787342848
     }
   },
-  "memoryfree": "14.33 GiB",
-  "memoryfree_mb": 14679.0078125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -116,9 +97,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -136,7 +114,6 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
   "pe_patch": {
     "blackouts": {
@@ -144,18 +121,23 @@
     "block_patching_on_warnings": "false",
     "blocked": false,
     "blocked_reasons": [
+
     ],
     "last_run": {
     },
     "missing_security_kbs": [
+
     ],
     "missing_update_kbs": [
+
     ],
     "package_update_count": 0,
     "package_updates": [
+
     ],
     "patch_group": "",
     "pinned_packages": [
+
     ],
     "reboot_override": "default",
     "reboots": {
@@ -163,16 +145,14 @@
     },
     "security_package_update_count": 0,
     "security_package_updates": [
+
     ],
     "warnings": {
       "security_update_file": "Security update file not found, update information invalid",
       "update_file": "Update file not found, update information invalid"
     }
   },
-  "physicalprocessorcount": 1,
   "platform_symlink_writable": false,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -183,7 +163,6 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppet_files_dir_present": false,
   "puppet_inventory_metadata": {
     "packages": {
@@ -197,13 +176,7 @@
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0000-4452-9283-8040-7164-34",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -211,14 +184,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 543,
-  "uuid": "062DFF7A-1871-4492-A90D-8F6ADCFCEAE4",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2016-x86_64.facts
+++ b/facts/4.2/windows-2016-x86_64.facts
@@ -1,7 +1,6 @@
 {
   "aio_agent_build": "7.18.0",
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "archive_windir": "C:\\ProgramData\\staging",
   "common_appdata": "C:\\ProgramData",
   "dhcp_servers": {
@@ -16,26 +15,18 @@
       "uuid": "AFF8C8FC-AB7F-40C9-A4C8-D4099CE94831"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::1192:25ce:6192:3d25",
   "ipaddress6_Ethernet": "fe80::1192:25ce:6192:3d25",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_pe": false,
@@ -44,9 +35,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "00:22:48:43:1F:54",
   "macaddress_Ethernet": "00:22:48:43:1F:54",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "13.93 GiB",
@@ -58,17 +47,9 @@
       "used_bytes": 2224209920
     }
   },
-  "memoryfree": "13.93 GiB",
-  "memoryfree_mb": 14262.37890625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -116,9 +97,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -136,7 +114,6 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
   "pe_patch": {
     "blackouts": {
@@ -144,18 +121,23 @@
     "block_patching_on_warnings": "false",
     "blocked": false,
     "blocked_reasons": [
+
     ],
     "last_run": {
     },
     "missing_security_kbs": [
+
     ],
     "missing_update_kbs": [
+
     ],
     "package_update_count": 0,
     "package_updates": [
+
     ],
     "patch_group": "",
     "pinned_packages": [
+
     ],
     "reboot_override": "default",
     "reboots": {
@@ -163,16 +145,14 @@
     },
     "security_package_update_count": 0,
     "security_package_updates": [
+
     ],
     "warnings": {
       "security_update_file": "Security update file not found, update information invalid",
       "update_file": "Update file not found, update information invalid"
     }
   },
-  "physicalprocessorcount": 1,
   "platform_symlink_writable": false,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -183,7 +163,6 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppet_files_dir_present": false,
   "puppet_inventory_metadata": {
     "packages": {
@@ -197,13 +176,7 @@
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0012-6801-0573-8396-1888-73",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 2,
@@ -211,14 +184,5 @@
     "uptime": "2:31 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "2:31 hours",
-  "uptime_days": 0,
-  "uptime_hours": 2,
-  "uptime_seconds": 9105,
-  "uuid": "AFF8C8FC-AB7F-40C9-A4C8-D4099CE94831",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2019-core-x86_64.facts
+++ b/facts/4.2/windows-2019-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "F9EFD055-3AAA-4671-839A-AFB0DA1AFF8D"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::25:a9fc:b117:aa17",
   "ipaddress6_Ethernet": "fe80::25:a9fc:b117:aa17",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "60:45:BD:D2:13:E1",
   "macaddress_Ethernet": "60:45:BD:D2:13:E1",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.63 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1471913984
     }
   },
-  "memoryfree": "14.63 GiB",
-  "memoryfree_mb": 14979.82421875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,19 +121,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0018-0098-4249-9352-9380-97",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -167,14 +134,5 @@
     "uptime": "0:17 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:17 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1020,
-  "uuid": "F9EFD055-3AAA-4671-839A-AFB0DA1AFF8D",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Datacenter",
-  "windows_release_id": "1809"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2019-x86_64.facts
+++ b/facts/4.2/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "5F761DEA-CB2C-4ECA-AC50-0E49EEC383FF"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::d239:4bd2:8b25:9c98",
   "ipaddress6_Ethernet": "fe80::d239:4bd2:8b25:9c98",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "60:45:BD:D1:42:F8",
   "macaddress_Ethernet": "60:45:BD:D1:42:F8",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "13.31 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 2882715648
     }
   },
-  "memoryfree": "13.31 GiB",
-  "memoryfree_mb": 13634.37890625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,19 +121,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0006-8787-1837-5123-2426-98",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -167,14 +134,5 @@
     "uptime": "0:46 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:46 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2818,
-  "uuid": "5F761DEA-CB2C-4ECA-AC50-0E49EEC383FF",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2019 Datacenter",
-  "windows_release_id": "1809"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2022-core-x86_64.facts
+++ b/facts/4.2/windows-2022-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "E224D705-36CE-4C7F-9EC3-E03624D29236"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::ee38:234b:cd2:1a92",
   "ipaddress6_Ethernet": "fe80::ee38:234b:cd2:1a92",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "60:45:BD:D2:90:74",
   "macaddress_Ethernet": "60:45:BD:D2:90:74",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.68 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1415028736
     }
   },
-  "memoryfree": "14.68 GiB",
-  "memoryfree_mb": 15034.07421875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,19 +122,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0016-2953-8576-9127-5951-35",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,15 +135,5 @@
     "uptime": "0:30 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:30 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1807,
-  "uuid": "E224D705-36CE-4C7F-9EC3-E03624D29236",
-  "virtual": "hyperv",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Datacenter",
-  "windows_release_id": "21H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.2/windows-2022-x86_64.facts
+++ b/facts/4.2/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.18.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "A3B26E41-B020-4271-8369-044D9E3FC447"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.2.11",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::a86c:fe40:b6b2:1e4",
   "ipaddress6_Ethernet": "fe80::a86c:fe40:b6b2:1e4",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "60:45:BD:C1:54:79",
   "macaddress_Ethernet": "60:45:BD:C1:54:79",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "13.84 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 2313453568
     }
   },
-  "memoryfree": "13.84 GiB",
-  "memoryfree_mb": 14177.26953125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,19 +122,12 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.6"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.6",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0011-7956-1160-2443-5841-13",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,15 +135,5 @@
     "uptime": "0:23 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:23 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1414,
-  "uuid": "A3B26E41-B020-4271-8369-044D9E3FC447",
-  "virtual": "hyperv",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2022 Datacenter",
-  "windows_release_id": "21H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/almalinux-8-x86_64.facts
+++ b/facts/4.3/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 2.13,
     "5m": 1.66
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "596.32 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 371511296
     }
   },
-  "memoryfree": "596.32 MiB",
-  "memoryfree_mb": 596.3203125,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.16 GiB",
@@ -319,14 +288,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -405,9 +370,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -437,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -449,9 +410,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -463,26 +421,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -522,10 +468,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 423,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/almalinux-9-x86_64.facts
+++ b/facts/4.3/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.14,
     "5m": 0.61
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "560.27 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 403681280
     }
   },
-  "memoryfree": "560.27 MiB",
-  "memoryfree_mb": 560.2734375,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.60 GiB",
@@ -412,14 +381,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -498,9 +463,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -530,7 +492,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -567,9 +528,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -581,26 +539,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -640,10 +586,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 168,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/archlinux-x86_64.facts
+++ b/facts/4.3/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,9 +69,7 @@
     "1m": 1.01,
     "5m": 0.38
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -114,10 +90,6 @@
       "used_bytes": 343830528
     }
   },
-  "memoryfree": "637.33 MiB",
-  "memoryfree_mb": 637.328125,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.85 GiB",
@@ -336,14 +308,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -424,7 +392,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -449,7 +416,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -477,10 +443,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,20 +455,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -539,10 +494,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -550,10 +501,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 107,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/centos-7-x86_64.facts
+++ b/facts/4.3/centos-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,22 +38,15 @@
       "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:febc:824c",
   "ipaddress6_lo": "::1",
@@ -93,13 +71,8 @@
     "1m": 1.31,
     "5m": 0.33
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:bc:82:4c",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -120,10 +93,6 @@
       "used_bytes": 181911552
     }
   },
-  "memoryfree": "313.51 MiB",
-  "memoryfree_mb": 313.51171875,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.49 GiB",
@@ -341,16 +310,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -462,9 +427,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -494,7 +456,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -505,9 +466,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -519,27 +477,15 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -572,10 +518,6 @@
   "sshfp_ed25519": "SSHFP 4 1 c7dc9219798ee1d0781307f9f2d928be40f7c56b\nSSHFP 4 2 fc9078b55611fee68a52197cc99a44ead6f43272ffe36fadf7c15fe3571c6644",
   "sshfp_rsa": "SSHFP 1 1 979ee2b3de8a6845741abec79f2a10b4a716545d\nSSHFP 1 2 b6d48705149c9da9d3502fd6e144a8edddf7a6260a4623075231a4a0461637ce",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDNGBlzNJ4Sh8ezy03xB7ogfs9nonlHUNhCvRhKrjmbVg5bQUOOmabmGZ3hfMIIMBrvM0Zw42NUAB2aDzYGDHOTXz3ucxDAXJwXPkUyKSPnSgfVOfC9D3fbJoJOblYu0MrcX2rdgUl7J+zpBuaJ66aP1oCdJ+LU5DksEmBPwJJHYEdnPjA9CrI7COTnsewTTMr9AGQLRSbltiDYLLGSfS4TsvHFCKDFf7mKFzFPxSJKfwZVwvO4FeTjBCt//nkE/B7pmBT6l4DLk1U89nTADoGDTMmfdFWmiZrPj80Aavg8OUtCpc+9DDMCq5VVFErwHBwgn/GBfi7C13cdaXNYXz89",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2044.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -583,10 +525,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 96,
-  "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/centos-8-x86_64.facts
+++ b/facts/4.3/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 2.88,
     "5m": 2.52
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 160059392
     }
   },
-  "memoryfree": "306.13 MiB",
-  "memoryfree_mb": 306.1328125,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.76 GiB",
@@ -308,14 +278,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -394,9 +360,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -423,7 +386,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -435,9 +397,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -449,26 +408,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -501,10 +448,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.71484375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -512,10 +455,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 562,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/centos-9-x86_64.facts
+++ b/facts/4.3/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,11 +66,7 @@
     "1m": 1.25,
     "5m": 0.74
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.99 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 140693504
     }
   },
-  "memoryfree": "323.71 MiB",
-  "memoryfree_mb": 323.70703125,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.80 GiB",
@@ -372,14 +342,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -458,9 +424,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -487,7 +450,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -499,9 +461,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -513,26 +472,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -565,10 +512,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.99 GiB",
-  "swapfree_mb": 2035.9140625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -576,10 +519,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 227,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/debian-11-x86_64.facts
+++ b/facts/4.3/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,15 +38,9 @@
       "uuid": "be037311-7594-41a5-8599-8496211026af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 1.14,
     "5m": 0.61
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "337.12 MiB",
@@ -113,10 +83,6 @@
       "used_bytes": 130064384
     }
   },
-  "memoryfree": "337.12 MiB",
-  "memoryfree_mb": 337.12109375,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "91.21 GiB",
@@ -303,14 +269,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -391,9 +353,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -418,7 +377,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -430,10 +388,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -446,21 +400,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -500,10 +447,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 258,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/debian-12-i386.facts
+++ b/facts/4.3/debian-12-i386.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "i386",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "i386",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.21,
     "5m": 0.08
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.65 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 286068736
     }
   },
-  "memoryfree": "1.65 GiB",
-  "memoryfree_mb": 1694.5234375,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "i386",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "i386-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "i386-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 364,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/debian-12-x86_64.facts
+++ b/facts/4.3/debian-12-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.21,
     "5m": 0.08
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.65 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 286068736
     }
   },
-  "memoryfree": "1.65 GiB",
-  "memoryfree_mb": 1694.5234375,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 364,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-36-x86_64.facts
+++ b/facts/4.3/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.17,
     "5m": 0.59
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 443936768
     }
   },
-  "memoryfree": "1.49 GiB",
-  "memoryfree_mb": 1530.3671875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.97 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -470,10 +432,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -486,25 +444,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -537,10 +483,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -548,10 +490,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 221,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-37-x86_64.facts
+++ b/facts/4.3/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.99,
     "5m": 0.39
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 424747008
     }
   },
-  "memoryfree": "1.51 GiB",
-  "memoryfree_mb": 1548.37890625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.96 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -475,10 +437,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -491,25 +449,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -542,10 +488,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -553,10 +495,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 169,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-38-x86_64.facts
+++ b/facts/4.3/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.14,
     "5m": 0.45
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 322412544
     }
   },
-  "memoryfree": "1.61 GiB",
-  "memoryfree_mb": 1646.515625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -439,14 +409,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -525,9 +491,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -555,7 +518,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -595,9 +557,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -609,25 +568,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -660,10 +607,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -671,10 +614,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 222,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-39-x86_64.facts
+++ b/facts/4.3/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.97,
     "5m": 0.43
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 335577088
     }
   },
-  "memoryfree": "1.60 GiB",
-  "memoryfree_mb": 1633.69921875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.63 GiB",
@@ -362,14 +332,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -448,9 +414,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -478,7 +441,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -518,9 +480,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -532,25 +491,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -583,10 +530,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -594,10 +537,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 170,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/freebsd-13-x86_64.facts
+++ b/facts/4.3/freebsd-13-x86_64.facts
@@ -1,12 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "dmi": {
     "bios": {
       "release_date": "12/01/2006",
@@ -20,15 +15,8 @@
       "uuid": "039c5d1d-7af6-fa45-a633-89a0b93f1213"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -36,7 +24,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "ipaddress6_lo0": "::1",
   "ipaddress_em0": "10.0.2.15",
   "ipaddress_lo0": "127.0.0.1",
@@ -50,8 +37,6 @@
     "1m": 0.39306640625,
     "5m": 0.1279296875
   },
-  "macaddress": "08:00:27:a0:78:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -73,10 +58,6 @@
       "used_bytes": 542416896
     }
   },
-  "memoryfree": "1.45 GiB",
-  "memoryfree_mb": 1489.265625,
-  "memorysize": "1.96 GiB",
-  "memorysize_mb": 2006.5546875,
   "mountpoints": {
     "/": {
       "available": "58.44 GiB",
@@ -292,11 +273,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +339,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.2-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -375,11 +351,7 @@
       "minor": "2"
     }
   },
-  "osfamily": "FreeBSD",
   "path": "/usr/home/vagrant/vendor/bundler/ruby/3.1/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -389,16 +361,11 @@
     ],
     "speed": "3.19 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/3.1",
     "version": "3.1.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.1",
-  "rubyversion": "3.1.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -431,11 +398,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6e7a963faae3ab450b8b26b3cc16e8e9e8698c0d\nSSHFP 4 2 a3edc3fa54b8a129abbb03b9c45346f973b259294eab644b7ae7696a84a7feab",
   "sshfp_rsa": "SSHFP 1 1 a515c1bc994712f2510d5e1e6f367690dd28daab\nSSHFP 1 2 52e894012cee246ff054ebda61f8f0aa49543e964c62c37440ce3979a135a209",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDWWcTfOdwXStChm2iWg4/Ul2asGkmD78IKEClglrxOsOJq9hcMJiTtVNxGWht1bR1+4zoDO+fZfAHdbxvxNTV1wTda85yquMNUxJThiuF4kVlJJrPlxuBtTvGNL3bpQfgWi1fWk7cKLdj8It5BNV4KSWcK3DuG14jhGFx3zesv8fDa1sZRnJZHiNPQoPJ5UWFj36N8urub096lWCHssYQ2vmgGrs4aqnWgh6a0E243VoOhGDKTRgYGzGRI3s+UHUoxcQeqvpQnPLOeT/YU6AZTbbJV6xcTbuWOK9YN1NdAXsp/+kLpDOPwNZdofexB2Hz/yYA4Z8gp8pZaP+4gtjnaNdLBN1g2CljGr6Wv/D/7xgyCAEvkqlWLbvTpcDB5NECAOm7tN0+H/EDC8rmjIjPIatPy/e956wxSXdkbfknOWCUQ9DnMFDbyw91Euof9VCHb/rXiLW04EMceiLdjAaLWsGWCS3rwLLXBHRASWLYPrSD9I3iiKcTa7Bfqhlxa0Bs=",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -443,11 +405,6 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 68,
-  "uuid": "039c5d1d-7af6-fa45-a633-89a0b93f1213",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.3/gentoo-2-x86_64.facts
+++ b/facts/4.3/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -48,23 +35,16 @@
       "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,16 +67,7 @@
     "1m": 0.75,
     "5m": 0.36
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -119,10 +88,6 @@
       "used_bytes": 339718144
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3585.94921875,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -292,14 +257,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -378,9 +339,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -406,7 +364,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -442,12 +399,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -462,20 +413,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -508,10 +452,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -519,10 +459,5 @@
     "uptime": "1:12 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:12 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4371,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/opensuse-15-x86_64.facts
+++ b/facts/4.3/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "bcb1cbe7-a14b-d44b-be13-e5c7b6a148da"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:7c16",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:7c16",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,12 +66,7 @@
     "1m": 0.62,
     "5m": 0.17
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:5f:7c:16",
   "macaddress_eth0": "08:00:27:5f:7c:16",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "685.12 MiB",
@@ -105,10 +78,6 @@
       "used_bytes": 291065856
     }
   },
-  "memoryfree": "685.12 MiB",
-  "memoryfree_mb": 685.1171875,
-  "memorysize": "962.70 MiB",
-  "memorysize_mb": 962.69921875,
   "mountpoints": {
     "/": {
       "available": "37.53 GiB",
@@ -320,14 +289,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +371,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -433,7 +395,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -446,9 +407,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -460,21 +418,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -524,10 +475,5 @@
     "uptime": "0:47 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:47 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2850,
-  "uuid": "bcb1cbe7-a14b-d44b-be13-e5c7b6a148da",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/oraclelinux-8-x86_64.facts
+++ b/facts/4.3/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_eth0": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,16 +69,7 @@
     "1m": 1.13,
     "5m": 0.52
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Oracle Linux Server release 8.9",
-  "lsbdistid": "OracleServer",
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
-  "macaddress": "08:00:27:14:27:05",
   "macaddress_eth0": "08:00:27:14:27:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -121,10 +90,6 @@
       "used_bytes": 521809920
     }
   },
-  "memoryfree": "1.15 GiB",
-  "memoryfree_mb": 1182.55078125,
-  "memorysize": "1.64 GiB",
-  "memorysize_mb": 1680.1875,
   "mountpoints": {
     "/": {
       "available": "57.44 GiB",
@@ -338,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -424,9 +385,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -457,7 +415,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -476,10 +433,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -492,25 +445,13 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -543,10 +484,6 @@
   "sshfp_ed25519": "SSHFP 4 1 de5b1ba064c808e938c843f2791b85d7a9ddd313\nSSHFP 4 2 7b8b8985b248c027edcab5d85d6b88ff91bbae4ef9d41db7e99163400892e85f",
   "sshfp_rsa": "SSHFP 1 1 df37431d9ea1fb5f9d0f7086b7644514e93a786c\nSSHFP 1 2 daa7bdfedd44dfd625c631250213584261c1f2cca2dc4106e67fc6ed69b7d72f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDIWh8Ism8vmAG6N7OkgqLlylyYTLYBoM4LEf3uhLa9g+o9LsUqtmKZxvlqqt37me3suHAkSi2qS6tAFNpvSeFQCzl2UhUL7quELTEtwIYiQH/t826t6yfKUbX8UiCovAKbvs7uf4SNniL9I33IDhCezQphBYweOxmjZ9Hv8xTOWTHMCLDZd/TuBkTodXQmikKx3IpSG+/5InETmuLlr1iqBoFu+T/0WQ+elMlghn1qMgLGYwQUpTX9Ix0dZy5tMsUZdB+OjGRHghPolEVMbKUliXvRrHX2iN1fmUE23Dvn17jzerYAgrxZvJVivCPNkSFramAl5150XslwkxRm+u/bfPD7hX3H8SsbUEy5vNFpuku0b4aInVT1WNAd0Q5he8tG8lOPmr1QDyUtXs8FFB+znzi3z0hPchTQ9KDZIguYHR178wsOezN7lYqhCj41Pz8xoVUUBx9nwMoPRJYIDcuPT7tvtXewvFK7KDkISCmqTuXeP3mf/dFZP4MFIv3Xukc=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2084.47265625,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2086.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -554,10 +491,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 691,
-  "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/oraclelinux-9-x86_64.facts
+++ b/facts/4.3/oraclelinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_eth0": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.92,
     "5m": 0.51
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:9d:8c:b7",
   "macaddress_eth0": "08:00:27:9d:8c:b7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.01 GiB",
@@ -108,10 +81,6 @@
       "used_bytes": 497270784
     }
   },
-  "memoryfree": "1.01 GiB",
-  "memoryfree_mb": 1037.89453125,
-  "memorysize": "1.48 GiB",
-  "memorysize_mb": 1512.12890625,
   "mountpoints": {
     "/": {
       "available": "60.45 GiB",
@@ -371,14 +340,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -457,9 +422,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -489,7 +451,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -501,10 +462,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -517,25 +474,13 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -575,10 +520,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 207,
-  "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/redhat-8-x86_64.facts
+++ b/facts/4.3/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.0,
     "5m": 0.84
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 472653824
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1315.60546875,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "66.95 GiB",
@@ -334,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -420,9 +385,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -452,7 +414,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -484,10 +445,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -500,26 +457,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -552,10 +497,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -563,10 +504,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 558,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/redhat-9-x86_64.facts
+++ b/facts/4.3/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.08,
     "5m": 0.67
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 477302784
     }
   },
-  "memoryfree": "1.47 GiB",
-  "memoryfree_mb": 1500.53515625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.46 GiB",
@@ -385,14 +354,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -471,9 +436,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -503,7 +465,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -535,10 +496,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -551,26 +508,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -603,10 +548,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -614,10 +555,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 468,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/rocky-8-x86_64.facts
+++ b/facts/4.3/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 41943040000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "e12c307e-fd53-d14b-ab4d-c5c560650695"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.65,
     "5m": 0.17
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 501010432
     }
   },
-  "memoryfree": "7.31 GiB",
-  "memoryfree_mb": 7483.4609375,
-  "memorysize": "7.77 GiB",
-  "memorysize_mb": 7961.26171875,
   "mountpoints": {
     "/": {
       "available": "34.91 GiB",
@@ -327,14 +296,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -445,7 +407,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -457,10 +418,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -473,26 +430,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -525,10 +470,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1c579819a7fac24f450aa11e50530be7ec7bca19\nSSHFP 4 2 ff53f053c3e6c42788b0d6946a1201e63763a54a0176d31db25923b52661edb2",
   "sshfp_rsa": "SSHFP 1 1 dcfebf14980d034cf2e4c18f811c7ba2daa403f3\nSSHFP 1 2 ad0008faafe3c8ab16c714a9cdd8dd195ab82994479f279b4c4acb631a6fb66f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDoz4tiN2ezhz14zMw3rRyE0iqlB2k59F2W4IKUBkXfR6JFRknmE3z03noUnoC/TxroeFWoPAizYwaPtOmVSIruKV94tQqg+UnAt42ycYwCg8Yvt38b8l2yAbzIbbS/mFNf+QKOESl5ggjyy4x+sR4ZnDJk+h3y7vrxfv2n448I2h7axFIUaxJpkTVtZ5/p6Dp4dV6M9jULI3RittyqoU5UoGxG1A+JUIbDMPDZU48SppMo3XQL56Wj80ClTnoZxbdRVDS0H6O0iRBRCHwCPqhlLDNwN/yurzs7MTVsIlnqZSI4/doumfmn21tLcX5J5YnGS0DtOnGuf7reiwRxY9iIv3vi4wt/05b5DbYLtUve+409hT2RTp8qRD4FOX0mm297JgUJVAcwSVkFJPdxckDWzBy498Ely1cCyfjHXNBrzNhD9u02m0yXOzyaG8MwQGQy8G8n5FdEA9DO2Ihl9J6Yj/3qEmGD8Yj3hhspiR8o55dOxmOlYpwVClZWGTi9qIM=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -536,10 +477,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 73,
-  "uuid": "e12c307e-fd53-d14b-ab4d-c5c560650695",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/rocky-9-x86_64.facts
+++ b/facts/4.3/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.05,
     "5m": 0.66
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 507969536
     }
   },
-  "memoryfree": "7.28 GiB",
-  "memoryfree_mb": 7457.26953125,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.24 GiB",
@@ -441,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -527,9 +492,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -559,7 +521,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -599,10 +560,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -615,26 +572,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -667,10 +612,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -678,10 +619,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 284,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/sles-12-x86_64.facts
+++ b/facts/4.3/sles-12-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevice_sr0_model": "CD-ROM",
-  "blockdevice_sr0_size": 1073741312,
-  "blockdevice_sr0_vendor": "VBOX",
-  "blockdevices": "sda,sr0",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -59,23 +43,16 @@
       "uuid": "470DA272-E404-453F-8FE6-0A262EDB69AF"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe91:1b4e",
   "ipaddress6_eth0": "fe80::a00:27ff:fe91:1b4e",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -100,12 +75,7 @@
     "1m": 0.02,
     "5m": 0.09
   },
-  "lsbdistrelease": "12.3",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:91:1b:4e",
   "macaddress_eth0": "08:00:27:91:1b:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.45 GiB",
@@ -126,10 +96,6 @@
       "used_bytes": 319827968
     }
   },
-  "memoryfree": "686.96 MiB",
-  "memoryfree_mb": 686.95703125,
-  "memorysize": "991.97 MiB",
-  "memorysize_mb": 991.96875,
   "mountpoints": {
     "/": {
       "available": "94.18 GiB",
@@ -686,14 +652,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -772,9 +734,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "SLES",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -799,7 +758,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -818,9 +776,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/games",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -832,20 +787,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -888,10 +836,6 @@
   "sshfp_ed25519": "SSHFP 4 1 c0768129f2794cdc0bb5d700beb6a4bb8ded721a\nSSHFP 4 2 613f288805cde3e0452d293e932b00540364f8060e12b646d9f48ff20a9c246c",
   "sshfp_rsa": "SSHFP 1 1 f170173649cb43e05e5146c29ecd04c9785557c1\nSSHFP 1 2 060ed5033f2d24b1dcabbed92a4ba08430d30517cc2aa25450a7bfd5d65cc751",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDkvQ2BxWXVBUkc7+y2Ky6VB1+wZoEfE+iD9Vj5daM9lYLY+ZkdPHBW6Id8BEXPL8Fax2hl9EchS+89He0Rql/bUOcavW6wHb5KTX3hRY75wI3z2MHpur4iEObSWP8LnzrOo8kAMhT7IJwdVYqHtXzYfKMltoYnP1xbfWYPwC+bs8piecbO0ix4LIivSLHUJUGNHZVeFxWVe14NOxMH4pY1YF/sTq3ZdeVf4AOPwuHhHr6Dy3UHYQL1Tul0/wFgTN83hKCoAKpanW8UTN0c7p2h46p8Up5XVZtCGKaEgLHJrie/f2nd1mAoeuJpO9jBDjuZzLwWHuuQYvxk6tgKAEYZ",
-  "swapfree": "1.45 GiB",
-  "swapfree_mb": 1487.9140625,
-  "swapsize": "1.45 GiB",
-  "swapsize_mb": 1488.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -899,10 +843,5 @@
     "uptime": "0:17 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:17 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1043,
-  "uuid": "470DA272-E404-453F-8FE6-0A262EDB69AF",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/ubuntu-18.04-x86_64.facts
+++ b/facts/4.3/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "5D8122BB-BD9B-F04F-AA78-E2C6C19722CE"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_enp0s3": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.92,
     "5m": 0.28
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:98:b5:2c:07:4e",
   "macaddress_enp0s3": "02:98:b5:2c:07:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "688.01 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 311328768
     }
   },
-  "memoryfree": "688.01 MiB",
-  "memoryfree_mb": 688.0078125,
-  "memorysize": "984.91 MiB",
-  "memorysize_mb": 984.9140625,
   "mountpoints": {
     "/": {
       "available": "37.18 GiB",
@@ -342,14 +306,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -430,9 +390,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -455,7 +412,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -468,10 +424,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -484,21 +436,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -548,10 +493,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 80,
-  "uuid": "5D8122BB-BD9B-F04F-AA78-E2C6C19722CE",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/ubuntu-20.04-x86_64.facts
+++ b/facts/4.3/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "9b9cb5dd-36ab-a34a-88ce-830812b80f12"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_enp0s3": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.09,
     "5m": 0.4
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.3 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:6b:e6:b4:03:6e",
   "macaddress_enp0s3": "02:6b:e6:b4:03:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "597.66 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 401985536
     }
   },
-  "memoryfree": "597.66 MiB",
-  "memoryfree_mb": 597.6640625,
-  "memorysize": "981.03 MiB",
-  "memorysize_mb": 981.02734375,
   "mountpoints": {
     "/": {
       "available": "36.96 GiB",
@@ -411,14 +375,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -499,9 +459,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -524,7 +481,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -558,10 +514,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -574,21 +526,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -638,10 +583,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 80,
-  "uuid": "9b9cb5dd-36ab-a34a-88ce-830812b80f12",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/ubuntu-22.04-x86_64.facts
+++ b/facts/4.3/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.3.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.3,
     "5m": 0.62
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "551.82 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 425152512
     }
   },
-  "memoryfree": "551.82 MiB",
-  "memoryfree_mb": 551.8203125,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "36.63 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -507,9 +467,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -532,7 +489,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -566,10 +522,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -582,21 +534,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -636,10 +581,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 174,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/windows-10-x86_64.facts
+++ b/facts/4.3/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "08:00:27:85:56:BC",
   "macaddress_Ethernet": "08:00:27:85:56:BC",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.48 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1612689408
     }
   },
-  "memoryfree": "2.48 GiB",
-  "memoryfree_mb": 2541.7109375,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
   "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 103,
-  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
-  "virtual": "virtualbox",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "22H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.3/windows-11-x86_64.facts
+++ b/facts/4.3/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::f72f:511:e1c3:e451",
   "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22631",
   "kernelversion": "10.0.22631",
-  "macaddress": "08:00:27:02:6D:35",
   "macaddress_Ethernet": "08:00:27:02:6D:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.49 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1599533056
     }
   },
-  "memoryfree": "2.49 GiB",
-  "memoryfree_mb": 2554.2578125,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
   "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 112,
-  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
-  "virtual": "virtualbox",
-  "windows_display_version": "23H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "23H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.3/windows-2012 r2-x86_64.facts
+++ b/facts/4.3/windows-2012 r2-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "C086D0F8-C4AC-42A5-8FA6-C37C9145DAAB"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::751a:4f9f:1828:70cf",
   "ipaddress6_Ethernet": "fe80::751a:4f9f:1828:70cf",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
-  "macaddress": "00:0D:3A:7E:EF:DA",
   "macaddress_Ethernet": "00:0D:3A:7E:EF:DA",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.46 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1655439360
     }
   },
-  "memoryfree": "14.46 GiB",
-  "memoryfree_mb": 14804.80078125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012 R2",
-  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -131,11 +109,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Pupet Labs\\Puppet\\bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windowssystem32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Pupet Labs\\Puppet\\bin",
   "processors": {
     "cores": 2,
     "count": 4,
@@ -146,20 +120,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0013-8730-0546-9031-4820-21",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 2,
@@ -167,13 +134,5 @@
     "uptime": "2:25 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "2:25 hours",
-  "uptime_days": 0,
-  "uptime_hours": 2,
-  "uptime_seconds": 8713,
-  "uuid": "C086D0F8-C4AC-42A5-8FA6-C37C9145DAAB",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 R2 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2012-x86_64.facts
+++ b/facts/4.3/windows-2012-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "33A55257-8197-4D55-ACB9-2385F74881FB"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::a0c7:5ddf:bfec:7803",
   "ipaddress6_Ethernet": "fe80::a0c7:5ddf:bfec:7803",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
-  "macaddress": "60:45:BD:D1:22:1D",
   "macaddress_Ethernet": "60:45:BD:D1:22:1D",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.18 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1950035968
     }
   },
-  "memoryfree": "14.18 GiB",
-  "memoryfree_mb": 14523.8515625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012",
-  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -131,11 +109,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -146,20 +120,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0003-7214-7120-2881-3919-57",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 2,
@@ -167,13 +134,5 @@
     "uptime": "2:32 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "2:32 hours",
-  "uptime_days": 0,
-  "uptime_hours": 2,
-  "uptime_seconds": 9132,
-  "uuid": "33A55257-8197-4D55-ACB9-2385F74881FB",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2016-core-x86_64.facts
+++ b/facts/4.3/windows-2016-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "583D300E-FE81-4311-AC88-A211E67DA08B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::9975:9451:9f80:1964",
   "ipaddress6_Ethernet": "fe80::9975:9451:9f80:1964",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "60:45:BD:0F:F0:40",
   "macaddress_Ethernet": "60:45:BD:0F:F0:40",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.63 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1472536576
     }
   },
-  "memoryfree": "14.63 GiB",
-  "memoryfree_mb": 14979.23046875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0006-3582-9108-9874-5679-53",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,14 +135,5 @@
     "uptime": "0:43 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:43 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2590,
-  "uuid": "583D300E-FE81-4311-AC88-A211E67DA08B",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2016-x86_64.facts
+++ b/facts/4.3/windows-2016-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "3FE9CFAE-0264-4E81-B722-29D5F9026CD8"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::8dd6:a4af:1f7d:8c62",
   "ipaddress6_Ethernet": "fe80::8dd6:a4af:1f7d:8c62",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "60:45:BD:F1:D9:88",
   "macaddress_Ethernet": "60:45:BD:F1:D9:88",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "13.83 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 2325680128
     }
   },
-  "memoryfree": "13.83 GiB",
-  "memoryfree_mb": 14165.609375,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps;",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0004-6054-4044-0234-4300-81",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 21,
@@ -168,14 +135,5 @@
     "uptime": "21:17 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "21:17 hours",
-  "uptime_days": 0,
-  "uptime_hours": 21,
-  "uptime_seconds": 76637,
-  "uuid": "3FE9CFAE-0264-4E81-B722-29D5F9026CD8",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2019-core-x86_64.facts
+++ b/facts/4.3/windows-2019-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "2402FAF6-A829-43F0-BC0C-3213AF5918E3"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "c:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::6859:5ae2:a7d7:bdb0",
   "ipaddress6_Ethernet": "fe80::6859:5ae2:a7d7:bdb0",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "60:45:BD:F1:2F:7A",
   "macaddress_Ethernet": "60:45:BD:F1:2F:7A",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.46 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1658195968
     }
   },
-  "memoryfree": "14.46 GiB",
-  "memoryfree_mb": 14802.171875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "c:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;c:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps;",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0002-5949-1227-2609-0024-80",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,14 +135,5 @@
     "uptime": "0:19 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:19 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1199,
-  "uuid": "2402FAF6-A829-43F0-BC0C-3213AF5918E3",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Datacenter",
-  "windows_release_id": "1809"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2019-x86_64.facts
+++ b/facts/4.3/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5156:1072:2404:1e7f",
   "ipaddress6_Ethernet": "fe80::5156:1072:2404:1e7f",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "08:00:27:E5:87:1C",
   "macaddress_Ethernet": "08:00:27:E5:87:1C",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "992.11 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1090084864
     }
   },
-  "memoryfree": "992.11 MiB",
-  "memoryfree_mb": 992.10546875,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -134,11 +112,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -149,19 +123,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -204,7 +172,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
   "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -212,14 +179,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 105,
-  "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052",
-  "virtual": "virtualbox",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Standard Evaluation",
-  "windows_release_id": "1809"
+  "virtual": "virtualbox"
 }

--- a/facts/4.3/windows-2022-core-x86_64.facts
+++ b/facts/4.3/windows-2022-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "BB4DA294-BD58-479E-B47A-F882CBDB4EC3"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::3514:7fe0:14f0:9535",
   "ipaddress6_Ethernet": "fe80::3514:7fe0:14f0:9535",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "00:0D:3A:D5:07:70",
   "macaddress_Ethernet": "00:0D:3A:D5:07:70",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.27 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1858158592
     }
   },
-  "memoryfree": "14.27 GiB",
-  "memoryfree_mb": 14611.47265625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\dotnet\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,20 +122,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0013-4966-2241-8014-7833-90",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 2,
@@ -169,15 +136,5 @@
     "uptime": "2:20 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "2:20 hours",
-  "uptime_days": 0,
-  "uptime_hours": 2,
-  "uptime_seconds": 8403,
-  "uuid": "BB4DA294-BD58-479E-B47A-F882CBDB4EC3",
-  "virtual": "hyperv",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Datacenter",
-  "windows_release_id": "21H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.3/windows-2022-x86_64.facts
+++ b/facts/4.3/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "7.24.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.3.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::8d97:e947:bec7:8686",
   "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "08:00:27:E7:59:F0",
   "macaddress_Ethernet": "08:00:27:E7:59:F0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "939.47 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1145278464
     }
   },
-  "memoryfree": "939.47 MiB",
-  "memoryfree_mb": 939.46875,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "7.24.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
     "version": "2.7.7"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.7.0",
-  "rubyversion": "2.7.7",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
   "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 109,
-  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
-  "virtual": "virtualbox",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Standard Evaluation",
-  "windows_release_id": "21H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.4/almalinux-8-x86_64.facts
+++ b/facts/4.4/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 2.99,
     "5m": 2.29
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "594.71 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 373202944
     }
   },
-  "memoryfree": "594.71 MiB",
-  "memoryfree_mb": 594.70703125,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.12 GiB",
@@ -319,14 +288,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -405,9 +370,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -437,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -449,9 +410,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -463,26 +421,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -522,10 +468,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 595,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/almalinux-9-x86_64.facts
+++ b/facts/4.4/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.25,
     "5m": 0.78
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "565.28 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 398430208
     }
   },
-  "memoryfree": "565.28 MiB",
-  "memoryfree_mb": 565.28125,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.57 GiB",
@@ -412,14 +381,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -498,9 +463,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -530,7 +492,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -567,9 +528,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -581,26 +539,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -640,10 +586,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 261,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/archlinux-x86_64.facts
+++ b/facts/4.4/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,9 +69,7 @@
     "1m": 1.01,
     "5m": 0.38
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -114,10 +90,6 @@
       "used_bytes": 350416896
     }
   },
-  "memoryfree": "631.05 MiB",
-  "memoryfree_mb": 631.046875,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.85 GiB",
@@ -336,14 +308,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -424,7 +392,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -449,7 +416,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -477,10 +443,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,20 +455,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -539,10 +494,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -550,10 +501,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 110,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/centos-7-x86_64.facts
+++ b/facts/4.4/centos-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,22 +38,15 @@
       "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:febc:824c",
   "ipaddress6_lo": "::1",
@@ -93,13 +71,8 @@
     "1m": 1.36,
     "5m": 0.36
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:bc:82:4c",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -120,10 +93,6 @@
       "used_bytes": 182562816
     }
   },
-  "memoryfree": "312.89 MiB",
-  "memoryfree_mb": 312.890625,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.44 GiB",
@@ -341,16 +310,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -462,9 +427,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -494,7 +456,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -505,9 +466,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -519,27 +477,15 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -572,10 +518,6 @@
   "sshfp_ed25519": "SSHFP 4 1 c7dc9219798ee1d0781307f9f2d928be40f7c56b\nSSHFP 4 2 fc9078b55611fee68a52197cc99a44ead6f43272ffe36fadf7c15fe3571c6644",
   "sshfp_rsa": "SSHFP 1 1 979ee2b3de8a6845741abec79f2a10b4a716545d\nSSHFP 1 2 b6d48705149c9da9d3502fd6e144a8edddf7a6260a4623075231a4a0461637ce",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDNGBlzNJ4Sh8ezy03xB7ogfs9nonlHUNhCvRhKrjmbVg5bQUOOmabmGZ3hfMIIMBrvM0Zw42NUAB2aDzYGDHOTXz3ucxDAXJwXPkUyKSPnSgfVOfC9D3fbJoJOblYu0MrcX2rdgUl7J+zpBuaJ66aP1oCdJ+LU5DksEmBPwJJHYEdnPjA9CrI7COTnsewTTMr9AGQLRSbltiDYLLGSfS4TsvHFCKDFf7mKFzFPxSJKfwZVwvO4FeTjBCt//nkE/B7pmBT6l4DLk1U89nTADoGDTMmfdFWmiZrPj80Aavg8OUtCpc+9DDMCq5VVFErwHBwgn/GBfi7C13cdaXNYXz89",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2044.23828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -583,10 +525,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 102,
-  "uuid": "A70AA05D-10BE-D94D-BA8C-BF0A9519011A",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/centos-8-x86_64.facts
+++ b/facts/4.4/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 2.91,
     "5m": 2.61
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 159924224
     }
   },
-  "memoryfree": "306.26 MiB",
-  "memoryfree_mb": 306.26171875,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.74 GiB",
@@ -308,14 +278,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -394,9 +360,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -423,7 +386,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -435,9 +397,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -449,26 +408,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -501,10 +448,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.21484375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -512,10 +455,5 @@
     "uptime": "0:13 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 794,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/centos-9-x86_64.facts
+++ b/facts/4.4/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,11 +66,7 @@
     "1m": 1.04,
     "5m": 0.83
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.99 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 139210752
     }
   },
-  "memoryfree": "325.12 MiB",
-  "memoryfree_mb": 325.12109375,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.78 GiB",
@@ -372,14 +342,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -458,9 +424,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -487,7 +450,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -499,9 +461,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -513,26 +472,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -565,10 +512,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.99 GiB",
-  "swapfree_mb": 2032.6640625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -576,10 +519,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 340,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/debian-11-x86_64.facts
+++ b/facts/4.4/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,15 +38,9 @@
       "uuid": "be037311-7594-41a5-8599-8496211026af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 1.0,
     "5m": 0.76
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "336.49 MiB",
@@ -113,10 +83,6 @@
       "used_bytes": 130723840
     }
   },
-  "memoryfree": "336.49 MiB",
-  "memoryfree_mb": 336.4921875,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "90.89 GiB",
@@ -303,14 +269,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -391,9 +353,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -418,7 +377,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -430,10 +388,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -446,21 +400,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -500,10 +447,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 377,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/debian-12-i386.facts
+++ b/facts/4.4/debian-12-i386.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "i386",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "i386",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.27,
     "5m": 0.09
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.63 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 311902208
     }
   },
-  "memoryfree": "1.63 GiB",
-  "memoryfree_mb": 1669.88671875,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "i386",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "i386-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "i386-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 365,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/debian-12-x86_64.facts
+++ b/facts/4.4/debian-12-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,16 +37,10 @@
       "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:4b64",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.27,
     "5m": 0.09
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.0",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "0",
-  "macaddress": "08:00:27:ae:4b:64",
   "macaddress_eth0": "08:00:27:ae:4b:64",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.63 GiB",
@@ -113,10 +83,6 @@
       "used_bytes": 311902208
     }
   },
-  "memoryfree": "1.63 GiB",
-  "memoryfree_mb": 1669.88671875,
-  "memorysize": "1.92 GiB",
-  "memorysize_mb": 1967.33984375,
   "mountpoints": {
     "/": {
       "available": "16.64 GiB",
@@ -387,14 +353,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -475,9 +437,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.0",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -502,7 +461,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -515,10 +473,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processor1": "11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -531,20 +485,13 @@
     "speed": "2.50 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux-gnu",
     "sitedir": "/usr/local/lib/site_ruby/3.1.0",
     "version": "3.1.2"
   },
-  "rubyplatform": "x86_64-linux-gnu",
-  "rubysitedir": "/usr/local/lib/site_ruby/3.1.0",
-  "rubyversion": "3.1.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -584,10 +531,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "-03",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 365,
-  "uuid": "6a57baa9-2d03-3041-bb98-60cbaa066b2e",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-36-x86_64.facts
+++ b/facts/4.4/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.14,
     "5m": 0.6
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 444788736
     }
   },
-  "memoryfree": "1.49 GiB",
-  "memoryfree_mb": 1529.5546875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.95 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -470,10 +432,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -486,25 +444,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -537,10 +483,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -548,10 +490,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 231,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-37-x86_64.facts
+++ b/facts/4.4/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.99,
     "5m": 0.4
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 428437504
     }
   },
-  "memoryfree": "1.51 GiB",
-  "memoryfree_mb": 1544.859375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.94 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -406,9 +372,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -436,7 +399,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -475,10 +437,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -491,25 +449,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -542,10 +488,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -553,10 +495,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 173,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-38-x86_64.facts
+++ b/facts/4.4/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.13,
     "5m": 0.46
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 322179072
     }
   },
-  "memoryfree": "1.61 GiB",
-  "memoryfree_mb": 1646.73828125,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -439,14 +409,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -525,9 +491,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -555,7 +518,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -595,9 +557,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -609,25 +568,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -660,10 +607,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -671,10 +614,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 228,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-39-x86_64.facts
+++ b/facts/4.4/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.97,
     "5m": 0.43
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 336392192
     }
   },
-  "memoryfree": "1.59 GiB",
-  "memoryfree_mb": 1632.921875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.63 GiB",
@@ -362,14 +332,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -448,9 +414,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -478,7 +441,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -518,9 +480,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -532,25 +491,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -583,10 +530,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -594,10 +537,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 173,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/freebsd-13-x86_64.facts
+++ b/facts/4.4/freebsd-13-x86_64.facts
@@ -1,12 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "disks": {
     "ada0": {
       "model": "VBOX HARDDISK",
@@ -28,13 +23,7 @@
       "uuid": "b1f06e4d-a71b-3d4b-b127-5e38134691d2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
-  "fqdn": "foo.example.com",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "ipaddress": "10.0.2.15",
   "ipaddress6_lo0": "::1",
   "ipaddress_em0": "10.0.2.15",
   "ipaddress_lo0": "127.0.0.1",
@@ -48,8 +37,6 @@
     "1m": 0.64599609375,
     "5m": 0.1689453125
   },
-  "macaddress": "08:00:27:37:c2:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -71,10 +58,6 @@
       "used_bytes": 364011520
     }
   },
-  "memoryfree": "637.34 MiB",
-  "memoryfree_mb": 637.3359375,
-  "memorysize": "984.48 MiB",
-  "memorysize_mb": 984.484375,
   "mountpoints": {
     "/": {
       "available": "58.50 GiB",
@@ -290,11 +273,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -358,9 +339,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.0-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -373,7 +351,6 @@
       "minor": "0"
     }
   },
-  "osfamily": "FreeBSD",
   "partitions": {
     "ada0p1": {
       "partlabel": "gptboot0",
@@ -395,9 +372,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -407,16 +381,11 @@
     ],
     "speed": "3.19 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/3.1",
     "version": "3.1.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.1",
-  "rubyversion": "3.1.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -449,11 +418,6 @@
   "sshfp_ed25519": "SSHFP 4 1 882c76c1ba285d186b53bb6e2a6ead8e960cc951\nSSHFP 4 2 fd302981dcc80d537e25eca6399a36a9c7a39d2a0656555e15e5f35bad0d678e",
   "sshfp_rsa": "SSHFP 1 1 a95edf0f08db96e27bcb0fd27428304fb0883037\nSSHFP 1 2 5dc90d4febda1dd40bc062d360bf104d36e482ea81a2bb68f83e140f5d0ac484",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCvTUsmTLlYzmSFQBalEC6yoI2nHsROPn6sUXXOAClXC9jwA52cP/InDscEnK6ubdiY4bivlXfZNJJdjqVWiv3E8wG8M8i7S2g7JcfF7615/L9w5GA7qwneCNUtwhIdwiYptCzxctkftwLmGKfWOZw7alvt7ebzPJjuw7KBKGBxOhG8oDaMmnTWRO2JjuR1bpMxbCj2NCGAe+ZTcwJfqtrVKBGZM2A+/ZqVqMHR5lYCj6lRUyOFKxa0OmkFt9MXAkJra11lqd+LcyI9PdcMom9UicLhv91HXxwuET4IHoUxvusr8L1ZP7iBKjH68kBSdpOhdXoqokOXqzWc/kYAdbdd",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -461,11 +425,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 48,
-  "uuid": "b1f06e4d-a71b-3d4b-b127-5e38134691d2",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.4/gentoo-2-x86_64.facts
+++ b/facts/4.4/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -48,23 +35,16 @@
       "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.3",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.3",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,16 +67,7 @@
     "1m": 0.78,
     "5m": 0.38
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -119,10 +88,6 @@
       "used_bytes": 339247104
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3586.3984375,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -292,14 +257,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -378,9 +339,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -406,7 +364,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -442,12 +399,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -462,20 +413,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -508,10 +452,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -519,10 +459,5 @@
     "uptime": "1:12 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:12 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4378,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/opensuse-15-x86_64.facts
+++ b/facts/4.4/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "bcb1cbe7-a14b-d44b-be13-e5c7b6a148da"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:7c16",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:7c16",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,12 +66,7 @@
     "1m": 0.25,
     "5m": 0.06
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:5f:7c:16",
   "macaddress_eth0": "08:00:27:5f:7c:16",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "708.86 MiB",
@@ -105,10 +78,6 @@
       "used_bytes": 266174464
     }
   },
-  "memoryfree": "708.86 MiB",
-  "memoryfree_mb": 708.85546875,
-  "memorysize": "962.70 MiB",
-  "memorysize_mb": 962.69921875,
   "mountpoints": {
     "/": {
       "available": "37.47 GiB",
@@ -301,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -387,9 +352,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -414,7 +376,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -427,9 +388,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -441,21 +399,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -505,10 +456,5 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 52,
-  "uuid": "bcb1cbe7-a14b-d44b-be13-e5c7b6a148da",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/oraclelinux-8-x86_64.facts
+++ b/facts/4.4/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_eth0": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,16 +68,7 @@
     "1m": 1.06,
     "5m": 0.48
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Oracle Linux Server release 8.9",
-  "lsbdistid": "OracleServer",
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
-  "macaddress": "08:00:27:14:27:05",
   "macaddress_eth0": "08:00:27:14:27:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -120,10 +89,6 @@
       "used_bytes": 530542592
     }
   },
-  "memoryfree": "1.15 GiB",
-  "memoryfree_mb": 1174.22265625,
-  "memorysize": "1.64 GiB",
-  "memorysize_mb": 1680.1875,
   "mountpoints": {
     "/": {
       "available": "57.45 GiB",
@@ -337,14 +302,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -423,9 +384,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -456,7 +414,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -475,10 +432,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -491,26 +444,14 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -543,10 +484,6 @@
   "sshfp_ed25519": "SSHFP 4 1 de5b1ba064c808e938c843f2791b85d7a9ddd313\nSSHFP 4 2 7b8b8985b248c027edcab5d85d6b88ff91bbae4ef9d41db7e99163400892e85f",
   "sshfp_rsa": "SSHFP 1 1 df37431d9ea1fb5f9d0f7086b7644514e93a786c\nSSHFP 1 2 daa7bdfedd44dfd625c631250213584261c1f2cca2dc4106e67fc6ed69b7d72f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDIWh8Ism8vmAG6N7OkgqLlylyYTLYBoM4LEf3uhLa9g+o9LsUqtmKZxvlqqt37me3suHAkSi2qS6tAFNpvSeFQCzl2UhUL7quELTEtwIYiQH/t826t6yfKUbX8UiCovAKbvs7uf4SNniL9I33IDhCezQphBYweOxmjZ9Hv8xTOWTHMCLDZd/TuBkTodXQmikKx3IpSG+/5InETmuLlr1iqBoFu+T/0WQ+elMlghn1qMgLGYwQUpTX9Ix0dZy5tMsUZdB+OjGRHghPolEVMbKUliXvRrHX2iN1fmUE23Dvn17jzerYAgrxZvJVivCPNkSFramAl5150XslwkxRm+u/bfPD7hX3H8SsbUEy5vNFpuku0b4aInVT1WNAd0Q5he8tG8lOPmr1QDyUtXs8FFB+znzi3z0hPchTQ9KDZIguYHR178wsOezN7lYqhCj41Pz8xoVUUBx9nwMoPRJYIDcuPT7tvtXewvFK7KDkISCmqTuXeP3mf/dFZP4MFIv3Xukc=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2084.47265625,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2086.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -554,10 +491,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 681,
-  "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/oraclelinux-9-x86_64.facts
+++ b/facts/4.4/oraclelinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_eth0": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.99,
     "5m": 0.5
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:9d:8c:b7",
   "macaddress_eth0": "08:00:27:9d:8c:b7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "991.21 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 546222080
     }
   },
-  "memoryfree": "991.21 MiB",
-  "memoryfree_mb": 991.2109375,
-  "memorysize": "1.48 GiB",
-  "memorysize_mb": 1512.12890625,
   "mountpoints": {
     "/": {
       "available": "60.47 GiB",
@@ -370,14 +339,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -456,9 +421,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -488,7 +450,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -500,10 +461,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -516,26 +473,14 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -575,10 +520,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 186,
-  "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/redhat-8-x86_64.facts
+++ b/facts/4.4/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.22,
     "5m": 1.01
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 479023104
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1309.53125,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "67.01 GiB",
@@ -334,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -420,9 +385,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -452,7 +414,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -484,10 +445,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -500,26 +457,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -552,10 +497,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -563,10 +504,5 @@
     "uptime": "0:12 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:12 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 731,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/redhat-9-x86_64.facts
+++ b/facts/4.4/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.93,
     "5m": 0.75
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 481652736
     }
   },
-  "memoryfree": "1.46 GiB",
-  "memoryfree_mb": 1496.38671875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.44 GiB",
@@ -385,14 +354,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -471,9 +436,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -503,7 +465,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -535,10 +496,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -551,26 +508,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -603,10 +548,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -614,10 +555,5 @@
     "uptime": "0:10 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:10 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 623,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/rocky-8-x86_64.facts
+++ b/facts/4.4/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 41943040000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "e12c307e-fd53-d14b-ab4d-c5c560650695"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.76,
     "5m": 0.2
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 496730112
     }
   },
-  "memoryfree": "7.31 GiB",
-  "memoryfree_mb": 7487.54296875,
-  "memorysize": "7.77 GiB",
-  "memorysize_mb": 7961.26171875,
   "mountpoints": {
     "/": {
       "available": "34.88 GiB",
@@ -327,14 +296,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -445,7 +407,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -457,10 +418,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -473,26 +430,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -525,10 +470,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1c579819a7fac24f450aa11e50530be7ec7bca19\nSSHFP 4 2 ff53f053c3e6c42788b0d6946a1201e63763a54a0176d31db25923b52661edb2",
   "sshfp_rsa": "SSHFP 1 1 dcfebf14980d034cf2e4c18f811c7ba2daa403f3\nSSHFP 1 2 ad0008faafe3c8ab16c714a9cdd8dd195ab82994479f279b4c4acb631a6fb66f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDoz4tiN2ezhz14zMw3rRyE0iqlB2k59F2W4IKUBkXfR6JFRknmE3z03noUnoC/TxroeFWoPAizYwaPtOmVSIruKV94tQqg+UnAt42ycYwCg8Yvt38b8l2yAbzIbbS/mFNf+QKOESl5ggjyy4x+sR4ZnDJk+h3y7vrxfv2n448I2h7axFIUaxJpkTVtZ5/p6Dp4dV6M9jULI3RittyqoU5UoGxG1A+JUIbDMPDZU48SppMo3XQL56Wj80ClTnoZxbdRVDS0H6O0iRBRCHwCPqhlLDNwN/yurzs7MTVsIlnqZSI4/doumfmn21tLcX5J5YnGS0DtOnGuf7reiwRxY9iIv3vi4wt/05b5DbYLtUve+409hT2RTp8qRD4FOX0mm297JgUJVAcwSVkFJPdxckDWzBy498Ely1cCyfjHXNBrzNhD9u02m0yXOzyaG8MwQGQy8G8n5FdEA9DO2Ihl9J6Yj/3qEmGD8Yj3hhspiR8o55dOxmOlYpwVClZWGTi9qIM=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -536,10 +477,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 78,
-  "uuid": "e12c307e-fd53-d14b-ab4d-c5c560650695",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/rocky-9-x86_64.facts
+++ b/facts/4.4/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.11,
     "5m": 0.86
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 529211392
     }
   },
-  "memoryfree": "7.26 GiB",
-  "memoryfree_mb": 7437.01171875,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.22 GiB",
@@ -441,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -527,9 +492,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -559,7 +521,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -599,10 +560,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -615,26 +572,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -667,10 +612,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -678,10 +619,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 470,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/sles-12-x86_64.facts
+++ b/facts/4.4/sles-12-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevice_sr0_model": "CD-ROM",
-  "blockdevice_sr0_size": 1073741312,
-  "blockdevice_sr0_vendor": "VBOX",
-  "blockdevices": "sda,sr0",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -59,23 +43,16 @@
       "uuid": "470DA272-E404-453F-8FE6-0A262EDB69AF"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "btrfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.4.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe91:1b4e",
   "ipaddress6_eth0": "fe80::a00:27ff:fe91:1b4e",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -100,12 +75,7 @@
     "1m": 0.02,
     "5m": 0.09
   },
-  "lsbdistrelease": "12.3",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:91:1b:4e",
   "macaddress_eth0": "08:00:27:91:1b:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.45 GiB",
@@ -126,10 +96,6 @@
       "used_bytes": 320135168
     }
   },
-  "memoryfree": "686.66 MiB",
-  "memoryfree_mb": 686.6640625,
-  "memorysize": "991.97 MiB",
-  "memorysize_mb": 991.96875,
   "mountpoints": {
     "/": {
       "available": "94.18 GiB",
@@ -686,14 +652,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -772,9 +734,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "SLES",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -799,7 +758,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -818,9 +776,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/games",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -832,20 +787,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -888,10 +836,6 @@
   "sshfp_ed25519": "SSHFP 4 1 c0768129f2794cdc0bb5d700beb6a4bb8ded721a\nSSHFP 4 2 613f288805cde3e0452d293e932b00540364f8060e12b646d9f48ff20a9c246c",
   "sshfp_rsa": "SSHFP 1 1 f170173649cb43e05e5146c29ecd04c9785557c1\nSSHFP 1 2 060ed5033f2d24b1dcabbed92a4ba08430d30517cc2aa25450a7bfd5d65cc751",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDkvQ2BxWXVBUkc7+y2Ky6VB1+wZoEfE+iD9Vj5daM9lYLY+ZkdPHBW6Id8BEXPL8Fax2hl9EchS+89He0Rql/bUOcavW6wHb5KTX3hRY75wI3z2MHpur4iEObSWP8LnzrOo8kAMhT7IJwdVYqHtXzYfKMltoYnP1xbfWYPwC+bs8piecbO0ix4LIivSLHUJUGNHZVeFxWVe14NOxMH4pY1YF/sTq3ZdeVf4AOPwuHhHr6Dy3UHYQL1Tul0/wFgTN83hKCoAKpanW8UTN0c7p2h46p8Up5XVZtCGKaEgLHJrie/f2nd1mAoeuJpO9jBDjuZzLwWHuuQYvxk6tgKAEYZ",
-  "swapfree": "1.45 GiB",
-  "swapfree_mb": 1487.9140625,
-  "swapsize": "1.45 GiB",
-  "swapsize_mb": 1488.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -899,10 +843,5 @@
     "uptime": "0:17 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:17 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 1044,
-  "uuid": "470DA272-E404-453F-8FE6-0A262EDB69AF",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/ubuntu-18.04-x86_64.facts
+++ b/facts/4.4/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "5D8122BB-BD9B-F04F-AA78-E2C6C19722CE"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_enp0s3": "fe80::98:b5ff:fe2c:74e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 0.93,
     "5m": 0.31
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:98:b5:2c:07:4e",
   "macaddress_enp0s3": "02:98:b5:2c:07:4e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "688.35 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 310972416
     }
   },
-  "memoryfree": "688.35 MiB",
-  "memoryfree_mb": 688.34765625,
-  "memorysize": "984.91 MiB",
-  "memorysize_mb": 984.9140625,
   "mountpoints": {
     "/": {
       "available": "37.13 GiB",
@@ -342,14 +306,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -430,9 +390,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -455,7 +412,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -468,10 +424,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -484,21 +436,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -548,10 +493,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 90,
-  "uuid": "5D8122BB-BD9B-F04F-AA78-E2C6C19722CE",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/ubuntu-20.04-x86_64.facts
+++ b/facts/4.4/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "9b9cb5dd-36ab-a34a-88ce-830812b80f12"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "156814",
       "version": "6.1.44"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_enp0s3": "fe80::6b:e6ff:feb4:36e",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.07,
     "5m": 0.43
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.3 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:6b:e6:b4:03:6e",
   "macaddress_enp0s3": "02:6b:e6:b4:03:6e",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "598.86 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 400736256
     }
   },
-  "memoryfree": "598.86 MiB",
-  "memoryfree_mb": 598.85546875,
-  "memorysize": "981.03 MiB",
-  "memorysize_mb": 981.02734375,
   "mountpoints": {
     "/": {
       "available": "36.91 GiB",
@@ -411,14 +375,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -499,9 +459,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -524,7 +481,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_1169.snap",
@@ -558,10 +514,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -574,21 +526,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -638,10 +583,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 95,
-  "uuid": "9b9cb5dd-36ab-a34a-88ce-830812b80f12",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/ubuntu-22.04-x86_64.facts
+++ b/facts/4.4/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.2.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.4.2",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.17,
     "5m": 0.81
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "557.35 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 419356672
     }
   },
-  "memoryfree": "557.35 MiB",
-  "memoryfree_mb": 557.34765625,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "36.31 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -507,9 +467,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -532,7 +489,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -566,10 +522,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -582,21 +534,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.2.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -636,10 +581,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 301,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/windows-10-x86_64.facts
+++ b/facts/4.4/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "08:00:27:85:56:BC",
   "macaddress_Ethernet": "08:00:27:85:56:BC",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.40 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1700548608
     }
   },
-  "memoryfree": "2.40 GiB",
-  "memoryfree_mb": 2457.921875,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
   "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 213,
-  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
-  "virtual": "virtualbox",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "22H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.4/windows-11-x86_64.facts
+++ b/facts/4.4/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::f72f:511:e1c3:e451",
   "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22631",
   "kernelversion": "10.0.22631",
-  "macaddress": "08:00:27:02:6D:35",
   "macaddress_Ethernet": "08:00:27:02:6D:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.41 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1694912512
     }
   },
-  "memoryfree": "2.41 GiB",
-  "memoryfree_mb": 2463.296875,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
   "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 213,
-  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
-  "virtual": "virtualbox",
-  "windows_display_version": "23H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "23H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.4/windows-2012 r2-x86_64.facts
+++ b/facts/4.4/windows-2012 r2-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "C086D0F8-C4AC-42A5-8FA6-C37C9145DAAB"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::751a:4f9f:1828:70cf",
   "ipaddress6_Ethernet": "fe80::751a:4f9f:1828:70cf",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
-  "macaddress": "00:0D:3A:7E:EF:DA",
   "macaddress_Ethernet": "00:0D:3A:7E:EF:DA",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.46 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1652686848
     }
   },
-  "memoryfree": "14.46 GiB",
-  "memoryfree_mb": 14807.42578125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012 R2",
-  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -131,11 +109,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -146,20 +120,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0013-8730-0546-9031-4820-21",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 2,
@@ -167,13 +134,5 @@
     "uptime": "2:31 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "2:31 hours",
-  "uptime_days": 0,
-  "uptime_hours": 2,
-  "uptime_seconds": 9097,
-  "uuid": "C086D0F8-C4AC-42A5-8FA6-C37C9145DAAB",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 R2 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2012-x86_64.facts
+++ b/facts/4.4/windows-2012-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "33A55257-8197-4D55-ACB9-2385F74881FB"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::a0c7:5ddf:bfec:7803",
   "ipaddress6_Ethernet": "fe80::a0c7:5ddf:bfec:7803",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
-  "macaddress": "60:45:BD:D1:22:1D",
   "macaddress_Ethernet": "60:45:BD:D1:22:1D",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.23 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1898233856
     }
   },
-  "memoryfree": "14.23 GiB",
-  "memoryfree_mb": 14573.25390625,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2012",
-  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -131,11 +109,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -146,20 +120,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0003-7214-7120-2881-3919-57",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 3,
@@ -167,13 +134,5 @@
     "uptime": "3:14 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "3:14 hours",
-  "uptime_days": 0,
-  "uptime_hours": 3,
-  "uptime_seconds": 11662,
-  "uuid": "33A55257-8197-4D55-ACB9-2385F74881FB",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2012 Datacenter"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2016-core-x86_64.facts
+++ b/facts/4.4/windows-2016-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "583D300E-FE81-4311-AC88-A211E67DA08B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.5",
-  "ipaddress6": "fe80::9975:9451:9f80:1964",
   "ipaddress6_Ethernet": "fe80::9975:9451:9f80:1964",
   "ipaddress_Ethernet": "10.138.1.5",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "60:45:BD:0F:F0:40",
   "macaddress_Ethernet": "60:45:BD:0F:F0:40",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.47 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1639157760
     }
   },
-  "memoryfree": "14.47 GiB",
-  "memoryfree_mb": 14820.328125,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0006-3582-9108-9874-5679-53",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 3,
@@ -168,14 +135,5 @@
     "uptime": "3:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "3:29 hours",
-  "uptime_days": 0,
-  "uptime_hours": 3,
-  "uptime_seconds": 12583,
-  "uuid": "583D300E-FE81-4311-AC88-A211E67DA08B",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2016-x86_64.facts
+++ b/facts/4.4/windows-2016-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "3FE9CFAE-0264-4E81-B722-29D5F9026CD8"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.6",
-  "ipaddress6": "fe80::8dd6:a4af:1f7d:8c62",
   "ipaddress6_Ethernet": "fe80::8dd6:a4af:1f7d:8c62",
   "ipaddress_Ethernet": "10.138.1.6",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
-  "macaddress": "60:45:BD:F1:D9:88",
   "macaddress_Ethernet": "60:45:BD:F1:D9:88",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "13.82 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 2340265984
     }
   },
-  "memoryfree": "13.82 GiB",
-  "memoryfree_mb": 14151.69921875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2016",
-  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps;",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0004-6054-4044-0234-4300-81",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 21,
@@ -168,14 +135,5 @@
     "uptime": "21:28 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "21:28 hours",
-  "uptime_days": 0,
-  "uptime_hours": 21,
-  "uptime_seconds": 77319,
-  "uuid": "3FE9CFAE-0264-4E81-B722-29D5F9026CD8",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server",
-  "windows_product_name": "Windows Server 2016 Datacenter",
-  "windows_release_id": "1607"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2019-core-x86_64.facts
+++ b/facts/4.4/windows-2019-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "2402FAF6-A829-43F0-BC0C-3213AF5918E3"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "c:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::6859:5ae2:a7d7:bdb0",
   "ipaddress6_Ethernet": "fe80::6859:5ae2:a7d7:bdb0",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "60:45:BD:F1:2F:7A",
   "macaddress_Ethernet": "60:45:BD:F1:2F:7A",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.44 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1672433664
     }
   },
-  "memoryfree": "14.44 GiB",
-  "memoryfree_mb": 14788.59375,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -132,11 +110,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "c:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;c:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps;",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -147,20 +121,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0002-5949-1227-2609-0024-80",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -168,14 +135,5 @@
     "uptime": "0:34 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:34 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2084,
-  "uuid": "2402FAF6-A829-43F0-BC0C-3213AF5918E3",
-  "virtual": "hyperv",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Datacenter",
-  "windows_release_id": "1809"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2019-x86_64.facts
+++ b/facts/4.4/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5156:1072:2404:1e7f",
   "ipaddress6_Ethernet": "fe80::5156:1072:2404:1e7f",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "08:00:27:E5:87:1C",
   "macaddress_Ethernet": "08:00:27:E5:87:1C",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "988.43 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1093943296
     }
   },
-  "memoryfree": "988.43 MiB",
-  "memoryfree_mb": 988.42578125,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -134,11 +112,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -149,19 +123,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -204,7 +172,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
   "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -212,14 +179,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 186,
-  "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052",
-  "virtual": "virtualbox",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Standard Evaluation",
-  "windows_release_id": "1809"
+  "virtual": "virtualbox"
 }

--- a/facts/4.4/windows-2022-core-x86_64.facts
+++ b/facts/4.4/windows-2022-core-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "168.63.129.16",
     "system": "168.63.129.16"
@@ -13,26 +12,18 @@
       "uuid": "E160D59E-7890-43A2-AF45-C58C5508965E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "c:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "hyperv": {
     }
   },
-  "id": "foo\\windows",
   "identity": {
     "privileged": true,
     "user": "foo\\windows"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.138.1.4",
-  "ipaddress6": "fe80::743b:97b3:ed37:294",
   "ipaddress6_Ethernet": "fe80::743b:97b3:ed37:294",
   "ipaddress_Ethernet": "10.138.1.4",
   "is_virtual": true,
@@ -40,9 +31,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "60:45:BD:D0:18:BD",
   "macaddress_Ethernet": "60:45:BD:D0:18:BD",
-  "manufacturer": "American Megatrends Inc.",
   "memory": {
     "system": {
       "available": "14.41 GiB",
@@ -54,17 +43,9 @@
       "used_bytes": 1704284160
     }
   },
-  "memoryfree": "14.41 GiB",
-  "memoryfree_mb": 14758.21875,
-  "memorysize": "16.00 GiB",
-  "memorysize_mb": 16383.55078125,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.138.1.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.138.1.0",
   "networking": {
@@ -112,9 +93,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -133,11 +111,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "c:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;c:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\dotnet\\;C:\\Users\\windows\\AppData\\Local\\Microsoft\\WindowsApps;",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
-  "processorcount": 4,
   "processors": {
     "cores": 2,
     "count": 4,
@@ -148,20 +122,13 @@
     "physicalcount": 1,
     "threads": 2
   },
-  "productname": "Virtual Machine",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "c:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0000-0016-2402-1513-2902-2780-50",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -169,15 +136,5 @@
     "uptime": "0:37 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:37 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 2220,
-  "uuid": "E160D59E-7890-43A2-AF45-C58C5508965E",
-  "virtual": "hyperv",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerDatacenter",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Datacenter",
-  "windows_release_id": "21H2"
+  "virtual": "hyperv"
 }

--- a/facts/4.4/windows-2022-x86_64.facts
+++ b/facts/4.4/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.4.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::8d97:e947:bec7:8686",
   "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "08:00:27:E7:59:F0",
   "macaddress_Ethernet": "08:00:27:E7:59:F0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "956.80 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1127108608
     }
   },
-  "memoryfree": "956.80 MiB",
-  "memoryfree_mb": 956.796875,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.0.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
   "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 198,
-  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
-  "virtual": "virtualbox",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Standard Evaluation",
-  "windows_release_id": "21H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.5/almalinux-8-x86_64.facts
+++ b/facts/4.5/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 2.63,
     "5m": 2.28
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "595.18 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 372707328
     }
   },
-  "memoryfree": "595.18 MiB",
-  "memoryfree_mb": 595.1796875,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.12 GiB",
@@ -319,14 +288,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -411,9 +376,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -443,7 +405,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -455,9 +416,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -469,26 +427,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -528,10 +474,5 @@
     "uptime": "0:10 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:10 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 630,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/almalinux-9-x86_64.facts
+++ b/facts/4.5/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.4,
     "5m": 0.84
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "565.52 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 398184448
     }
   },
-  "memoryfree": "565.52 MiB",
-  "memoryfree_mb": 565.515625,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.57 GiB",
@@ -412,14 +381,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -504,9 +469,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -536,7 +498,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -573,9 +534,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -587,26 +545,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -646,10 +592,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 281,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/amazon-2-x86_64.facts
+++ b/facts/4.5/amazon-2-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 26843545600,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,23 +38,16 @@
       "uuid": "6A204E20-8B4A-5846-958D-EF36ECF0A386"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
       "version": "7.0.10"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -76,8 +56,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea6:b56c",
   "ipaddress6_eth0": "fe80::a00:27ff:fea6:b56c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -92,11 +70,7 @@
     "1m": 1.31,
     "5m": 0.72
   },
-  "lsbdistrelease": "2",
-  "lsbmajdistrelease": "2",
-  "macaddress": "08:00:27:a6:b5:6c",
   "macaddress_eth0": "08:00:27:a6:b5:6c",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1.64 GiB",
@@ -108,10 +82,6 @@
       "used_bytes": 312922112
     }
   },
-  "memoryfree": "1.64 GiB",
-  "memoryfree_mb": 1681.75,
-  "memorysize": "1.93 GiB",
-  "memorysize_mb": 1980.17578125,
   "mountpoints": {
     "/": {
       "available": "22.50 GiB",
@@ -309,14 +279,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -403,9 +369,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Amazon",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -428,7 +391,6 @@
       "enabled": false
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -448,10 +410,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -464,20 +422,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -517,10 +468,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 139,
-  "uuid": "6A204E20-8B4A-5846-958D-EF36ECF0A386",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/archlinux-x86_64.facts
+++ b/facts/4.5/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -50,23 +37,16 @@
       "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,9 +69,7 @@
     "1m": 1.01,
     "5m": 0.39
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -114,10 +90,6 @@
       "used_bytes": 365563904
     }
   },
-  "memoryfree": "616.60 MiB",
-  "memoryfree_mb": 616.6015625,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.84 GiB",
@@ -336,14 +308,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -430,7 +398,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -455,7 +422,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -483,10 +449,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -499,20 +461,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -545,10 +500,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -556,10 +507,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 113,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/centos-7-x86_64.facts
+++ b/facts/4.5/centos-7-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,23 +38,16 @@
       "uuid": "CF7523BE-BD2D-2F43-B164-E85BD8B24901"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "159484",
       "version": "7.0.12"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -76,8 +56,6 @@
     "user": "root"
   },
   "interfaces": "eth0,eth1,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth0": "fe80::5054:ff:fe4d:77d3",
   "ipaddress6_eth1": "fe80::a00:27ff:fee6:7baa",
   "ipaddress6_lo": "::1",
@@ -94,13 +72,8 @@
     "1m": 1.02,
     "5m": 0.31
   },
-  "lsbdistrelease": "7.8.2003",
-  "lsbmajdistrelease": "7",
-  "lsbminordistrelease": "8",
-  "macaddress": "52:54:00:4d:77:d3",
   "macaddress_eth0": "52:54:00:4d:77:d3",
   "macaddress_eth1": "08:00:27:e6:7b:aa",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -121,10 +94,6 @@
       "used_bytes": 160899072
     }
   },
-  "memoryfree": "333.55 MiB",
-  "memoryfree_mb": 333.55078125,
-  "memorysize": "487.00 MiB",
-  "memorysize_mb": 486.99609375,
   "mountpoints": {
     "/": {
       "available": "36.44 GiB",
@@ -342,16 +311,12 @@
   "mtu_eth0": 1500,
   "mtu_eth1": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_eth1": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_eth1": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_eth1": "fe80::",
   "network6_lo": "::1",
@@ -473,9 +438,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.8.2003",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -505,7 +467,6 @@
       "policy_version": "31"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -516,9 +477,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -530,26 +488,14 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_eth1": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "31",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -582,10 +528,6 @@
   "sshfp_ed25519": "SSHFP 4 1 649c63dfbc92eb5b595ca9e961cc6b0570b1e60b\nSSHFP 4 2 7294579440a32c285e6ef6b271e876be58264a3c1bf6b431708b1d205fa4c6bc",
   "sshfp_rsa": "SSHFP 1 1 4a22cb2030be8dc2a161dee19d9b184c89007b7d\nSSHFP 1 2 4d55cc3ad95412bcaf302b754dc464c35005da4286ca327a905ffe2f0ed8dcf5",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCcLQ5cQEU6w6s1jDCOVlRQ+v0ZXfkkZaCqjstqQnrQUqvCzO7zeGumUr/KJakHzkRhq0pwLRO0ZHfrU9pwVB7B7Pk4S2GYB2xDZznwobi3+WDNjol3iidd3Xlj/hAvZBWj9dcnGdCoC6CzYYx1quc2DDGhGtjSBdFeleBjTYlqASSR+eFIOBA8skqalw7cvJ7MgzWt21vyezoFSn6gb73xUgTSAMqKWkLXrtvUQfP+c8R8NHML/FcAj3dvC22kBbtpQ5gYo8ZQtVhE/1GWtN2cLsXodNbRUe2P6kM/yQyLUd+XPCNCUOU/TxqUomr4JXek8EUGZs1mgD+vH1VOE4Kz",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2043.73828125,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -593,10 +535,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 132,
-  "uuid": "CF7523BE-BD2D-2F43-B164-E85BD8B24901",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/centos-8-x86_64.facts
+++ b/facts/4.5/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 2.74,
     "5m": 2.61
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 162562048
     }
   },
-  "memoryfree": "303.75 MiB",
-  "memoryfree_mb": 303.74609375,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.74 GiB",
@@ -308,14 +278,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -400,9 +366,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -429,7 +392,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -441,9 +403,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -455,26 +414,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -507,10 +454,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.21484375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -518,10 +461,5 @@
     "uptime": "0:14 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:14 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 844,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/centos-9-x86_64.facts
+++ b/facts/4.5/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,20 +37,13 @@
       "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -72,8 +52,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -88,11 +66,7 @@
     "1m": 0.95,
     "5m": 0.82
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.98 GiB",
@@ -113,10 +87,6 @@
       "used_bytes": 148054016
     }
   },
-  "memoryfree": "316.69 MiB",
-  "memoryfree_mb": 316.6875,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.78 GiB",
@@ -372,14 +342,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -464,9 +430,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -493,7 +456,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -505,9 +467,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -519,26 +478,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -571,10 +518,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.98 GiB",
-  "swapfree_mb": 2030.9140625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -582,10 +525,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 365,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/debian-11-x86_64.facts
+++ b/facts/4.5/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,15 +38,9 @@
       "uuid": "be037311-7594-41a5-8599-8496211026af"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -68,7 +49,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -77,8 +57,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -93,15 +71,7 @@
     "1m": 0.93,
     "5m": 0.76
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "336.09 MiB",
@@ -113,10 +83,6 @@
       "used_bytes": 131149824
     }
   },
-  "memoryfree": "336.09 MiB",
-  "memoryfree_mb": 336.0859375,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "90.82 GiB",
@@ -303,14 +269,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -397,9 +359,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -424,7 +383,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -436,10 +394,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -452,21 +406,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -506,10 +453,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 399,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/debian-12-x86_64.facts
+++ b/facts/4.5/debian-12-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,16 +38,10 @@
       "uuid": "4a2212ba-ed4c-4fa5-9b09-b523d43a4b39"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.1",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -69,7 +50,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -78,8 +58,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -94,15 +72,7 @@
     "1m": 1.22,
     "5m": 0.39
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.5",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "5",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "290.56 MiB",
@@ -114,10 +84,6 @@
       "used_bytes": 174845952
     }
   },
-  "memoryfree": "290.56 MiB",
-  "memoryfree_mb": 290.55859375,
-  "memorysize": "457.30 MiB",
-  "memorysize_mb": 457.3046875,
   "mountpoints": {
     "/": {
       "available": "90.83 GiB",
@@ -385,14 +351,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -479,9 +441,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.5",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -506,7 +465,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -518,10 +476,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -534,20 +488,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -587,10 +534,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 92,
-  "uuid": "4a2212ba-ed4c-4fa5-9b09-b523d43a4b39",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-36-x86_64.facts
+++ b/facts/4.5/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.12,
     "5m": 0.62
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 448532480
     }
   },
-  "memoryfree": "1.49 GiB",
-  "memoryfree_mb": 1525.984375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.93 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -412,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -442,7 +405,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -476,10 +438,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -492,25 +450,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -543,10 +489,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -554,10 +496,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 240,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-37-x86_64.facts
+++ b/facts/4.5/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.91,
     "5m": 0.4
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 430952448
     }
   },
-  "memoryfree": "1.51 GiB",
-  "memoryfree_mb": 1542.4609375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.92 GiB",
@@ -320,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -412,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -442,7 +405,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -481,10 +443,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -497,25 +455,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -548,10 +494,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -559,10 +501,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 177,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-38-x86_64.facts
+++ b/facts/4.5/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 1.12,
     "5m": 0.47
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 322629632
     }
   },
-  "memoryfree": "1.61 GiB",
-  "memoryfree_mb": 1646.30859375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -439,14 +409,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -531,9 +497,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -561,7 +524,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -601,9 +563,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -615,25 +574,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -666,10 +613,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -677,10 +620,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 232,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-39-x86_64.facts
+++ b/facts/4.5/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,11 +68,7 @@
     "1m": 0.97,
     "5m": 0.44
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -115,10 +89,6 @@
       "used_bytes": 337711104
     }
   },
-  "memoryfree": "1.59 GiB",
-  "memoryfree_mb": 1631.6640625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.63 GiB",
@@ -362,14 +332,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -454,9 +420,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -484,7 +447,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -524,9 +486,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -538,25 +497,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -589,10 +536,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -600,10 +543,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 177,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/freebsd-12-x86_64.facts
+++ b/facts/4.5/freebsd-12-x86_64.facts
@@ -1,12 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "dmi": {
     "bios": {
       "release_date": "12/01/2006",
@@ -20,15 +15,8 @@
       "uuid": "b7e4158d-a5de-6548-a3eb-e503e084c8f0"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -36,7 +24,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "ipaddress6_lo0": "::1",
   "ipaddress_em0": "10.0.2.15",
   "ipaddress_lo0": "127.0.0.1",
@@ -50,8 +37,6 @@
     "1m": 0.48388671875,
     "5m": 0.1337890625
   },
-  "macaddress": "08:00:27:cc:5d:60",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -73,10 +58,6 @@
       "used_bytes": 455225344
     }
   },
-  "memoryfree": "548.41 MiB",
-  "memoryfree_mb": 548.40625,
-  "memorysize": "982.54 MiB",
-  "memorysize_mb": 982.54296875,
   "mountpoints": {
     "/": {
       "available": "58.49 GiB",
@@ -292,11 +273,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +339,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.2-RELEASE-p6",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -376,11 +352,7 @@
       "patchlevel": "6"
     }
   },
-  "osfamily": "FreeBSD",
   "path": "/usr/home/vagrant/vendor/bundler/ruby/3.1/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -390,16 +362,11 @@
     ],
     "speed": "3.19 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd12",
     "sitedir": "/usr/local/lib/ruby/site_ruby/3.1",
     "version": "3.1.4"
   },
-  "rubyplatform": "amd64-freebsd12",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.1",
-  "rubyversion": "3.1.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -432,11 +399,6 @@
   "sshfp_ed25519": "SSHFP 4 1 aaedcc84b12a9ee5858d1d57396209b5478e4460\nSSHFP 4 2 dd536bc7ec52cb2b42ba56c7fa0e1ca050a476f35fa600a8a09152c0f08bd92c",
   "sshfp_rsa": "SSHFP 1 1 d25c836cfde179592f943b2f0683ec4cb9ea1df6\nSSHFP 1 2 1a3730ad9a5898dcb501c23f8fae567a1c8f8d703924d631bc357af0f1a79f9f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC6BdnKic9BQ4waex+wmaoLHLX2RUXuSVi/ZP9FJz+GrcaZAHsM50dF1zybjgQiKqxMsVBtjntIsYiN1hVXyWHfTNbwpb7mdMlkgZusAIZwTIk1+08oa2U2Btv3D5x/l/sZrliMWHHqH2nFa4W0dwYTmpFugFE/HZDYlnGdU/15BF1jMpr2wMj0xN4KYCmhwQy2J8DKQlbKKNgoKm24ryDYTGyU3X73GkYqMHlucU3sl3d1aQW8unQ7y3F3gOlmyikw6G9inb+LqeZGqlejb6azAm/juyFamE1h3WA3l7O3HIwGdE5QQ82cotkxTlxLMBlxVg8zIwXEqJLTRhy6iWlp",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -444,11 +406,6 @@
     "uptime": "0:00 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:00 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 57,
-  "uuid": "b7e4158d-a5de-6548-a3eb-e503e084c8f0",
   "virtual": "generic",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.5/freebsd-13-x86_64.facts
+++ b/facts/4.5/freebsd-13-x86_64.facts
@@ -1,12 +1,7 @@
 {
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.0"
   },
-  "augeasversion": "1.14.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
   "dmi": {
     "bios": {
       "release_date": "12/01/2006",
@@ -20,15 +15,8 @@
       "uuid": "039c5d1d-7af6-fa45-a633-89a0b93f1213"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.1",
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -36,7 +24,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.2.15",
   "ipaddress6_lo0": "::1",
   "ipaddress_em0": "10.0.2.15",
   "ipaddress_lo0": "127.0.0.1",
@@ -50,8 +37,6 @@
     "1m": 0.361328125,
     "5m": 0.12548828125
   },
-  "macaddress": "08:00:27:a0:78:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -73,10 +58,6 @@
       "used_bytes": 541114368
     }
   },
-  "memoryfree": "1.46 GiB",
-  "memoryfree_mb": 1490.5078125,
-  "memorysize": "1.96 GiB",
-  "memorysize_mb": 2006.5546875,
   "mountpoints": {
     "/": {
       "available": "58.43 GiB",
@@ -292,11 +273,9 @@
       "used_bytes": 98304
     }
   },
-  "netmask": "255.255.255.0",
   "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_em0": "255.255.255.0",
   "netmask_lo0": "255.0.0.0",
-  "network": "10.0.2.0",
   "network6_lo0": "::1",
   "network_em0": "10.0.2.0",
   "network_lo0": "127.0.0.0",
@@ -360,9 +339,6 @@
     "network": "10.0.2.0",
     "primary": "em0"
   },
-  "operatingsystem": "FreeBSD",
-  "operatingsystemmajrelease": "13",
-  "operatingsystemrelease": "13.2-RELEASE",
   "os": {
     "architecture": "amd64",
     "family": "FreeBSD",
@@ -375,11 +351,7 @@
       "minor": "2"
     }
   },
-  "osfamily": "FreeBSD",
   "path": "/usr/home/vagrant/vendor/bundler/ruby/3.1/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/home/vagrant/bin",
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "amd64",
@@ -389,16 +361,11 @@
     ],
     "speed": "3.19 GHz"
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "amd64-freebsd13",
     "sitedir": "/usr/local/lib/ruby/site_ruby/3.1",
     "version": "3.1.4"
   },
-  "rubyplatform": "amd64-freebsd13",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.1",
-  "rubyversion": "3.1.4",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -431,11 +398,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6e7a963faae3ab450b8b26b3cc16e8e9e8698c0d\nSSHFP 4 2 a3edc3fa54b8a129abbb03b9c45346f973b259294eab644b7ae7696a84a7feab",
   "sshfp_rsa": "SSHFP 1 1 a515c1bc994712f2510d5e1e6f367690dd28daab\nSSHFP 1 2 52e894012cee246ff054ebda61f8f0aa49543e964c62c37440ce3979a135a209",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDWWcTfOdwXStChm2iWg4/Ul2asGkmD78IKEClglrxOsOJq9hcMJiTtVNxGWht1bR1+4zoDO+fZfAHdbxvxNTV1wTda85yquMNUxJThiuF4kVlJJrPlxuBtTvGNL3bpQfgWi1fWk7cKLdj8It5BNV4KSWcK3DuG14jhGFx3zesv8fDa1sZRnJZHiNPQoPJ5UWFj36N8urub096lWCHssYQ2vmgGrs4aqnWgh6a0E243VoOhGDKTRgYGzGRI3s+UHUoxcQeqvpQnPLOeT/YU6AZTbbJV6xcTbuWOK9YN1NdAXsp/+kLpDOPwNZdofexB2Hz/yYA4Z8gp8pZaP+4gtjnaNdLBN1g2CljGr6Wv/D/7xgyCAEvkqlWLbvTpcDB5NECAOm7tN0+H/EDC8rmjIjPIatPy/e956wxSXdkbfknOWCUQ9DnMFDbyw91Euof9VCHb/rXiLW04EMceiLdjAaLWsGWCS3rwLLXBHRASWLYPrSD9I3iiKcTa7Bfqhlxa0Bs=",
-  "swapencrypted": false,
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2048.0,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2048.0,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -443,11 +405,6 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 70,
-  "uuid": "039c5d1d-7af6-fa45-a633-89a0b93f1213",
   "virtual": "vbox",
   "zfs_featurenumbers": "1,2,3,4,5",
   "zfs_version": "5",

--- a/facts/4.5/gentoo-2-x86_64.facts
+++ b/facts/4.5/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -48,23 +35,16 @@
       "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.2",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,16 +67,7 @@
     "1m": 0.8,
     "5m": 0.39
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -119,10 +88,6 @@
       "used_bytes": 338759680
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3586.86328125,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -292,14 +257,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -384,9 +345,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -412,7 +370,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -448,12 +405,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -468,20 +419,13 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -514,10 +458,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -525,10 +465,5 @@
     "uptime": "1:13 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4385,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/opensuse-15-x86_64.facts
+++ b/facts/4.5/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "uuid": "ec083458-0c0a-c04b-bfed-1136be41382e"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
       "version": "7.0.10"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe79:5e9d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe79:5e9d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.72,
     "5m": 0.29
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:79:5e:9d",
   "macaddress_eth0": "08:00:27:79:5e:9d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "709.51 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 265490432
     }
   },
-  "memoryfree": "709.51 MiB",
-  "memoryfree_mb": 709.5078125,
-  "memorysize": "962.70 MiB",
-  "memorysize_mb": 962.69921875,
   "mountpoints": {
     "/": {
       "available": "37.49 GiB",
@@ -323,14 +292,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -415,9 +380,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -442,7 +404,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -455,9 +416,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -469,20 +427,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -532,10 +483,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 160,
-  "uuid": "ec083458-0c0a-c04b-bfed-1136be41382e",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/oraclelinux-8-x86_64.facts
+++ b/facts/4.5/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_eth0": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,16 +68,7 @@
     "1m": 0.79,
     "5m": 0.4
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Oracle Linux Server release 8.9",
-  "lsbdistid": "OracleServer",
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
-  "macaddress": "08:00:27:14:27:05",
   "macaddress_eth0": "08:00:27:14:27:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -120,10 +89,6 @@
       "used_bytes": 545652736
     }
   },
-  "memoryfree": "1.13 GiB",
-  "memoryfree_mb": 1159.8125,
-  "memorysize": "1.64 GiB",
-  "memorysize_mb": 1680.1875,
   "mountpoints": {
     "/": {
       "available": "57.49 GiB",
@@ -337,14 +302,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -429,9 +390,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -462,7 +420,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -481,10 +438,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -497,26 +450,14 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -549,10 +490,6 @@
   "sshfp_ed25519": "SSHFP 4 1 de5b1ba064c808e938c843f2791b85d7a9ddd313\nSSHFP 4 2 7b8b8985b248c027edcab5d85d6b88ff91bbae4ef9d41db7e99163400892e85f",
   "sshfp_rsa": "SSHFP 1 1 df37431d9ea1fb5f9d0f7086b7644514e93a786c\nSSHFP 1 2 daa7bdfedd44dfd625c631250213584261c1f2cca2dc4106e67fc6ed69b7d72f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDIWh8Ism8vmAG6N7OkgqLlylyYTLYBoM4LEf3uhLa9g+o9LsUqtmKZxvlqqt37me3suHAkSi2qS6tAFNpvSeFQCzl2UhUL7quELTEtwIYiQH/t826t6yfKUbX8UiCovAKbvs7uf4SNniL9I33IDhCezQphBYweOxmjZ9Hv8xTOWTHMCLDZd/TuBkTodXQmikKx3IpSG+/5InETmuLlr1iqBoFu+T/0WQ+elMlghn1qMgLGYwQUpTX9Ix0dZy5tMsUZdB+OjGRHghPolEVMbKUliXvRrHX2iN1fmUE23Dvn17jzerYAgrxZvJVivCPNkSFramAl5150XslwkxRm+u/bfPD7hX3H8SsbUEy5vNFpuku0b4aInVT1WNAd0Q5he8tG8lOPmr1QDyUtXs8FFB+znzi3z0hPchTQ9KDZIguYHR178wsOezN7lYqhCj41Pz8xoVUUBx9nwMoPRJYIDcuPT7tvtXewvFK7KDkISCmqTuXeP3mf/dFZP4MFIv3Xukc=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2084.47265625,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2086.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -560,10 +497,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 666,
-  "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/oraclelinux-9-x86_64.facts
+++ b/facts/4.5/oraclelinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_eth0": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 0.99,
     "5m": 0.48
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:9d:8c:b7",
   "macaddress_eth0": "08:00:27:9d:8c:b7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1006.41 MiB",
@@ -107,10 +80,6 @@
       "used_bytes": 530288640
     }
   },
-  "memoryfree": "1006.41 MiB",
-  "memoryfree_mb": 1006.40625,
-  "memorysize": "1.48 GiB",
-  "memorysize_mb": 1512.12890625,
   "mountpoints": {
     "/": {
       "available": "60.47 GiB",
@@ -370,14 +339,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -462,9 +427,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -494,7 +456,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -506,10 +467,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -522,26 +479,14 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -581,10 +526,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 176,
-  "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/redhat-8-x86_64.facts
+++ b/facts/4.5/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.34,
     "5m": 1.07
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 477794304
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1310.703125,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "66.97 GiB",
@@ -334,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -426,9 +391,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -458,7 +420,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -490,10 +451,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -506,26 +463,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -558,10 +503,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -569,10 +510,5 @@
     "uptime": "0:12 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:12 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 773,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/redhat-9-x86_64.facts
+++ b/facts/4.5/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.03,
     "5m": 0.79
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 483311616
     }
   },
-  "memoryfree": "1.46 GiB",
-  "memoryfree_mb": 1494.8046875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.44 GiB",
@@ -385,14 +354,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -477,9 +442,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -509,7 +471,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -541,10 +502,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -557,26 +514,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -609,10 +554,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -620,10 +561,5 @@
     "uptime": "0:10 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:10 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 652,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/rocky-8-x86_64.facts
+++ b/facts/4.5/rocky-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 41943040000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "uuid": "71dbbe9d-a96d-934f-9650-72393ac47baf"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
       "version": "7.0.10"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.52,
     "5m": 0.2
   },
-  "lsbdistrelease": "8.4",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 480231424
     }
   },
-  "memoryfree": "7.33 GiB",
-  "memoryfree_mb": 7503.265625,
-  "memorysize": "7.77 GiB",
-  "memorysize_mb": 7961.25,
   "mountpoints": {
     "/": {
       "available": "34.80 GiB",
@@ -328,14 +297,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -420,9 +385,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -452,7 +414,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -464,10 +425,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -480,25 +437,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -531,10 +476,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1c579819a7fac24f450aa11e50530be7ec7bca19\nSSHFP 4 2 ff53f053c3e6c42788b0d6946a1201e63763a54a0176d31db25923b52661edb2",
   "sshfp_rsa": "SSHFP 1 1 dcfebf14980d034cf2e4c18f811c7ba2daa403f3\nSSHFP 1 2 ad0008faafe3c8ab16c714a9cdd8dd195ab82994479f279b4c4acb631a6fb66f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDoz4tiN2ezhz14zMw3rRyE0iqlB2k59F2W4IKUBkXfR6JFRknmE3z03noUnoC/TxroeFWoPAizYwaPtOmVSIruKV94tQqg+UnAt42ycYwCg8Yvt38b8l2yAbzIbbS/mFNf+QKOESl5ggjyy4x+sR4ZnDJk+h3y7vrxfv2n448I2h7axFIUaxJpkTVtZ5/p6Dp4dV6M9jULI3RittyqoU5UoGxG1A+JUIbDMPDZU48SppMo3XQL56Wj80ClTnoZxbdRVDS0H6O0iRBRCHwCPqhlLDNwN/yurzs7MTVsIlnqZSI4/doumfmn21tLcX5J5YnGS0DtOnGuf7reiwRxY9iIv3vi4wt/05b5DbYLtUve+409hT2RTp8qRD4FOX0mm297JgUJVAcwSVkFJPdxckDWzBy498Ely1cCyfjHXNBrzNhD9u02m0yXOzyaG8MwQGQy8G8n5FdEA9DO2Ihl9J6Yj/3qEmGD8Yj3hhspiR8o55dOxmOlYpwVClZWGTi9qIM=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -542,10 +483,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 118,
-  "uuid": "71dbbe9d-a96d-934f-9650-72393ac47baf",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/rocky-9-x86_64.facts
+++ b/facts/4.5/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,22 +37,15 @@
       "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,12 +68,7 @@
     "1m": 1.22,
     "5m": 0.93
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -116,10 +89,6 @@
       "used_bytes": 525582336
     }
   },
-  "memoryfree": "7.27 GiB",
-  "memoryfree_mb": 7440.47265625,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.22 GiB",
@@ -441,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -533,9 +498,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -565,7 +527,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -605,10 +566,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -621,26 +578,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -673,10 +618,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -684,10 +625,5 @@
     "uptime": "0:08 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:08 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 508,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/ubuntu-18.04-x86_64.facts
+++ b/facts/4.5/ubuntu-18.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,23 +44,16 @@
       "uuid": "4FB9D400-A76D-9140-8CB0-08AA283C1719"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
       "version": "7.0.10"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::3b:7bff:feb7:3b2d",
   "ipaddress6_enp0s3": "fe80::3b:7bff:feb7:3b2d",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 0.81,
     "5m": 0.36
   },
-  "lsbdistcodename": "bionic",
-  "lsbdistdescription": "Ubuntu 18.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "18.04",
-  "lsbmajdistrelease": "18.04",
-  "macaddress": "02:3b:7b:b7:3b:2d",
   "macaddress_enp0s3": "02:3b:7b:b7:3b:2d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "707.97 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 290361344
     }
   },
-  "memoryfree": "707.97 MiB",
-  "memoryfree_mb": 707.96875,
-  "memorysize": "984.88 MiB",
-  "memorysize_mb": 984.87890625,
   "mountpoints": {
     "/": {
       "available": "36.88 GiB",
@@ -343,14 +307,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -437,9 +397,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "18.04",
-  "operatingsystemrelease": "18.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -462,7 +419,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -475,10 +431,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -491,20 +443,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -554,10 +499,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 115,
-  "uuid": "4FB9D400-A76D-9140-8CB0-08AA283C1719",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/ubuntu-20.04-x86_64.facts
+++ b/facts/4.5/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.0.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,23 +44,16 @@
       "uuid": "318f4a21-4b7b-694b-a525-ef9c52c73ab2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.5.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "158379",
       "version": "7.0.10"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::97:10ff:fe79:f0c1",
   "ipaddress6_enp0s3": "fe80::97:10ff:fe79:f0c1",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 0.79,
     "5m": 0.25
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:97:10:79:f0:c1",
   "macaddress_enp0s3": "02:97:10:79:f0:c1",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "624.42 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 357003264
     }
   },
-  "memoryfree": "624.42 MiB",
-  "memoryfree_mb": 624.421875,
-  "memorysize": "964.89 MiB",
-  "memorysize_mb": 964.88671875,
   "mountpoints": {
     "/": {
       "available": "36.59 GiB",
@@ -412,14 +376,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -506,9 +466,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -531,7 +488,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/lxd_24061.snap",
@@ -565,10 +521,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -581,20 +533,13 @@
     "speed": "3.19 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -644,10 +589,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 105,
-  "uuid": "318f4a21-4b7b-694b-a525-ef9c52c73ab2",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/ubuntu-22.04-x86_64.facts
+++ b/facts/4.5/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -60,22 +44,15 @@
       "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.5.2",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -84,8 +61,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -100,14 +75,7 @@
     "1m": 1.26,
     "5m": 0.86
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "558.72 MiB",
@@ -119,10 +87,6 @@
       "used_bytes": 417914880
     }
   },
-  "memoryfree": "558.72 MiB",
-  "memoryfree_mb": 558.72265625,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "36.25 GiB",
@@ -419,14 +383,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -513,9 +473,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -538,7 +495,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -572,10 +528,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -588,21 +540,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -642,10 +587,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 322,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/windows-10-x86_64.facts
+++ b/facts/4.5/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.5.2",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "08:00:27:85:56:BC",
   "macaddress_Ethernet": "08:00:27:85:56:BC",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.46 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1640919040
     }
   },
-  "memoryfree": "2.46 GiB",
-  "memoryfree_mb": 2514.7890625,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
   "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 555,
-  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
-  "virtual": "virtualbox",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "22H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.5/windows-11-x86_64.facts
+++ b/facts/4.5/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.5.2",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::f72f:511:e1c3:e451",
   "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22631",
   "kernelversion": "10.0.22631",
-  "macaddress": "08:00:27:02:6D:35",
   "macaddress_Ethernet": "08:00:27:02:6D:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.44 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1662627840
     }
   },
-  "memoryfree": "2.44 GiB",
-  "memoryfree_mb": 2494.0859375,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
   "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 334,
-  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
-  "virtual": "virtualbox",
-  "windows_display_version": "23H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "23H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.5/windows-2019-x86_64.facts
+++ b/facts/4.5/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "E9E43331-3478-4C89-9186-895D4580BB80"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.5.2",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::c2c9:fe72:6f76:9134",
   "ipaddress6_Ethernet": "fe80::c2c9:fe72:6f76:9134",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "08:00:27:E5:87:1C",
   "macaddress_Ethernet": "08:00:27:E5:87:1C",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "943.78 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1140760576
     }
   },
-  "memoryfree": "943.78 MiB",
-  "memoryfree_mb": 943.77734375,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -134,11 +112,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -149,19 +123,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -204,7 +172,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
   "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -212,14 +179,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 699,
-  "uuid": "E9E43331-3478-4C89-9186-895D4580BB80",
-  "virtual": "virtualbox",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Standard Evaluation",
-  "windows_release_id": "1809"
+  "virtual": "virtualbox"
 }

--- a/facts/4.5/windows-2022-x86_64.facts
+++ b/facts/4.5/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.4.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.5.2",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::8d97:e947:bec7:8686",
   "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "08:00:27:E7:59:F0",
   "macaddress_Ethernet": "08:00:27:E7:59:F0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "899.27 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1187430400
     }
   },
-  "memoryfree": "899.27 MiB",
-  "memoryfree_mb": 899.26953125,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.4.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.2"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.2",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
   "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 300,
-  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
-  "virtual": "virtualbox",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Standard Evaluation",
-  "windows_release_id": "21H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.6/almalinux-8-x86_64.facts
+++ b/facts/4.6/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 2.53,
     "5m": 2.3
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "593.87 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 374079488
     }
   },
-  "memoryfree": "593.87 MiB",
-  "memoryfree_mb": 593.87109375,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.15 GiB",
@@ -320,14 +289,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -412,9 +377,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -444,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -456,9 +417,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -470,7 +428,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -478,19 +435,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -530,10 +476,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 675,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/almalinux-9-x86_64.facts
+++ b/facts/4.6/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.29,
     "5m": 0.86
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "560.58 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 403357696
     }
   },
-  "memoryfree": "560.58 MiB",
-  "memoryfree_mb": 560.58203125,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.57 GiB",
@@ -413,14 +382,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -505,9 +470,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -537,7 +499,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -574,9 +535,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -588,7 +546,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -596,19 +553,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -648,10 +594,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 300,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/archlinux-x86_64.facts
+++ b/facts/4.6/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,23 +38,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -76,8 +56,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -92,9 +70,7 @@
     "1m": 1.01,
     "5m": 0.4
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -115,10 +91,6 @@
       "used_bytes": 356691968
     }
   },
-  "memoryfree": "625.06 MiB",
-  "memoryfree_mb": 625.0625,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.84 GiB",
@@ -337,14 +309,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -431,7 +399,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -456,7 +423,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -484,10 +450,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -500,21 +462,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -547,10 +502,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -558,10 +509,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 116,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/centos-8-x86_64.facts
+++ b/facts/4.6/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 3.14,
     "5m": 2.73
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 164065280
     }
   },
-  "memoryfree": "302.31 MiB",
-  "memoryfree_mb": 302.3125,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.73 GiB",
@@ -309,14 +279,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -401,9 +367,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -430,7 +393,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -442,9 +404,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -456,7 +415,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -464,19 +422,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -509,10 +456,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.46484375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -520,10 +463,5 @@
     "uptime": "0:15 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:15 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 903,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/centos-9-x86_64.facts
+++ b/facts/4.6/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,20 +38,13 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,11 +67,7 @@
     "1m": 1.19,
     "5m": 0.89
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.98 GiB",
@@ -114,10 +88,6 @@
       "used_bytes": 136466432
     }
   },
-  "memoryfree": "327.74 MiB",
-  "memoryfree_mb": 327.73828125,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.78 GiB",
@@ -373,14 +343,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -465,9 +431,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -494,7 +457,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -506,9 +468,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -520,7 +479,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -528,19 +486,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -573,10 +520,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.98 GiB",
-  "swapfree_mb": 2030.9140625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -584,10 +527,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 389,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/debian-11-x86_64.facts
+++ b/facts/4.6/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -52,15 +39,9 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -69,7 +50,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -78,8 +58,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -94,15 +72,7 @@
     "1m": 1.03,
     "5m": 0.8
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "336.04 MiB",
@@ -114,10 +84,6 @@
       "used_bytes": 131198976
     }
   },
-  "memoryfree": "336.04 MiB",
-  "memoryfree_mb": 336.0390625,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "90.75 GiB",
@@ -304,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -398,9 +360,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -425,7 +384,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -437,10 +395,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -453,7 +407,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -461,14 +414,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -508,10 +455,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 422,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/debian-12-x86_64.facts
+++ b/facts/4.6/debian-12-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -52,15 +39,9 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -69,7 +50,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -78,8 +58,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -94,15 +72,7 @@
     "1m": 1.2,
     "5m": 0.33
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.5",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "5",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "267.64 MiB",
@@ -114,10 +84,6 @@
       "used_bytes": 198881280
     }
   },
-  "memoryfree": "267.64 MiB",
-  "memoryfree_mb": 267.63671875,
-  "memorysize": "457.30 MiB",
-  "memorysize_mb": 457.3046875,
   "mountpoints": {
     "/": {
       "available": "90.83 GiB",
@@ -385,14 +351,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -479,9 +441,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.5",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -506,7 +465,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -518,10 +476,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -534,7 +488,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -542,14 +495,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -589,10 +536,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 73,
-  "uuid": "4a2212ba-ed4c-4fa5-9b09-b523d43a4b39",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/fedora-36-x86_64.facts
+++ b/facts/4.6/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 1.11,
     "5m": 0.62
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 451497984
     }
   },
-  "memoryfree": "1.49 GiB",
-  "memoryfree_mb": 1523.15625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.92 GiB",
@@ -321,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +379,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -443,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -477,10 +439,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,26 +451,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -545,10 +491,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -556,10 +498,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 249,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/fedora-37-x86_64.facts
+++ b/facts/4.6/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 0.92,
     "5m": 0.41
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 434987008
     }
   },
-  "memoryfree": "1.50 GiB",
-  "memoryfree_mb": 1538.61328125,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.89 GiB",
@@ -321,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +379,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -443,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -482,10 +444,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -498,26 +456,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -550,10 +496,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -561,10 +503,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 181,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/fedora-38-x86_64.facts
+++ b/facts/4.6/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 1.11,
     "5m": 0.48
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 323641344
     }
   },
-  "memoryfree": "1.61 GiB",
-  "memoryfree_mb": 1645.34375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.66 GiB",
@@ -440,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -532,9 +498,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -562,7 +525,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -602,9 +564,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -616,26 +575,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -668,10 +615,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -679,10 +622,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 237,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/fedora-39-x86_64.facts
+++ b/facts/4.6/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 0.97,
     "5m": 0.45
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 339283968
     }
   },
-  "memoryfree": "1.59 GiB",
-  "memoryfree_mb": 1630.1640625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.63 GiB",
@@ -363,14 +333,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -455,9 +421,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -485,7 +448,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -525,9 +487,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -539,26 +498,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -591,10 +538,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -602,10 +545,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 180,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/gentoo-2-x86_64.facts
+++ b/facts/4.6/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.6.0",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,16 +68,7 @@
     "1m": 0.82,
     "5m": 0.4
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -120,10 +89,6 @@
       "used_bytes": 337092608
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3588.453125,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -293,14 +258,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -385,9 +346,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -413,7 +371,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -449,12 +406,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -469,21 +420,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -516,10 +460,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -527,10 +467,5 @@
     "uptime": "1:13 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4392,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/oraclelinux-8-x86_64.facts
+++ b/facts/4.6/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_eth0": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,16 +69,7 @@
     "1m": 0.55,
     "5m": 0.34
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Oracle Linux Server release 8.9",
-  "lsbdistid": "OracleServer",
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
-  "macaddress": "08:00:27:14:27:05",
   "macaddress_eth0": "08:00:27:14:27:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -121,10 +90,6 @@
       "used_bytes": 536510464
     }
   },
-  "memoryfree": "1.14 GiB",
-  "memoryfree_mb": 1168.53125,
-  "memorysize": "1.64 GiB",
-  "memorysize_mb": 1680.1875,
   "mountpoints": {
     "/": {
       "available": "57.45 GiB",
@@ -338,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -430,9 +391,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -463,7 +421,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -482,10 +439,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -498,7 +451,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -506,19 +458,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -551,10 +492,6 @@
   "sshfp_ed25519": "SSHFP 4 1 de5b1ba064c808e938c843f2791b85d7a9ddd313\nSSHFP 4 2 7b8b8985b248c027edcab5d85d6b88ff91bbae4ef9d41db7e99163400892e85f",
   "sshfp_rsa": "SSHFP 1 1 df37431d9ea1fb5f9d0f7086b7644514e93a786c\nSSHFP 1 2 daa7bdfedd44dfd625c631250213584261c1f2cca2dc4106e67fc6ed69b7d72f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDIWh8Ism8vmAG6N7OkgqLlylyYTLYBoM4LEf3uhLa9g+o9LsUqtmKZxvlqqt37me3suHAkSi2qS6tAFNpvSeFQCzl2UhUL7quELTEtwIYiQH/t826t6yfKUbX8UiCovAKbvs7uf4SNniL9I33IDhCezQphBYweOxmjZ9Hv8xTOWTHMCLDZd/TuBkTodXQmikKx3IpSG+/5InETmuLlr1iqBoFu+T/0WQ+elMlghn1qMgLGYwQUpTX9Ix0dZy5tMsUZdB+OjGRHghPolEVMbKUliXvRrHX2iN1fmUE23Dvn17jzerYAgrxZvJVivCPNkSFramAl5150XslwkxRm+u/bfPD7hX3H8SsbUEy5vNFpuku0b4aInVT1WNAd0Q5he8tG8lOPmr1QDyUtXs8FFB+znzi3z0hPchTQ9KDZIguYHR178wsOezN7lYqhCj41Pz8xoVUUBx9nwMoPRJYIDcuPT7tvtXewvFK7KDkISCmqTuXeP3mf/dFZP4MFIv3Xukc=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2084.47265625,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2086.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -562,10 +499,5 @@
     "uptime": "0:10 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:10 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 652,
-  "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/oraclelinux-9-x86_64.facts
+++ b/facts/4.6/oraclelinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_eth0": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.99,
     "5m": 0.46
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:9d:8c:b7",
   "macaddress_eth0": "08:00:27:9d:8c:b7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "991.26 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 546172928
     }
   },
-  "memoryfree": "991.26 MiB",
-  "memoryfree_mb": 991.2578125,
-  "memorysize": "1.48 GiB",
-  "memorysize_mb": 1512.12890625,
   "mountpoints": {
     "/": {
       "available": "60.47 GiB",
@@ -371,14 +340,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -463,9 +428,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -495,7 +457,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -507,10 +468,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -523,7 +480,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -531,19 +487,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -583,10 +528,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 166,
-  "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/redhat-8-x86_64.facts
+++ b/facts/4.6/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.04,
     "5m": 1.03
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 474963968
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1313.40234375,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "66.95 GiB",
@@ -335,14 +304,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -427,9 +392,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -459,7 +421,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -491,10 +452,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -507,7 +464,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -515,19 +471,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -560,10 +505,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -571,10 +512,5 @@
     "uptime": "0:13 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 807,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/redhat-9-x86_64.facts
+++ b/facts/4.6/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.02,
     "5m": 0.81
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 481054720
     }
   },
-  "memoryfree": "1.46 GiB",
-  "memoryfree_mb": 1496.95703125,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.44 GiB",
@@ -386,14 +355,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -478,9 +443,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -510,7 +472,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -542,10 +503,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -558,7 +515,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -566,19 +522,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -611,10 +556,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -622,10 +563,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 683,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/rocky-9-x86_64.facts
+++ b/facts/4.6/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.12,
     "5m": 0.94
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 519741440
     }
   },
-  "memoryfree": "7.27 GiB",
-  "memoryfree_mb": 7446.04296875,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.22 GiB",
@@ -442,14 +411,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -534,9 +499,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -566,7 +528,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -606,10 +567,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -622,7 +579,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -630,19 +586,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -675,10 +620,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -686,10 +627,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 544,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/ubuntu-20.04-x86_64.facts
+++ b/facts/4.6/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -61,22 +45,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::e9:94ff:fee1:d413",
   "ipaddress6_enp0s3": "fe80::e9:94ff:fee1:d413",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 0.82,
     "5m": 0.3
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:e9:94:e1:d4:13",
   "macaddress_enp0s3": "02:e9:94:e1:d4:13",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "587.93 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 395243520
     }
   },
-  "memoryfree": "587.93 MiB",
-  "memoryfree_mb": 587.9296875,
-  "memorysize": "964.86 MiB",
-  "memorysize_mb": 964.86328125,
   "mountpoints": {
     "/": {
       "available": "36.75 GiB",
@@ -412,14 +376,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -506,9 +466,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -531,7 +488,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/lxd_24061.snap",
@@ -565,10 +521,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -581,7 +533,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -589,14 +540,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -646,10 +591,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 94,
-  "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/ubuntu-22.04-x86_64.facts
+++ b/facts/4.6/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -61,22 +45,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.6.1",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 1.18,
     "5m": 0.87
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "552.12 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 424841216
     }
   },
-  "memoryfree": "552.12 MiB",
-  "memoryfree_mb": 552.1171875,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "36.18 GiB",
@@ -420,14 +384,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -514,9 +474,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -539,7 +496,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -573,10 +529,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -589,7 +541,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.5.1",
   "ruby": {
@@ -597,14 +548,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -644,10 +589,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 343,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/windows-10-x86_64.facts
+++ b/facts/4.6/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.6.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "08:00:27:85:56:BC",
   "macaddress_Ethernet": "08:00:27:85:56:BC",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.49 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1600942080
     }
   },
-  "memoryfree": "2.49 GiB",
-  "memoryfree_mb": 2552.9140625,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.5.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
   "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 321,
-  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
-  "virtual": "virtualbox",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "22H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.6/windows-11-x86_64.facts
+++ b/facts/4.6/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.6.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::f72f:511:e1c3:e451",
   "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22631",
   "kernelversion": "10.0.22631",
-  "macaddress": "08:00:27:02:6D:35",
   "macaddress_Ethernet": "08:00:27:02:6D:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.36 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1745620992
     }
   },
-  "memoryfree": "2.36 GiB",
-  "memoryfree_mb": 2414.9375,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.5.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
   "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 319,
-  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
-  "virtual": "virtualbox",
-  "windows_display_version": "23H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "23H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.6/windows-2019-x86_64.facts
+++ b/facts/4.6/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.6.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5156:1072:2404:1e7f",
   "ipaddress6_Ethernet": "fe80::5156:1072:2404:1e7f",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "08:00:27:E5:87:1C",
   "macaddress_Ethernet": "08:00:27:E5:87:1C",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1016.45 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1064558592
     }
   },
-  "memoryfree": "1016.45 MiB",
-  "memoryfree_mb": 1016.44921875,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -134,11 +112,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -149,19 +123,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.5.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -204,7 +172,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
   "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -212,14 +179,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 282,
-  "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052",
-  "virtual": "virtualbox",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Standard Evaluation",
-  "windows_release_id": "1809"
+  "virtual": "virtualbox"
 }

--- a/facts/4.6/windows-2022-x86_64.facts
+++ b/facts/4.6/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.5.1",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.6.1",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::8d97:e947:bec7:8686",
   "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "08:00:27:E7:59:F0",
   "macaddress_Ethernet": "08:00:27:E7:59:F0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "914.12 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1171861504
     }
   },
-  "memoryfree": "914.12 MiB",
-  "memoryfree_mb": 914.1171875,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.5.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
   "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 290,
-  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
-  "virtual": "virtualbox",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Standard Evaluation",
-  "windows_release_id": "21H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.7/almalinux-8-x86_64.facts
+++ b/facts/4.7/almalinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_enp0s3": "fe80::a00:27ff:feca:eec9",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 2.26,
     "5m": 2.25
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:ca:ee:c9",
   "macaddress_enp0s3": "08:00:27:ca:ee:c9",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "595.42 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 372453376
     }
   },
-  "memoryfree": "595.42 MiB",
-  "memoryfree_mb": 595.421875,
-  "memorysize": "950.62 MiB",
-  "memorysize_mb": 950.62109375,
   "mountpoints": {
     "/": {
       "available": "17.12 GiB",
@@ -320,14 +289,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -412,9 +377,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -444,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -456,9 +417,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -470,7 +428,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -478,19 +435,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -530,10 +476,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 693,
-  "uuid": "7a8edf87-7159-524f-9738-7688aea7d22f",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/almalinux-9-x86_64.facts
+++ b/facts/4.7/almalinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 20971520000,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_eth0": "fe80::a00:27ff:feae:15f5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.24,
     "5m": 0.86
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:ae:15:f5",
   "macaddress_eth0": "08:00:27:ae:15:f5",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "561.33 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 402571264
     }
   },
-  "memoryfree": "561.33 MiB",
-  "memoryfree_mb": 561.33203125,
-  "memorysize": "945.25 MiB",
-  "memorysize_mb": 945.25390625,
   "mountpoints": {
     "/": {
       "available": "16.57 GiB",
@@ -413,14 +382,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -505,9 +470,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "AlmaLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -537,7 +499,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "biosboot",
@@ -574,9 +535,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -588,7 +546,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -596,19 +553,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -648,10 +594,5 @@
     "uptime": "0:05 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 310,
-  "uuid": "16a6c05e-0363-0349-b676-e1cf7b1d48c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/archlinux-x86_64.facts
+++ b/facts/4.7/archlinux-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 21474836480,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -51,23 +38,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -76,8 +56,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_eth0": "fe80::a00:27ff:fea2:3d7",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -92,9 +70,7 @@
     "1m": 1.01,
     "5m": 0.4
   },
-  "macaddress": "08:00:27:a2:03:d7",
   "macaddress_eth0": "08:00:27:a2:03:d7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "511.73 MiB",
@@ -115,10 +91,6 @@
       "used_bytes": 359862272
     }
   },
-  "memoryfree": "622.04 MiB",
-  "memoryfree_mb": 622.0390625,
-  "memorysize": "965.23 MiB",
-  "memorysize_mb": 965.23046875,
   "mountpoints": {
     "/": {
       "available": "17.84 GiB",
@@ -337,14 +309,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -431,7 +399,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Archlinux",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -456,7 +423,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "BIOS boot partition",
@@ -484,10 +450,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.0.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -500,21 +462,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/3.0.0",
     "version": "3.0.6"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib/ruby/site_ruby/3.0.0",
-  "rubyversion": "3.0.6",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -547,10 +502,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e14cdda6c9ede25b28a4caeee44dafda9527f0d8\nSSHFP 4 2 3fb39189a3654cd246846f8252981c153f90c7002a4b11c7f544b0dfe1c40696",
   "sshfp_rsa": "SSHFP 1 1 cb34f01921cf9764d957a54e379328f6e56ca7a1\nSSHFP 1 2 6bdb7526b159365d09685f8b89d1b5e0bcc424ddf3d4e93d923ff9642774ad0a",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjs5Cnv7AK0k38ZssRr3vdu9+hQk5DY1TZs5ivChYhvHdH75UJIP+FKaUUiLB/5zMEvcIXDiAnUqlMQA0YLVsxkhWhxVdkQzu3OJp3jf6BHO7ynJ6d5hrdw10aoRIqvTnwEc82iYi3aF8UZ2rb/bunbJJsoJ8w6C7KBFBEsVnejM8RD6T6SpdcARLX4Fy6BmnO8AgxOcwicTbl+UXURRB79HVI4VG2ORz/j5UxJUm1t3yvaNos9+SyejKxXUbDDRwgjwbimpnP5n/QzFtQncaEp/wNIMB8iY7qZRfK2WogS9SHL5yiMSi01uxvjVyJzB4GAAxBUQPijD/z+WwcjX5Njj0RbxvNzvPMz8VUojG+XWkwJUrm+VFPlZX4E0TIpZ9T0zcqTy/C1o83XlLOVBYojFchJhS1Gl2vE++xyBUilmD2VNmCPHbiEXNf+a3vAm0dJz9g8Tcw35zQsQR5HVuy6cMRMdMpFZaCTizggCSvaZLXYdNEKnRiszG6di1fsUU=",
-  "swapfree": "511.73 MiB",
-  "swapfree_mb": 511.734375,
-  "swapsize": "512.00 MiB",
-  "swapsize_mb": 511.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -558,10 +509,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 119,
-  "uuid": "33998003-ad73-e945-93b6-703ac3c9b74c",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/centos-8-x86_64.facts
+++ b/facts/4.7/centos-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_eth0": "fe80::5054:ff:fe51:9a78",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 2.98,
     "5m": 2.72
   },
-  "lsbdistrelease": "8",
-  "lsbmajdistrelease": "8",
-  "macaddress": "52:54:00:51:9a:78",
   "macaddress_eth0": "52:54:00:51:9a:78",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.96 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 163921920
     }
   },
-  "memoryfree": "302.45 MiB",
-  "memoryfree_mb": 302.44921875,
-  "memorysize": "458.78 MiB",
-  "memorysize_mb": 458.77734375,
   "mountpoints": {
     "/": {
       "available": "5.74 GiB",
@@ -309,14 +279,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -401,9 +367,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -430,7 +393,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -442,9 +404,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -456,7 +415,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -464,19 +422,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -509,10 +456,6 @@
   "sshfp_ed25519": "SSHFP 4 1 972d968feac4b86c4e4cb1ee4aefba7fb58a0234\nSSHFP 4 2 ffb08ebd30a1302186751d7b7b351cc8748202645db021ea19327da391161a57",
   "sshfp_rsa": "SSHFP 1 1 202258569eb197a958aa61d056e75bc47b2cc245\nSSHFP 1 2 4a8d1cc47e0b9ff6ea5d9b8025c756369048cfc4a037f84a9ef721fb18710594",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDwEylaOHMJp4HUGyjhW1/72Udke+ixH9MXQSA4UHf2BPP8NDa+aRM7L212F7RItRDa6eHAIOHpQ6I0j8Op9ncXv8THAH189F1Fqw7iU26M5me66DMPwtGmRkj5anA5x7RbAFWnmL3qQZjIjnvBEQbOa+uYLGc+DAsDrMNYAfMFUj9j+pfS9P0kWIhW9nAX5HpSP0ZnEBEjNHo8fDgih79zOUQDGBczpwq+KA6CbdNwgmOJjaMgokMWHOA2jhsVN+J0GlKgk7/PCNEg9v+r8yU3xLwKAVSjkfnHvysUCTdmpwGYBhBqtOHIO+yJ1m7NZfwDF2cpQwkgv1W609q3Pg8Oxzf6N9DHwzDklES/RZ44sEBRrXBcl1UkqcP1G4iB7tC7DVOsD4e1StYIhrOCl79yy3525PGJlCGwvU3AwBJcXxoqH0JWeFzDMDCCN51JOXRioabQ2WmaUjJUdjTRVT8vIHUpioNOQ8lIYFWFr5gjwB6A4b7IH4le2sgqs81hqwM=",
-  "swapfree": "1.96 GiB",
-  "swapfree_mb": 2005.21484375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -520,10 +463,5 @@
     "uptime": "0:15 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:15 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 929,
-  "uuid": "f874691c-cc77-b242-863a-3ed44e7be9d3",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/centos-9-x86_64.facts
+++ b/facts/4.7/centos-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,20 +38,13 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_eth0": "fe80::5054:ff:fee2:d4ac",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,11 +67,7 @@
     "1m": 1.16,
     "5m": 0.89
   },
-  "lsbdistrelease": "9",
-  "lsbmajdistrelease": "9",
-  "macaddress": "52:54:00:e2:d4:ac",
   "macaddress_eth0": "52:54:00:e2:d4:ac",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.98 GiB",
@@ -114,10 +88,6 @@
       "used_bytes": 144625664
     }
   },
-  "memoryfree": "319.96 MiB",
-  "memoryfree_mb": 319.95703125,
-  "memorysize": "457.88 MiB",
-  "memorysize_mb": 457.8828125,
   "mountpoints": {
     "/": {
       "available": "5.78 GiB",
@@ -373,14 +343,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -465,9 +431,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "CentOS",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -494,7 +457,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -506,9 +468,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -520,7 +479,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -528,19 +486,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -573,10 +520,6 @@
   "sshfp_ed25519": "SSHFP 4 1 af5c5ea7a5411eb74d4221a067022ec0f0b5029e\nSSHFP 4 2 4e6ce8a4a585f823256b76805f2f8dc5e2c50c1852f84c824d73beae6f1c9d1c",
   "sshfp_rsa": "SSHFP 1 1 65e9d9884187069e4c375bfcd9afc573a2d6838e\nSSHFP 1 2 5c0c48a0736bf32b90d1ab459bfb8cc3473269dea0bf2610c0b3ffd1275dc160",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCjlHjNsifG2yT0VUnV4tmum0v4nKtHX6zdktOaKxqaxPoLYsfPx6b9MyIzFRDeVZvREEwBvJ2x5cXsN9uUll8n5j/3xjJXhhrBqj5FQLso0fdigwrXgXoI4vWdWFs6d3AHd+YIOCv3o1u7+tthoXfjIsDZm6AClA5NFPYtJ8ynbyt+iN6g+AT/rBQxQIX/tEMKrGw7C+gQHwYyI2hoew2mQWfabhsROulmbEqe0LvmJJRwBNanIfTIWqOAkRtt4eCxbqQCOkNGI5ueF6473LTQ3xAaM0fnTLoTKmK5pwvtPQK23TOiLVqpvsblSwis/52hRl1bWKWucZgz7k19AOBT49OT0x3lEZe7M2RUxHNDWlLEN/yK2TY3hL8mOotF8/TVV8Oi+Yw9hi4X7FYG5O2oOrdchf7X04hT+XLbXeSN2rKv5Rz9NEs6t0oAxvRLLQPAOoBEgxajRsc5In1e0ZLXYFnYyAjBDRKZlG1/1rHwheJCStu+cQSpk69BBgXStYs=",
-  "swapfree": "1.98 GiB",
-  "swapfree_mb": 2030.9140625,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -584,10 +527,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 400,
-  "uuid": "811cb5e9-8f36-d940-b355-f98e2438bc09",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/debian-11-x86_64.facts
+++ b/facts/4.7/debian-11-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -52,15 +39,9 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -69,7 +50,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -78,8 +58,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -94,15 +72,7 @@
     "1m": 1.03,
     "5m": 0.8
   },
-  "lsbdistcodename": "bullseye",
-  "lsbdistdescription": "Debian GNU/Linux 11 (bullseye)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "11.9",
-  "lsbmajdistrelease": "11",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "336.14 MiB",
@@ -114,10 +84,6 @@
       "used_bytes": 131092480
     }
   },
-  "memoryfree": "336.14 MiB",
-  "memoryfree_mb": 336.140625,
-  "memorysize": "461.16 MiB",
-  "memorysize_mb": 461.16015625,
   "mountpoints": {
     "/": {
       "available": "90.72 GiB",
@@ -304,14 +270,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -398,9 +360,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11.9",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -425,7 +384,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -437,10 +395,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -453,7 +407,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -461,14 +414,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -508,10 +455,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 433,
-  "uuid": "be037311-7594-41a5-8599-8496211026af",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/debian-12-x86_64.facts
+++ b/facts/4.7/debian-12-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 107374182400,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "eth0": "10.0.2.2",
     "system": "10.0.2.2"
@@ -52,15 +39,9 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
@@ -69,7 +50,6 @@
     "vmware": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -78,8 +58,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_eth0": "fe80::a00:27ff:fe8d:c04d",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -94,15 +72,7 @@
     "1m": 1.18,
     "5m": 0.35
   },
-  "lsbdistcodename": "bookworm",
-  "lsbdistdescription": "Debian GNU/Linux 12 (bookworm)",
-  "lsbdistid": "Debian",
-  "lsbdistrelease": "12.5",
-  "lsbmajdistrelease": "12",
-  "lsbminordistrelease": "5",
-  "macaddress": "08:00:27:8d:c0:4d",
   "macaddress_eth0": "08:00:27:8d:c0:4d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "267.97 MiB",
@@ -114,10 +84,6 @@
       "used_bytes": 198529024
     }
   },
-  "memoryfree": "267.97 MiB",
-  "memoryfree_mb": 267.97265625,
-  "memorysize": "457.30 MiB",
-  "memorysize_mb": 457.3046875,
   "mountpoints": {
     "/": {
       "available": "90.83 GiB",
@@ -385,14 +351,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -479,9 +441,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Debian",
-  "operatingsystemmajrelease": "12",
-  "operatingsystemrelease": "12.5",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -506,7 +465,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -518,10 +476,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -534,7 +488,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -542,14 +495,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -589,10 +536,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 82,
-  "uuid": "4a2212ba-ed4c-4fa5-9b09-b523d43a4b39",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/fedora-36-x86_64.facts
+++ b/facts/4.7/fedora-36-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_eth0": "fe80::a00:27ff:fee4:4caf",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 1.09,
     "5m": 0.64
   },
-  "lsbdistrelease": "36",
-  "lsbmajdistrelease": "36",
-  "macaddress": "08:00:27:e4:4c:af",
   "macaddress_eth0": "08:00:27:e4:4c:af",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 455413760
     }
   },
-  "memoryfree": "1.48 GiB",
-  "memoryfree_mb": 1519.421875,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
   "mountpoints": {
     "/": {
       "available": "121.95 GiB",
@@ -321,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +379,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "36",
-  "operatingsystemrelease": "36",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -443,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -477,10 +439,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -493,26 +451,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -545,10 +491,6 @@
   "sshfp_ed25519": "SSHFP 4 1 48f09e4ea5d2287e3b2a95a7dca7a66025dac3a6\nSSHFP 4 2 8c3d3d9a6b30fecda1b513bd9b2c5204cc7a90512412e482d2b374c2a8978f9f",
   "sshfp_rsa": "SSHFP 1 1 5ed2299e419f63407dd87b96fd216f772c630140\nSSHFP 1 2 481c71b93760a403e68a097a52f7c82e727a6014a01cdf65c2c49231441fa439",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDRGJkg4nKhtzDZ3zEsSn/k6RgVLYse1v0BG72WkZkz9J/hiwiEH2LM+esDEpc3rTGYN9f/nXBuJEnaDxQwaYUMq+36PoXjwRiX9YpEp/WEw+rlSfYnXFlbpTNERapTkxQuN9lTl2oLTp2d69Jnidhl5qZ8OTlckVqmO9v6aSmUMM0vZjUIHOgv04iUQDMkF4ULUDrLtswn9Vo0Mz7C4jnjq64fqtGfNNCoheury03YTy5yrb8zDiQSnXF/4A/eFz3Etij09lZxXvvy2fDl949m9ruLGDmMwDN23XptQZj7nVbg5BLBnDsJSAmXs6Q09nrTV7bxAQbm7NNgd9akRn5mN+htT+y+nuP9CWqZ0QjhMuLjm7YrC6nb2tUYU7JB2zYuiKstcCQFXBpHVBXUBuMvBGbuvsTHqgTntpr5ScGtwbciw7hFdhamM881XyruZw2Uo4ZwSo4879A9lhrzsd8PYn4r5UpQLZ243wHehfCK6Mob/rMiPtFS3BdZYWMveeM=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -556,10 +498,5 @@
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:04 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 257,
-  "uuid": "c16bb4a7-9b55-1a42-8433-2bf91a8be296",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/fedora-37-x86_64.facts
+++ b/facts/4.7/fedora-37-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_eth0": "fe80::a00:27ff:feb2:207b",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 0.92,
     "5m": 0.41
   },
-  "lsbdistrelease": "37",
-  "lsbmajdistrelease": "37",
-  "macaddress": "08:00:27:b2:20:7b",
   "macaddress_eth0": "08:00:27:b2:20:7b",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 433733632
     }
   },
-  "memoryfree": "1.50 GiB",
-  "memoryfree_mb": 1539.80859375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.44921875,
   "mountpoints": {
     "/": {
       "available": "121.89 GiB",
@@ -321,14 +291,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +379,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "37",
-  "operatingsystemrelease": "37",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -443,7 +406,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/fedora-root": {
       "filesystem": "xfs",
@@ -482,10 +444,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -498,26 +456,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -550,10 +496,6 @@
   "sshfp_ed25519": "SSHFP 4 1 16dcf5a9a6a640b2289c552f6737ba5a56f69ef9\nSSHFP 4 2 aad7252460b77f70e785eb057748a7c28dd0ef2dd58ce409d7175dc91e194993",
   "sshfp_rsa": "SSHFP 1 1 fff088764bc3ffe2123a5b82589ebf9969c0cd19\nSSHFP 1 2 f68ee4a98bbcc34c59c10b167af05f278ded996cffa89c5ff1611efa7bd4a456",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC6mSOGV9B5DbXB/XA1aCM/27WbBlebB9W67ctvSnUHLlLACRq4JE+WZxRwdivsa8PakrbWoSKNZZkYr0a7TO5nTmptp/oVY7593dUm8yXbPmqZ8eSn0x71tYdm7f9E/jbC2wVJcqv0woEk90vTBpEvbtKHx9jrLWeuLxk8OsNIZMh9hmTOYBJ5C6p1whvpA5d9L+dkUAlK/m24Qf5sK+Xoab23+gVAHBREtmLYJ/rekvUEZ7R+widrcuCUFnTHBh8225nStpPOf15RBcJwzb2ce/Sm5gu2cRK9++L5TMJoXWexoWJDVtT044bBgT/Vz1w1OLtRkaZPcQTdap6dMhfjlC6w7kA7ncPoxskOm463om++Ok0UDplb5tQuiTAOPAazOhHRhnYYEjXg87PQHt+JJVE3PdA1MuTCtnWAqj5N+4IjwWMa3XZrx90GBeFRdDY/3qXe/0pwR2+e/LIE7Zg8eprHc8IWQa3DAIxY+EyocJ/xILNGtLZYj/aCiY2Rf7U=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -561,10 +503,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 184,
-  "uuid": "9ca995a5-712c-aa41-bee8-21a17e35b189",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/fedora-38-x86_64.facts
+++ b/facts/4.7/fedora-38-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 0.37,
     "5m": 0.28
   },
-  "lsbdistrelease": "38",
-  "lsbmajdistrelease": "38",
-  "macaddress": "52:54:00:d6:6b:09",
   "macaddress_eth0": "52:54:00:d6:6b:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 333180928
     }
   },
-  "memoryfree": "1.60 GiB",
-  "memoryfree_mb": 1636.24609375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
       "available": "37.64 GiB",
@@ -440,14 +410,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -532,9 +498,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "38",
-  "operatingsystemrelease": "38",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -562,7 +525,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
@@ -602,9 +564,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -616,26 +575,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -668,10 +615,6 @@
   "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
   "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -679,10 +622,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 583,
-  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/fedora-39-x86_64.facts
+++ b/facts/4.7/fedora-39-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.13.0"
   },
-  "augeasversion": "1.13.0",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -50,23 +37,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "unknown",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,11 +69,7 @@
     "1m": 0.97,
     "5m": 0.45
   },
-  "lsbdistrelease": "39",
-  "lsbmajdistrelease": "39",
-  "macaddress": "52:54:00:52:8d:1d",
   "macaddress_eth0": "52:54:00:52:8d:1d",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "1.91 GiB",
@@ -116,10 +90,6 @@
       "used_bytes": 339255296
     }
   },
-  "memoryfree": "1.59 GiB",
-  "memoryfree_mb": 1630.19140625,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
       "available": "37.63 GiB",
@@ -363,14 +333,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -455,9 +421,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Fedora",
-  "operatingsystemmajrelease": "39",
-  "operatingsystemrelease": "39",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -485,7 +448,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
@@ -525,9 +487,6 @@
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -539,26 +498,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -591,10 +538,6 @@
   "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
   "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
-  "swapfree": "1.91 GiB",
-  "swapfree_mb": 1952.99609375,
-  "swapsize": "1.91 GiB",
-  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -602,10 +545,5 @@
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:03 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 184,
-  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/gentoo-2-x86_64.facts
+++ b/facts/4.7/gentoo-2-x86_64.facts
@@ -1,20 +1,7 @@
 {
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -49,23 +36,16 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
   "gem_version": "~> 4.7.0",
-  "gid": "root",
-  "hardwareisa": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -74,8 +54,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_eth0": "fe80::a00:27ff:fe3c:62a0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -90,16 +68,7 @@
     "1m": 0.17,
     "5m": 0.24
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Gentoo Linux",
-  "lsbdistid": "Gentoo",
-  "lsbdistrelease": "2.14",
-  "lsbmajdistrelease": "2",
-  "lsbminordistrelease": "14",
-  "lsbrelease": "n/a",
-  "macaddress": "08:00:27:3c:62:a0",
   "macaddress_eth0": "08:00:27:3c:62:a0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "3.82 GiB",
@@ -120,10 +89,6 @@
       "used_bytes": 342712320
     }
   },
-  "memoryfree": "3.50 GiB",
-  "memoryfree_mb": 3583.09375,
-  "memorysize": "3.82 GiB",
-  "memorysize_mb": 3909.9296875,
   "mountpoints": {
     "/": {
       "available": "111.40 GiB",
@@ -293,14 +258,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -385,9 +346,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Gentoo",
-  "operatingsystemmajrelease": "2",
-  "operatingsystemrelease": "2.14",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -413,7 +371,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Gentoo",
   "partitions": {
     "/dev/sda1": {
       "partlabel": "EFI",
@@ -449,12 +406,6 @@
     }
   },
   "path": "/vagrant/vendor/bundler/ruby/3.1.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor2": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor3": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 4,
   "processors": {
     "cores": 4,
     "count": 4,
@@ -469,21 +420,14 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
     "version": "3.1.4"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/usr/lib64/ruby/site_ruby/3.1.0",
-  "rubyversion": "3.1.4",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -516,10 +460,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dd18c27339e48c23c2cf985b021980bb3949e619\nSSHFP 4 2 68df2d7857198d81f1e3a068ad621cd684159e4c954682bc56319ee693ea33d5",
   "sshfp_rsa": "SSHFP 1 1 0ac295631b0665c9a828f925608361e4de0a69cc\nSSHFP 1 2 86064ffcac44d8716c15989b7b1fc4ee09a9ea785cbcce113c80e69ecf50c289",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC4vp7qdQoKpDfSf/0HaOwFvcfVNRTCaFCvaVgnd2I5u5jyxfJYFBfhUUxZOtlYGbDn3jgfIKdOs0ZEDQIJgyQIoXKw64EldilfJmH6SgSluw7OGNj45tzhPllllDIxmIgkNj6oZ2FK8CChRsKI2cUMWTnQCTEoU4Dzupj/u1vltUOMW9xf65jQ5GFBnNRHFY9Fzu4YF4L+x/ioqs/M7PNHcuJVmW5rkGRKk30oxmBuT0Xycfs57vT0wQUvMimwM6FzKFwczs/kDtBXcYCiUv3cN5OoQZv7OEYczRcgRBUrgBhVfYNPHm8I60DhNxNbgRcGtsd2diHzGKZZ8FIO0UciRQswhmMGIZbPlMflysefmYYNbrESI/DcwR46K82PWhYySy+OVWBnxJQ5LmjKzZsM+5DApcAIWk0iANrJhI3Z3udoy7E9XV/KBVFjS2m+sONMBNgCINj9F2OgFkINgCZXIZ7VV+BkuqBLOPH1bZXThBitHUsHOl18GQN/qpa+9p8=",
-  "swapfree": "3.82 GiB",
-  "swapfree_mb": 3906.99609375,
-  "swapsize": "3.82 GiB",
-  "swapsize_mb": 3906.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 1,
@@ -527,10 +467,5 @@
     "uptime": "1:17 hours"
   },
   "timezone": "UTC",
-  "uptime": "1:17 hours",
-  "uptime_days": 0,
-  "uptime_hours": 1,
-  "uptime_seconds": 4658,
-  "uuid": "ff6e1f78-e753-b843-9f40-5e4f6d4ff510",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/openbsd-7-x86_64.facts
+++ b/facts/4.7/openbsd-7-x86_64.facts
@@ -1,6 +1,4 @@
 {
-  "architecture": "amd64",
-  "bios_vendor": "OpenBSD",
   "dmi": {
     "bios": {
       "vendor": "OpenBSD"
@@ -10,14 +8,7 @@
       "name": "VMM"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
-  "fqdn": "foo.example.com",
-  "gid": "wheel",
-  "hardwareisa": "amd64",
-  "hardwaremodel": "amd64",
-  "hostname": "foo",
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "wheel",
@@ -25,8 +16,6 @@
     "uid": 0,
     "user": "root"
   },
-  "ipaddress": "10.0.0.1",
-  "ipaddress6": "2aa1:1470:5ab6::a00:1",
   "is_virtual": true,
   "kernel": "OpenBSD",
   "kernelmajversion": "7",
@@ -37,8 +26,6 @@
     "1m": 0.138671875,
     "5m": 0.10546875
   },
-  "macaddress": "08:00:66:66:16:a1",
-  "manufacturer": "OpenBSD",
   "mountpoints": {
     "/": {
       "available": "842.44 MiB",
@@ -182,10 +169,6 @@
       "used_bytes": 9838592
     }
   },
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
-  "network": "10.0.0.0",
-  "network6": "2aa1:1470:5ab6::",
   "networking": {
     "dhcp": "10.0.0.59",
     "domain": "example.com",
@@ -272,9 +255,6 @@
     "primary": "vio0",
     "scope6": "global"
   },
-  "operatingsystem": "OpenBSD",
-  "operatingsystemmajrelease": "7",
-  "operatingsystemrelease": "7.5",
   "os": {
     "architecture": "amd64",
     "family": "OpenBSD",
@@ -286,10 +266,7 @@
       "minor": "5"
     }
   },
-  "osfamily": "OpenBSD",
   "path": "/sbin:/usr/sbin:/bin:/usr/bin:/usr/X11R6/bin:/usr/local/sbin:/usr/local/bin",
-  "processor0": "Intel(R) Atom(TM) CPU C2750 @ 2.40GHz",
-  "processorcount": 1,
   "processors": {
     "count": 1,
     "isa": "amd64",
@@ -298,15 +275,11 @@
     ],
     "speed": "2.40 GHz"
   },
-  "productname": "VMM",
   "ruby": {
     "platform": "x86_64-openbsd",
     "sitedir": "/usr/local/lib/ruby/site_ruby/3.2",
     "version": "3.2.4"
   },
-  "rubyplatform": "x86_64-openbsd",
-  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.2",
-  "rubyversion": "3.2.4",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -356,9 +329,5 @@
     "uptime": "0:16 hours"
   },
   "timezone": "CEST",
-  "uptime": "0:16 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 964,
   "virtual": "vmm"
 }

--- a/facts/4.7/opensuse-15-x86_64.facts
+++ b/facts/4.7/opensuse-15-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 45097156608,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,20 +38,13 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "ext2,ext3,ext4",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -73,8 +53,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe02:113f",
   "ipaddress6_eth0": "fe80::a00:27ff:fe02:113f",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -89,12 +67,7 @@
     "1m": 0.76,
     "5m": 0.3
   },
-  "lsbdistrelease": "15.4",
-  "lsbmajdistrelease": "15",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:02:11:3f",
   "macaddress_eth0": "08:00:27:02:11:3f",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "672.99 MiB",
@@ -106,10 +79,6 @@
       "used_bytes": 291205120
     }
   },
-  "memoryfree": "672.99 MiB",
-  "memoryfree_mb": 672.9921875,
-  "memorysize": "950.71 MiB",
-  "memorysize_mb": 950.70703125,
   "mountpoints": {
     "/": {
       "available": "37.50 GiB",
@@ -321,14 +290,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -413,9 +378,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "openSUSE",
-  "operatingsystemmajrelease": "15",
-  "operatingsystemrelease": "15.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -440,7 +402,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Suse",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -453,9 +414,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 1,
   "processors": {
     "cores": 1,
     "count": 1,
@@ -467,7 +425,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -475,14 +432,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -532,10 +483,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 164,
-  "uuid": "95ee16a2-96bf-c74e-8bc9-b20f4e0d8454",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/oraclelinux-8-x86_64.facts
+++ b/facts/4.7/oraclelinux-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_eth0": "fe80::9794:7075:7850:ad0c",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,16 +69,7 @@
     "1m": 0.32,
     "5m": 0.29
   },
-  "lsbdistcodename": "n/a",
-  "lsbdistdescription": "Oracle Linux Server release 8.9",
-  "lsbdistid": "OracleServer",
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
-  "macaddress": "08:00:27:14:27:05",
   "macaddress_eth0": "08:00:27:14:27:05",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -121,10 +90,6 @@
       "used_bytes": 531324928
     }
   },
-  "memoryfree": "1.15 GiB",
-  "memoryfree_mb": 1173.4765625,
-  "memorysize": "1.64 GiB",
-  "memorysize_mb": 1680.1875,
   "mountpoints": {
     "/": {
       "available": "57.49 GiB",
@@ -338,14 +303,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -430,9 +391,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -463,7 +421,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
@@ -482,10 +439,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -498,7 +451,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -506,19 +458,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -551,10 +492,6 @@
   "sshfp_ed25519": "SSHFP 4 1 de5b1ba064c808e938c843f2791b85d7a9ddd313\nSSHFP 4 2 7b8b8985b248c027edcab5d85d6b88ff91bbae4ef9d41db7e99163400892e85f",
   "sshfp_rsa": "SSHFP 1 1 df37431d9ea1fb5f9d0f7086b7644514e93a786c\nSSHFP 1 2 daa7bdfedd44dfd625c631250213584261c1f2cca2dc4106e67fc6ed69b7d72f",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDIWh8Ism8vmAG6N7OkgqLlylyYTLYBoM4LEf3uhLa9g+o9LsUqtmKZxvlqqt37me3suHAkSi2qS6tAFNpvSeFQCzl2UhUL7quELTEtwIYiQH/t826t6yfKUbX8UiCovAKbvs7uf4SNniL9I33IDhCezQphBYweOxmjZ9Hv8xTOWTHMCLDZd/TuBkTodXQmikKx3IpSG+/5InETmuLlr1iqBoFu+T/0WQ+elMlghn1qMgLGYwQUpTX9Ix0dZy5tMsUZdB+OjGRHghPolEVMbKUliXvRrHX2iN1fmUE23Dvn17jzerYAgrxZvJVivCPNkSFramAl5150XslwkxRm+u/bfPD7hX3H8SsbUEy5vNFpuku0b4aInVT1WNAd0Q5he8tG8lOPmr1QDyUtXs8FFB+znzi3z0hPchTQ9KDZIguYHR178wsOezN7lYqhCj41Pz8xoVUUBx9nwMoPRJYIDcuPT7tvtXewvFK7KDkISCmqTuXeP3mf/dFZP4MFIv3Xukc=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2084.47265625,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2086.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -562,10 +499,5 @@
     "uptime": "0:10 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:10 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 637,
-  "uuid": "cadef7b9-dae6-5f4a-81a5-b8600e1832c8",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/oraclelinux-9-x86_64.facts
+++ b/facts/4.7/oraclelinux-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 68719476736,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs,zonefs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_eth0": "fe80::1dba:23aa:d73b:76b9",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.99,
     "5m": 0.44
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:9d:8c:b7",
   "macaddress_eth0": "08:00:27:9d:8c:b7",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "991.17 MiB",
@@ -108,10 +81,6 @@
       "used_bytes": 546267136
     }
   },
-  "memoryfree": "991.17 MiB",
-  "memoryfree_mb": 991.16796875,
-  "memorysize": "1.48 GiB",
-  "memorysize_mb": 1512.12890625,
   "mountpoints": {
     "/": {
       "available": "60.47 GiB",
@@ -371,14 +340,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -463,9 +428,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "OracleLinux",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -495,7 +457,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "xfs",
@@ -507,10 +468,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -523,7 +480,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -531,19 +487,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "permissive",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "permissive",
-  "selinux_enforced": false,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -583,10 +528,5 @@
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:02 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 156,
-  "uuid": "20e53e80-d156-cd47-a0db-27f20791b93a",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/redhat-8-x86_64.facts
+++ b/facts/4.7/redhat-8-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_eth0": "fe80::a00:27ff:fe06:c1d2",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.03,
     "5m": 1.02
   },
-  "lsbdistrelease": "8.9",
-  "lsbmajdistrelease": "8",
-  "lsbminordistrelease": "9",
-  "macaddress": "08:00:27:06:c1:d2",
   "macaddress_eth0": "08:00:27:06:c1:d2",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 472412160
     }
   },
-  "memoryfree": "1.28 GiB",
-  "memoryfree_mb": 1315.8359375,
-  "memorysize": "1.72 GiB",
-  "memorysize_mb": 1766.36328125,
   "mountpoints": {
     "/": {
       "available": "66.94 GiB",
@@ -335,14 +304,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -427,9 +392,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "8",
-  "operatingsystemrelease": "8.9",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -459,7 +421,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel8-root": {
       "filesystem": "xfs",
@@ -491,10 +452,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -507,7 +464,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -515,19 +471,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -560,10 +505,6 @@
   "sshfp_ed25519": "SSHFP 4 1 6d6b29484335da8a668b7576bafe8718b95a430f\nSSHFP 4 2 e5de0ce5b7f9c96be503d240e6660a599d5a3a741c6afb4c548aee2343ba0f39",
   "sshfp_rsa": "SSHFP 1 1 6c2597d7efba88c939b0495af57dd35e3b0a4803\nSSHFP 1 2 b5a2e631007f6b010a8bfc4d78c0dc69f0630d7a43ec98d1ca2d3cfbc3779187",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCpjkSDJk7fJcQBgkeVhcFPaFPxiKaUbCQyG50RuMqr3t/FjdCvInUIXOhcLjPEWDZ0UlCXU7LlwTmWZL75nTDDDR1BDzvodkXm7adbEonrm2MyAAF9Cr8+6bZoQ2OZPHCfufLk98nlIrxBnKZf71tO9BNZKp0kZxjMfs7J5Z6UIt8/nL99rVVOWUYBbPv3vtzIXRwzqI7Pd88OI26Nh2X+jD0MZJBk1s836mvb8hvZ2QmFs2hOimVKXHxdzp2NlbU/l0PoxK//hSKzkWtR7La1XbgUnRiTg0aABINxcuCG/f7Jpazr4UmBpQNGnU9Da3DYmC2PEhf3qLlO1DxUOiv2UawOEtGnSX60G79MvgtHEnO7DHWe4vLq6Rt8UeZFmWAuLP9rZhs9UAi0wweAvKaOTa9fYSojCGkbJcCFc6ESQc7jkzPKA9oFwE0qUkKLzKlH2AFxczwDDA6wMAZMjT7DVin0HMr/R/TYaSmp4qul492yNgtgUgmFxzfD9nEHXQU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2087.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2087.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -571,10 +512,5 @@
     "uptime": "0:13 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:13 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 825,
-  "uuid": "12efa474-895f-a643-b3b9-72f68b8e036a",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/redhat-9-x86_64.facts
+++ b/facts/4.7/redhat-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_eth0": "fe80::a00:27ff:fe5f:a709",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 0.95,
     "5m": 0.81
   },
-  "lsbdistrelease": "9.3",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "3",
-  "macaddress": "08:00:27:5f:a7:09",
   "macaddress_eth0": "08:00:27:5f:a7:09",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.04 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 483254272
     }
   },
-  "memoryfree": "1.46 GiB",
-  "memoryfree_mb": 1494.859375,
-  "memorysize": "1.91 GiB",
-  "memorysize_mb": 1955.7265625,
   "mountpoints": {
     "/": {
       "available": "67.44 GiB",
@@ -386,14 +355,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -478,9 +443,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "RedHat",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.3",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -510,7 +472,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/mapper/rhel_rhel9-root": {
       "filesystem": "xfs",
@@ -542,10 +503,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -558,7 +515,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -566,19 +522,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -611,10 +556,6 @@
   "sshfp_ed25519": "SSHFP 4 1 1e747319ecad455a6d8a0231468f8431665c87e5\nSSHFP 4 2 e576a8dac880d5fa6a6c697704c52e02ce7ae29eb0562ee2872f5eabf860b62d",
   "sshfp_rsa": "SSHFP 1 1 7ca7e5cfac08a4542cfc1464ce8f9b4eda2468ab\nSSHFP 1 2 abfdfc0835474bdab9fd754ebee9abfb3dfb6000246e070caa905d3d8a3298fb",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDW31ZI9SW8GxpQyIH3hNx523EBUWyS9Ecaas76XIMN9Yk0k+5ft/i/Zn3YPaF0Die2imFMXlKvSvaqNWMfffWjDDP8Ms4BVQhG86Aea9rfFLZNT1XNxivFr9JHU7z5k66oKuoAedA0XqmsUdQVneCCSNjxKPPRHzn+yOEA2sg7MpMnDW/MMuFWp0CcC8R7tu4f2x/FG/mxX5uooeLsPvxyqnYAaz8KHR2svRFExz2C7HesA4/dQrJB/gGbBUWVacIHzuD3SJ3Ueth/V/FEkCTTzKoV9fhWkNcwt8X8//uDaaLtvh5ibJj5uHfLQu6mThgYWJyGwJNQ1N9SzZTc2wJQj/OsEaqJLNRPOUZ/1ESTB+Q2vBEDXcIzA6fTY8u+HbyVAOXNGaZb8E7V57JRZKkI5sbdBp2c0FS3x3TSUBctxdCpffvMdJC+YSrhw8xuv5q1B7iXPFJ1aug79Wz8COa9RoRtjVgPBU7zOHSPHn0eWEoTi1JAu0VtxPmBUoZU3NU=",
-  "swapfree": "2.04 GiB",
-  "swapfree_mb": 2083.99609375,
-  "swapsize": "2.04 GiB",
-  "swapsize_mb": 2083.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -622,10 +563,5 @@
     "uptime": "0:11 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:11 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 701,
-  "uuid": "9ddeb5b2-50ae-8c40-98d3-4c61dbbcff2f",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/rocky-9-x86_64.facts
+++ b/facts/4.7/rocky-9-x86_64.facts
@@ -1,21 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x86_64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 10737418240,
-  "blockdevice_sda_vendor": "ATA",
-  "blockdevices": "sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "system": null
   },
@@ -51,22 +38,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "vfat,xfs",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -75,8 +55,6 @@
     "user": "root"
   },
   "interfaces": "eth0,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_eth0": "fe80::a00:27ff:fefc:e996",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
@@ -91,12 +69,7 @@
     "1m": 1.17,
     "5m": 0.96
   },
-  "lsbdistrelease": "9.4",
-  "lsbmajdistrelease": "9",
-  "lsbminordistrelease": "4",
-  "macaddress": "08:00:27:fc:e9:96",
   "macaddress_eth0": "08:00:27:fc:e9:96",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
       "available": "2.00 GiB",
@@ -117,10 +90,6 @@
       "used_bytes": 524771328
     }
   },
-  "memoryfree": "7.27 GiB",
-  "memoryfree_mb": 7441.24609375,
-  "memorysize": "7.76 GiB",
-  "memorysize_mb": 7941.70703125,
   "mountpoints": {
     "/": {
       "available": "4.22 GiB",
@@ -442,14 +411,10 @@
   },
   "mtu_eth0": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_eth0": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_eth0": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_eth0": "fe80::",
   "network6_lo": "::1",
   "network_eth0": "10.0.2.0",
@@ -534,9 +499,6 @@
     "primary": "eth0",
     "scope6": "link"
   },
-  "operatingsystem": "Rocky",
-  "operatingsystemmajrelease": "9",
-  "operatingsystemrelease": "9.4",
   "os": {
     "architecture": "x86_64",
     "distro": {
@@ -566,7 +528,6 @@
       "policy_version": "33"
     }
   },
-  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "vfat",
@@ -606,10 +567,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -622,7 +579,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -630,19 +586,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
-  "selinux": true,
-  "selinux_config_mode": "enforcing",
-  "selinux_config_policy": "targeted",
-  "selinux_current_mode": "enforcing",
-  "selinux_enforced": true,
-  "selinux_policyversion": "33",
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -675,10 +620,6 @@
   "sshfp_ed25519": "SSHFP 4 1 dc9a202428b5dfcac62a608183f38b290637b2f1\nSSHFP 4 2 dbae37fd75a42b481971b43780f4c1ed090812c78ad2e28fa9472efa650e058d",
   "sshfp_rsa": "SSHFP 1 1 6e2528fb7dcff5b80e8d5aba460756b1b8f5c9de\nSSHFP 1 2 cf616c88e4b14d51d025a163a5a51ddca4c7cfcca9cb40f8a6af3faf82006190",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDmgftqacce9cKgNGKor9BVjKloJuEa7sw4ju1hQgDxyl7mM/MqJSV654LrwuKJ4bqHm1Zni23G6aUqtFEV6YrvOSKQRiUIFuWa3LN6wyLDK0veW/AVWbnezV/Es1kCDbtdL4S7mvH3fOkdmJmliAxkF7j5hqiIjMy+SkJUiAPJKtEAxPgwsbjEm9TWg+tHqe0d0g4zu70BY8c1GCj1kRJEvhu6LkUYklh5wMGwY4Qs37Qmme0oOw8ihG+SiaevdMvEuYMSHNpnWy2GMlxpQAriksrkxgqJrKqiHkW38pIo6HBwbO3omrHFsrKKRsISBpAcqNl6hVoXfQBswQiHDiV9vznfLx0OF84oqEERqdjTHzSW27fzojvPRRB1wrcMoeYCmQAre4S31ZMdD4ShtL3z/7Z14gQyJE5AM0YXiS1GJ2RpPYIcVdQc8qRW/anRE6dzhEDvdCp0qttNz8N61L6S5g+9SZufKz0HXxUVxXOPnFUr3AWoe/unf8/j743nVvk=",
-  "swapfree": "2.00 GiB",
-  "swapfree_mb": 2047.99609375,
-  "swapsize": "2.00 GiB",
-  "swapsize_mb": 2047.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -686,10 +627,5 @@
     "uptime": "0:09 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:09 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 561,
-  "uuid": "eb6255a4-2ead-254e-801f-695cdbf50b33",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/ubuntu-20.04-x86_64.facts
+++ b/facts/4.7/ubuntu-20.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -61,22 +45,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::e9:94ff:fee1:d413",
   "ipaddress6_enp0s3": "fe80::e9:94ff:fee1:d413",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 0.76,
     "5m": 0.26
   },
-  "lsbdistcodename": "focal",
-  "lsbdistdescription": "Ubuntu 20.04.6 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "20.04",
-  "lsbmajdistrelease": "20.04",
-  "macaddress": "02:e9:94:e1:d4:13",
   "macaddress_enp0s3": "02:e9:94:e1:d4:13",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "592.66 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 390287360
     }
   },
-  "memoryfree": "592.66 MiB",
-  "memoryfree_mb": 592.65625,
-  "memorysize": "964.86 MiB",
-  "memorysize_mb": 964.86328125,
   "mountpoints": {
     "/": {
       "available": "36.79 GiB",
@@ -412,14 +376,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -506,9 +466,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "20.04",
-  "operatingsystemrelease": "20.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -531,7 +488,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/lxd_24061.snap",
@@ -565,10 +521,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -581,7 +533,6 @@
     "speed": "3.20 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -589,14 +540,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -646,10 +591,5 @@
     "uptime": "0:01 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 78,
-  "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/ubuntu-22.04-x86_64.facts
+++ b/facts/4.7/ubuntu-22.04-x86_64.facts
@@ -1,24 +1,8 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "amd64",
   "augeas": {
     "version": "1.14.1"
   },
-  "augeasversion": "1.14.1",
-  "bios_release_date": "12/01/2006",
-  "bios_vendor": "innotek GmbH",
-  "bios_version": "VirtualBox",
-  "blockdevice_sda_model": "HARDDISK",
-  "blockdevice_sda_size": 42949672960,
-  "blockdevice_sda_vendor": "VBOX",
-  "blockdevice_sdb_model": "HARDDISK",
-  "blockdevice_sdb_size": 10485760,
-  "blockdevice_sdb_vendor": "VBOX",
-  "blockdevices": "sdb,sda",
-  "boardmanufacturer": "Oracle Corporation",
-  "boardproductname": "VirtualBox",
-  "boardserialnumber": "0",
-  "chassistype": "Other",
   "dhcp_servers": {
     "enp0s3": "10.0.2.2",
     "system": "10.0.2.2"
@@ -61,22 +45,15 @@
       "version": "1.2"
     }
   },
-  "domain": "example.com",
   "facterversion": "4.7.0",
   "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "gid": "root",
-  "hardwareisa": "x86_64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "162988",
       "version": "7.0.18"
     }
   },
-  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -85,8 +62,6 @@
     "user": "root"
   },
   "interfaces": "enp0s3,lo",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_enp0s3": "fe80::92:d8ff:fe07:a3a8",
   "ipaddress6_lo": "::1",
   "ipaddress_enp0s3": "10.0.2.15",
@@ -101,14 +76,7 @@
     "1m": 0.99,
     "5m": 0.85
   },
-  "lsbdistcodename": "jammy",
-  "lsbdistdescription": "Ubuntu 22.04.4 LTS",
-  "lsbdistid": "Ubuntu",
-  "lsbdistrelease": "22.04",
-  "lsbmajdistrelease": "22.04",
-  "macaddress": "02:92:d8:07:a3:a8",
   "macaddress_enp0s3": "02:92:d8:07:a3:a8",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "549.80 MiB",
@@ -120,10 +88,6 @@
       "used_bytes": 427270144
     }
   },
-  "memoryfree": "549.80 MiB",
-  "memoryfree_mb": 549.80078125,
-  "memorysize": "957.28 MiB",
-  "memorysize_mb": 957.27734375,
   "mountpoints": {
     "/": {
       "available": "35.86 GiB",
@@ -420,14 +384,10 @@
   },
   "mtu_enp0s3": 1500,
   "mtu_lo": 65536,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
   "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
   "netmask_enp0s3": "255.255.255.0",
   "netmask_lo": "255.0.0.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_enp0s3": "fe80::",
   "network6_lo": "::1",
   "network_enp0s3": "10.0.2.0",
@@ -514,9 +474,6 @@
     "primary": "enp0s3",
     "scope6": "link"
   },
-  "operatingsystem": "Ubuntu",
-  "operatingsystemmajrelease": "22.04",
-  "operatingsystemrelease": "22.04",
   "os": {
     "architecture": "amd64",
     "distro": {
@@ -539,7 +496,6 @@
       "enabled": false
     }
   },
-  "osfamily": "Debian",
   "partitions": {
     "/dev/loop0": {
       "backing_file": "/var/lib/snapd/snaps/core20_2264.snap",
@@ -573,10 +529,6 @@
     }
   },
   "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
-  "physicalprocessorcount": 1,
-  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processor1": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -589,7 +541,6 @@
     "speed": "1.70 GHz",
     "threads": 1
   },
-  "productname": "VirtualBox",
   "productversion": "1.2",
   "puppetversion": "8.6.0",
   "ruby": {
@@ -597,14 +548,8 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x86_64-linux",
-  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_enp0s3": "link",
   "scope6_lo": "host",
-  "selinux": false,
-  "serialnumber": "0",
   "ssh": {
     "ecdsa": {
       "fingerprints": {
@@ -644,10 +589,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 379,
-  "uuid": "f2d81de8-f145-df41-ab40-15d35ed37d42",
   "virtual": "virtualbox"
 }

--- a/facts/4.7/windows-10-x86_64.facts
+++ b/facts/4.7/windows-10-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.7.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.19045",
   "kernelversion": "10.0.19045",
-  "macaddress": "08:00:27:85:56:BC",
   "macaddress_Ethernet": "08:00:27:85:56:BC",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.53 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1557131264
     }
   },
-  "memoryfree": "2.53 GiB",
-  "memoryfree_mb": 2594.6953125,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "10",
-  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.6.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
   "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 427,
-  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
-  "virtual": "virtualbox",
-  "windows_display_version": "22H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "22H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.7/windows-11-x86_64.facts
+++ b/facts/4.7/windows-11-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.7.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::f72f:511:e1c3:e451",
   "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.22631",
   "kernelversion": "10.0.22631",
-  "macaddress": "08:00:27:02:6D:35",
   "macaddress_Ethernet": "08:00:27:02:6D:35",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "2.38 GiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1724084224
     }
   },
-  "memoryfree": "2.38 GiB",
-  "memoryfree_mb": 2435.4765625,
-  "memorysize": "3.98 GiB",
-  "memorysize_mb": 4079.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "11",
-  "operatingsystemrelease": "11",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.6.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
   "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:07 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:07 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 422,
-  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
-  "virtual": "virtualbox",
-  "windows_display_version": "23H2",
-  "windows_edition_id": "EnterpriseEval",
-  "windows_installation_type": "Client",
-  "windows_product_name": "Windows 10 Enterprise Evaluation",
-  "windows_release_id": "23H2"
+  "virtual": "virtualbox"
 }

--- a/facts/4.7/windows-2019-x86_64.facts
+++ b/facts/4.7/windows-2019-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.7.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::5156:1072:2404:1e7f",
   "ipaddress6_Ethernet": "fe80::5156:1072:2404:1e7f",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.17763",
   "kernelversion": "10.0.17763",
-  "macaddress": "08:00:27:E5:87:1C",
   "macaddress_Ethernet": "08:00:27:E5:87:1C",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "1018.89 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1061994496
     }
   },
-  "memoryfree": "1018.89 MiB",
-  "memoryfree_mb": 1018.89453125,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2019",
-  "operatingsystemrelease": "2019",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -134,11 +112,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -149,19 +123,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.6.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -204,7 +172,6 @@
   "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
   "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -212,14 +179,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 377,
-  "uuid": "D30E43A8-C27A-4EA3-8C40-808DDE5CE052",
-  "virtual": "virtualbox",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2019 Standard Evaluation",
-  "windows_release_id": "1809"
+  "virtual": "virtualbox"
 }

--- a/facts/4.7/windows-2022-x86_64.facts
+++ b/facts/4.7/windows-2022-x86_64.facts
@@ -1,6 +1,5 @@
 {
   "aio_agent_version": "8.6.0",
-  "architecture": "x64",
   "dhcp_servers": {
     "Ethernet": "10.0.2.2",
     "system": "10.0.2.2"
@@ -13,28 +12,20 @@
       "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
     }
   },
-  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "4.7.0",
   "fips_enabled": false,
-  "fqdn": "foo.example.com",
-  "hardwareisa": "x64",
-  "hardwaremodel": "x86_64",
-  "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
       "revision": "161095",
       "version": "7.0.14"
     }
   },
-  "id": "FOO\\vagrant",
   "identity": {
     "privileged": true,
     "user": "FOO\\vagrant"
   },
   "interfaces": "Ethernet",
-  "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::8d97:e947:bec7:8686",
   "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
   "ipaddress_Ethernet": "10.0.2.15",
   "is_virtual": true,
@@ -42,9 +33,7 @@
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.20348",
   "kernelversion": "10.0.20348",
-  "macaddress": "08:00:27:E7:59:F0",
   "macaddress_Ethernet": "08:00:27:E7:59:F0",
-  "manufacturer": "innotek GmbH",
   "memory": {
     "system": {
       "available": "957.90 MiB",
@@ -56,17 +45,9 @@
       "used_bytes": 1125953536
     }
   },
-  "memoryfree": "957.90 MiB",
-  "memoryfree_mb": 957.8984375,
-  "memorysize": "1.98 GiB",
-  "memorysize_mb": 2031.69140625,
   "mtu_Ethernet": 1500,
-  "netmask": "255.255.255.0",
-  "netmask6": "ffff:ffff:ffff:ffff::",
   "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
   "netmask_Ethernet": "255.255.255.0",
-  "network": "10.0.2.0",
-  "network6": "fe80::",
   "network6_Ethernet": "fe80::",
   "network_Ethernet": "10.0.2.0",
   "networking": {
@@ -114,9 +95,6 @@
     "primary": "Ethernet",
     "scope6": "link"
   },
-  "operatingsystem": "windows",
-  "operatingsystemmajrelease": "2022",
-  "operatingsystemrelease": "2022",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -135,11 +113,7 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
-  "physicalprocessorcount": 1,
-  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
-  "processorcount": 2,
   "processors": {
     "cores": 2,
     "count": 2,
@@ -150,19 +124,13 @@
     "physicalcount": 1,
     "threads": 1
   },
-  "productname": "VirtualBox",
   "puppetversion": "8.6.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
     "version": "3.2.3"
   },
-  "rubyplatform": "x64-mingw32",
-  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
-  "rubyversion": "3.2.3",
-  "scope6": "link",
   "scope6_Ethernet": "link",
-  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -205,7 +173,6 @@
   "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
   "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
   "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
-  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
@@ -213,15 +180,5 @@
     "uptime": "0:06 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "uptime": "0:06 hours",
-  "uptime_days": 0,
-  "uptime_hours": 0,
-  "uptime_seconds": 376,
-  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
-  "virtual": "virtualbox",
-  "windows_display_version": "21H2",
-  "windows_edition_id": "ServerStandardEval",
-  "windows_installation_type": "Server Core",
-  "windows_product_name": "Windows Server 2022 Standard Evaluation",
-  "windows_release_id": "21H2"
+  "virtual": "virtualbox"
 }

--- a/facts/get_facts.sh
+++ b/facts/get_facts.sh
@@ -75,7 +75,7 @@ case "${osfamily}" in
       if yum install -y puppet-agent-${puppet_agent_version}; then
         output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter os.name | tr '[:upper:]' '[:lower:]')-$(facter os.release.major)-$(facter os.hardware).facts"
         mkdir -p $(dirname ${output_file})
-        facter --show-legacy -p -j | tee ${output_file}
+        facter --puppet --json | tee ${output_file}
       fi
     done
     yum remove -y puppet8-release
@@ -93,7 +93,7 @@ case "${osfamily}" in
       if apt_install puppet-agent=${puppet_agent_version}*; then
         output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter os.name | tr '[:upper:]' '[:lower:]')-$(facter os.release.major)-$(facter os.hardware).facts"
         mkdir -p $(dirname ${output_file})
-        facter --show-legacy -p -j | tee ${output_file}
+        facter --puppet --json | tee ${output_file}
       fi
     done
     apt-get -y remove --purge puppet8-release
@@ -107,7 +107,7 @@ case "${osfamily}" in
     apt_install ruby rubygems ruby-dev puppet facter
     output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemmajrelease)-$(facter hardwaremodel).facts"
     mkdir -p $(dirname ${output_file})
-    facter --show-legacy -p -j | tee ${output_file}
+    facter --puppet --json | tee ${output_file}
   fi
   ;;
 'FreeBSD')
@@ -124,7 +124,7 @@ case "${osfamily}" in
     [ "${hardwaremodel}" = 'amd64' ] && hardwaremodel=x86_64
     output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemmajrelease)-${hardwaremodel}.facts"
     mkdir -p $(dirname ${output_file})
-    [ ! -f ${output_file} ] && facter --show-legacy -p -j | tee ${output_file}
+    [ ! -f ${output_file} ] && facter --puppet --json | tee ${output_file}
   done
   ;;
 'OpenBSD')
@@ -133,7 +133,7 @@ case "${osfamily}" in
   # Vagrant box should already have puppet & facter installed
   output_file="/vagrant/$(facter --version | cut -d. -f1-2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemrelease)-${hardwaremodel}.facts"
   mkdir -p $(dirname ${output_file})
-  [ ! -f ${output_file} ] && facter --show-legacy -p -j | tee ${output_file}
+  [ ! -f ${output_file} ] && facter --puppet --json | tee ${output_file}
   ;;
 'Suse')
   # install deps that we need later for gem based setup
@@ -149,7 +149,7 @@ case "${osfamily}" in
       if zypper --gpg-auto-import-keys --non-interactive install puppet-agent-${puppet_agent_version}; then
         output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemmajrelease)-$(facter hardwaremodel).facts"
         mkdir -p $(dirname ${output_file})
-        facter --show-legacy -p -j | tee ${output_file}
+        facter --puppet --json | tee ${output_file}
       fi
     done
     zypper --non-interactive remove puppet8-release
@@ -159,13 +159,13 @@ case "${osfamily}" in
   pacman --sync --refresh --sysupgrade --noconfirm ruby ruby-bundler base-devel dnsutils facter augeas
   output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter hardwaremodel).facts"
   mkdir -p $(dirname ${output_file})
-  facter --show-legacy -p -j | tee ${output_file}
+  facter --puppet --json | tee ${output_file}
   ;;
 'Gentoo')
   emerge -vq1 dev-lang/ruby dev-ruby/bundler app-admin/puppet dev-ruby/facter sys-apps/dmidecode app-admin/augeas
   output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter hardwaremodel).facts"
   mkdir -p $(dirname ${output_file})
-  facter --show-legacy -p -j | tee ${output_file}
+  facter --puppet --json | tee ${output_file}
 esac
 
 # this lower section relies on the ruby version and facter version that came
@@ -214,6 +214,6 @@ for version in 4.2.14 4.3.0 4.4.3 4.5.2 4.6.0 4.7.0; do
   fi
   mkdir -p $(dirname $output_file)
   echo $version | grep -q -E '^1\.' &&
-    FACTER_GEM_VERSION="~> ${version}" bundle exec facter --show-legacy --json | bundle exec ruby -e 'require "json"; jj JSON.parse gets' | tee $output_file ||
-    FACTER_GEM_VERSION="~> ${version}" bundle exec facter --show-legacy --json | tee $output_file
+    FACTER_GEM_VERSION="~> ${version}" bundle exec facter --json | bundle exec ruby -e 'require "json"; jj JSON.parse gets' | tee $output_file ||
+    FACTER_GEM_VERSION="~> ${version}" bundle exec facter --json | tee $output_file
 done

--- a/facts/windows_get_facts.ps1
+++ b/facts/windows_get_facts.ps1
@@ -88,7 +88,7 @@ foreach ($pupAgentVer in $puppetAgentVersions) {
   # the domain name will fallback to the hypervisor's domain.
   $env:FACTER_fqdn = $fqdn
 
-  $facterArgs = @("-j", "-p", "--show-legacy")
+  $facterArgs = @("--json", "--puppet")
   $facterProcess = Start-Process -FilePath $facterBin -ArgumentList $facterArgs -Wait -PassThru -RedirectStandardOutput "X:\$facterVer\$Os-$Osmaj-$Hw.facts"
   if ($facterProcess.ExitCode -ne 0) {
     Write-Host "Facter failed."

--- a/spec/facter_db_spec.rb
+++ b/spec/facter_db_spec.rb
@@ -216,19 +216,19 @@ describe FacterDB do
       let(:facter_version) { '*' }
 
       context 'with an Array filter' do
-        let(:filter) { [{ osfamily: 'Debian' }] }
+        let(:filter) { [{ kernel: 'Linux' }] }
 
         include_examples 'returns a result'
       end
 
       context 'with a Hash filter' do
-        let(:filter) { { osfamily: 'Debian' } }
+        let(:filter) { { kernel: 'Linux' } }
 
         include_examples 'returns a result'
       end
 
       context 'with a String filter' do
-        let(:filter) { 'osfamily=Debian' }
+        let(:filter) { 'kernel=Linux' }
 
         include_examples 'returns a result'
       end
@@ -252,21 +252,21 @@ describe FacterDB do
       end
 
       context 'with an Array filter' do
-        let(:filter) { [{ osfamily: 'Debian' }] }
+        let(:filter) { [{ kernel: 'Linux' }] }
 
         include_examples 'returns a result'
         include_examples 'returns only the specified version'
       end
 
       context 'with a Hash filter' do
-        let(:filter) { { osfamily: 'Debian' } }
+        let(:filter) { { kernel: 'Linux' } }
 
         include_examples 'returns a result'
         include_examples 'returns only the specified version'
       end
 
       context 'with a String filter' do
-        let(:filter) { 'osfamily=Debian' }
+        let(:filter) { 'kernel=Linux' }
 
         include_examples 'returns a result'
         include_examples 'returns only the specified version'
@@ -302,11 +302,11 @@ describe FacterDB do
     end
 
     it 'with hash' do
-      expect(FacterDB.generate_filter_str({ osfamily: 'Debian' })).to eq('osfamily=Debian')
+      expect(FacterDB.generate_filter_str({ kernel: 'Linux' })).to eq('kernel=Linux')
     end
 
     it 'with Array' do
-      expect(FacterDB.generate_filter_str([osfamily: 'Debian'])).to eq('(osfamily=Debian)')
+      expect(FacterDB.generate_filter_str([kernel: 'Linux'])).to eq('(kernel=Linux)')
     end
 
     it 'empty' do
@@ -349,19 +349,19 @@ describe FacterDB do
     end
 
     context 'with an Array filter' do
-      let(:filter) { [osfamily: 'Debian'] }
+      let(:filter) { [kernel: 'Linux'] }
 
       include_examples 'returns a result'
     end
 
     context 'with a Hash filter' do
-      let(:filter) { { osfamily: 'Debian' } }
+      let(:filter) { { kernel: 'Linux' } }
 
       include_examples 'returns a result'
     end
 
     context 'with a String filter' do
-      let(:filter) { 'osfamily=Debian' }
+      let(:filter) { 'kernel=Linux' }
 
       include_examples 'returns a result'
     end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -98,8 +98,8 @@ describe 'Default Facts' do
         end
       end
 
-      it 'contains the legacy ipaddress fact' do
-        expect(content['ipaddress']).to not_be_nil.and not_be_empty
+      it 'does not contains the legacy ipaddress fact' do
+        expect(content['ipaddress']).to be_nil
       end
 
       it 'contains no facts from puppetlabs/stdlib' do
@@ -124,6 +124,20 @@ describe 'Default Facts' do
         expect(content['os']['release']['major']).to not_be_nil.and not_be_empty
         expect(content['os']['name']).to not_be_nil.and not_be_empty
         expect(content['os']['hardware']).to not_be_nil.and not_be_empty
+      end
+
+      it 'does not contain a legacy hostname, domain and fqdn fact' do
+        expect(content['hostname']).to be_nil
+        expect(content['fqdn']).to be_nil
+        expect(content['domain']).to be_nil
+      end
+
+      it 'does not contain the legacy osfamily fact' do
+        expect(content['osfamily']).to be_nil
+      end
+
+      it 'does not contain the legacy operatingsystem fact' do
+        expect(content['operatingsystem']).to be_nil
       end
     end
   end


### PR DESCRIPTION
Puppet 8 defaults to not providing Legacy Facts [1].  In order for our
tests to be relevant, we should not provide these facts.  We also had
special instructions to ask contributors to add these legacy facts which
are now obsolete.

As a baseline, do not provide any legacy facts.  Adjust references to
legacy fact to use non deprecated and still relevant ones in CI, and
provide a script that can asists us in updating the existing factsets.

[1]: https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#legacy-facts
