### PR TITLE
Release 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.24.0](https://rubygems.org/gems/facterdb/versions/1.24.0) (2024-03-19)
+
+[Full Changelog](https://github.com/voxpupuli/facterdb/compare/1.23.0...1.24.0)
+
+**Implemented enhancements:**
+
+- Rebuild RHEL facts on Vagrant [\#304](https://github.com/voxpupuli/facterdb/pull/304) ([yakatz](https://github.com/yakatz))
+
 ## [1.23.0](https://rubygems.org/gems/facterdb/versions/1.23.0) (2024-01-09)
 
 [Full Changelog](https://github.com/voxpupuli/facterdb/compare/1.22.0...1.23.0)

--- a/lib/facterdb/version.rb
+++ b/lib/facterdb/version.rb
@@ -1,5 +1,5 @@
 module FacterDB
   module Version
-    STRING = '1.23.0'
+    STRING = '1.24.0'
   end
 end


### PR DESCRIPTION
This release is needed to fix unit tests for [puppet-openvpn](https://github.com/voxpupuli/puppet-openvpn).
We might want to wait on a release for more PRs to be merged.