### PR TITLE
Change rhel_alts to use RHEL facts and remove discontinued OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Create i386 facts from x86_64's ones
 ```
 for file in facts/*/*-x86_64.facts; do cat $file | sed -e 's/x86_64/i386/' -e 's/amd64/i386/' > $(echo $file | sed 's/x86_64/i386/'); done
 ```
-Create RedHat, Scientific, OracleLinux facts from CentOS's ones
+Create OracleLinux facts from RedHat's ones
 
 ```
 $ bundle exec rake rhel_alts

--- a/rakelib/rhel_alts.rake
+++ b/rakelib/rhel_alts.rake
@@ -1,18 +1,9 @@
-desc 'Create RHEL/OracleLinux/Scientific factsets from CentOS factsets'
+desc 'Create OracleLinux factsets from RHEL factsets'
 task :rhel_alts do
-  Dir[File.join(__dir__, '..', 'facts', '*', 'centos-*-x86_64.facts')].each do |f|
-    centos_factset = File.read(f)
+  Dir[File.join(__dir__, '..', 'facts', '*', 'rhel-*-x86_64.facts')].each do |f|
+    rhel_factset = File.read(f)
 
-    rhel_path = f.gsub('centos-', 'redhat-')
-    File.write(rhel_path, centos_factset.gsub('CentOS', 'RedHat'))
-
-    oracle_path = f.gsub('centos-', 'oraclelinux-')
-    File.write(oracle_path, centos_factset.gsub('CentOS', 'OracleLinux'))
-
-    # Scientific isn't going to be updated to 8
-    next unless File.basename(f)[/-(\d+)-/, 1].to_i <= 7
-
-    scientific_path = f.gsub('centos-', 'scientific-')
-    File.write(scientific_path, centos_factset.gsub('CentOS', 'Scientific'))
+    oracle_path = f.gsub('rhel-', 'oraclelinux-')
+    File.write(oracle_path, rhel_factset.gsub('RedHat', 'OracleLinux'))
   end
 end


### PR DESCRIPTION
Scientific Linux EOL is June 30, 2024, so basically ready to remove - people shouldn't be developing for it anymore. There are also no new CentOS releases, so build Oracle facts from RHEL facts instead.