### PR TITLE
Add facts for OpenBSD 7.X for facter 4.7

### DIFF
--- a/facts/4.7/openbsd-7-x86_64.facts
+++ b/facts/4.7/openbsd-7-x86_64.facts
@@ -1,0 +1,364 @@
+{
+  "architecture": "amd64",
+  "bios_vendor": "OpenBSD",
+  "dmi": {
+    "bios": {
+      "vendor": "OpenBSD"
+    },
+    "manufacturer": "OpenBSD",
+    "product": {
+      "name": "VMM"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.7.0",
+  "fqdn": "foo.example.com",
+  "gid": "wheel",
+  "hardwareisa": "amd64",
+  "hardwaremodel": "amd64",
+  "hostname": "foo",
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "wheel",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "ipaddress": "10.0.0.1",
+  "ipaddress6": "2aa1:1470:5ab6::a00:1",
+  "is_virtual": true,
+  "kernel": "OpenBSD",
+  "kernelmajversion": "7",
+  "kernelrelease": "7.5",
+  "kernelversion": "7.5",
+  "load_averages": {
+    "15m": 0.11376953125,
+    "1m": 0.138671875,
+    "5m": 0.10546875
+  },
+  "macaddress": "08:00:66:66:16:a1",
+  "manufacturer": "OpenBSD",
+  "mountpoints": {
+    "/": {
+      "available": "842.44 MiB",
+      "available_bytes": 883363840,
+      "capacity": "9.54%",
+      "device": "/dev/sd0a",
+      "filesystem": "ffs",
+      "options": [
+        "local"
+      ],
+      "size": "985.76 MiB",
+      "size_bytes": 1033648128,
+      "used": "94.04 MiB",
+      "used_bytes": 98603008
+    },
+    "/home": {
+      "available": "6.83 GiB",
+      "available_bytes": 7329738752,
+      "capacity": "0.02%",
+      "device": "/dev/sd0k",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "nosuid",
+        "wxallowed"
+      ],
+      "size": "7.19 GiB",
+      "size_bytes": 7717337088,
+      "used": "1.65 MiB",
+      "used_bytes": 1732608
+    },
+    "/tmp": {
+      "available": "1.48 GiB",
+      "available_bytes": 1591691264,
+      "capacity": "0.00%",
+      "device": "/dev/sd0d",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "nosuid"
+      ],
+      "size": "1.56 GiB",
+      "size_bytes": 1675474944,
+      "used": "10.00 KiB",
+      "used_bytes": 10240
+    },
+    "/usr": {
+      "available": "1.83 GiB",
+      "available_bytes": 1960398848,
+      "capacity": "38.53%",
+      "device": "/dev/sd0f",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev"
+      ],
+      "size": "3.23 GiB",
+      "size_bytes": 3471620096,
+      "used": "1.25 GiB",
+      "used_bytes": 1337640960
+    },
+    "/usr/X11R6": {
+      "available": "575.18 MiB",
+      "available_bytes": 603115520,
+      "capacity": "33.01%",
+      "device": "/dev/sd0g",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev"
+      ],
+      "size": "927.81 MiB",
+      "size_bytes": 972879872,
+      "used": "306.25 MiB",
+      "used_bytes": 321122304
+    },
+    "/usr/local": {
+      "available": "3.45 GiB",
+      "available_bytes": 3708446720,
+      "capacity": "1.32%",
+      "device": "/dev/sd0h",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "wxallowed"
+      ],
+      "size": "3.69 GiB",
+      "size_bytes": 3958585344,
+      "used": "49.79 MiB",
+      "used_bytes": 52209664
+    },
+    "/usr/obj": {
+      "available": "5.29 GiB",
+      "available_bytes": 5674782720,
+      "capacity": "0.00%",
+      "device": "/dev/sd0j",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "nosuid"
+      ],
+      "size": "5.56 GiB",
+      "size_bytes": 5973456896,
+      "used": "2.00 KiB",
+      "used_bytes": 2048
+    },
+    "/usr/src": {
+      "available": "2.18 GiB",
+      "available_bytes": 2339993600,
+      "capacity": "0.00%",
+      "device": "/dev/sd0i",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "nosuid"
+      ],
+      "size": "2.29 GiB",
+      "size_bytes": 2463152128,
+      "used": "2.00 KiB",
+      "used_bytes": 2048
+    },
+    "/var": {
+      "available": "2.30 GiB",
+      "available_bytes": 2472480768,
+      "capacity": "0.38%",
+      "device": "/dev/sd0e",
+      "filesystem": "ffs",
+      "options": [
+        "local",
+        "nodev",
+        "nosuid"
+      ],
+      "size": "2.43 GiB",
+      "size_bytes": 2612967424,
+      "used": "9.38 MiB",
+      "used_bytes": 9838592
+    }
+  },
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "network": "10.0.0.0",
+  "network6": "2aa1:1470:5ab6::",
+  "networking": {
+    "dhcp": "10.0.0.59",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "enc0": {
+      },
+      "lo0": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host"
+          },
+          {
+            "address": "fe80::1",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 32768,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      },
+      "pflog0": {
+        "mtu": 33136
+      },
+      "vio0": {
+        "bindings": [
+          {
+            "address": "10.0.0.1",
+            "netmask": "255.255.255.0",
+            "network": "10.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::a00:66ff:fe66:16a1",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          },
+          {
+            "address": "2aa1:1470:5ab6::a00:1",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "2aa1:1470:5ab6::",
+            "scope6": "global"
+          }
+        ],
+        "ip": "10.0.0.1",
+        "ip6": "2aa1:1470:5ab6::a00:1",
+        "mac": "08:00:66:66:16:a1",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.0.0",
+        "network6": "2aa1:1470:5ab6::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.0.1",
+    "ip6": "2aa1:1470:5ab6::a00:1",
+    "mac": "08:00:66:66:16:a1",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.0.0",
+    "network6": "2aa1:1470:5ab6::",
+    "primary": "vio0",
+    "scope6": "global"
+  },
+  "operatingsystem": "OpenBSD",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7.5",
+  "os": {
+    "architecture": "amd64",
+    "family": "OpenBSD",
+    "hardware": "amd64",
+    "name": "OpenBSD",
+    "release": {
+      "full": "7.5",
+      "major": "7",
+      "minor": "5"
+    }
+  },
+  "osfamily": "OpenBSD",
+  "path": "/sbin:/usr/sbin:/bin:/usr/bin:/usr/X11R6/bin:/usr/local/sbin:/usr/local/bin",
+  "processor0": "Intel(R) Atom(TM) CPU C2750 @ 2.40GHz",
+  "processorcount": 1,
+  "processors": {
+    "count": 1,
+    "isa": "amd64",
+    "models": [
+      "Intel(R) Atom(TM) CPU C2750 @ 2.40GHz"
+    ],
+    "speed": "2.40 GHz"
+  },
+  "productname": "VMM",
+  "ruby": {
+    "platform": "x86_64-openbsd",
+    "sitedir": "/usr/local/lib/ruby/site_ruby/3.2",
+    "version": "3.2.4"
+  },
+  "rubyplatform": "x86_64-openbsd",
+  "rubysitedir": "/usr/local/lib/ruby/site_ruby/3.2",
+  "rubyversion": "3.2.4",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 e3efb8be356521016cb3a5a4f61493fb984dab41",
+        "sha256": "SSHFP 2 2 60b2b39530f973f8ff9bf2ef1bb5bda6eefc62fc9ca6bd0d8b8462b7d4c10374"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAPvQkh/xA4qXHRlAPAOylpCQ34eNcPhPPnL0ME1H2P338X26DvTR/hj2qdwoz/MiC2XhLY4wSlLGX62Zy31MWOmfOvS58YJ5QnoaPWJ40YE7lJzy/X0bdUSHmZ1n1TEQ22LSbeGp02YmnMPFNwpAaMFa3y14NVozREdTQAKjl+fXAAAAFQDBrazfwR4BQCN7BpZ3O///0EMTvQAAAIEApZa1vt21cb3Zu932GWf6MGGDMdwNIgtgd5vOzERZnKtII8K+LIQBY3E6jSLYJPN5MbFYjbKK1CN1mLx4qqhQl7qxXSfuJKjhuI86R4bS7zzhDDcINangrMT3v1tZAgS5ec59zoSruX80nGBCR12tGSnbFrM1lJM6+rarAJzmT7sAAACBAOX6U5gAr7zzdWVNxoiSR1Ms8Ic+X46Muf2WFoXWezrvg3YXd+rRoYCFavy5qctKCHqMiJ7Qo6+JZiW8/LiWYyifkF30ZgjEnjOOF1et6dtkSpsvzxkbk8nx6eFCKVMy1LEF4EuNVZEtwL/r48ZSZt9pr2UeHGcuEQGZKmKpPjpp",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 ea0c4b2f49f7f91b09692199b133e6bb7e865742",
+        "sha256": "SSHFP 3 2 e0172035e11db0adee2f64277971e1fca7f3de227d4d8db994ba94793f5d6667"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAeuHMimmx98kOLod5tb+a6EjmXHZ8WfSBEsMup0AZ83/3CqFJIg1Zwm+SVnv+XIJZXUeNDjKHtUlilNu3V4cFI=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 dc949f6423b504023f5dbdc0dfae61d10cd74d84",
+        "sha256": "SSHFP 4 2 1dcf5c9e9a05380deb0b68a84fd272ddc352488fe4cc5b4bdefc5626499b44b3"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILrTvGtds7GsG1o2C5U8uRR0iLx2EuZzP5haYJr0jpi1",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 244a9c70ccb869fc96add7a866c3aed05dbb9d3f",
+        "sha256": "SSHFP 1 2 8578f9a0e6dd240ddbf5cb9af9bcf61209cb8393fe8b3aea1be85217cac75aaf"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDs/xGIHmJejDMTa5BjEaGGsUziKZIaJ3dTbGBDLsLjRnNwyoUjhjKitrNuABEZSKubDM4yYHwGEfTxhu/i5JdwTIkrY3gO27bm/5fC12rglH3UBNKZyOoD3ogVtphmiCBFzRBkCvatiVCBw+jupK0h39wu+4iiuOZhr6JOcwOYARTTS7dwKbzLXhYYyuLzHbBwm921pJZCzfwB/YMSATvzzVsUq7qVxg5p+8J92L+pUBiT1V9+r+G3M/fE34KXB+wPDrYMLONhkkaBt1JfTOie+tBs+VHA7FvMxZvGcTd4NXIjhBHPBv2ngypBB6alVO35Borl+6KeBIF5ztPRJW0H",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPvQkh/xA4qXHRlAPAOylpCQ34eNcPhPPnL0ME1H2P338X26DvTR/hj2qdwoz/MiC2XhLY4wSlLGX62Zy31MWOmfOvS58YJ5QnoaPWJ40YE7lJzy/X0bdUSHmZ1n1TEQ22LSbeGp02YmnMPFNwpAaMFa3y14NVozREdTQAKjl+fXAAAAFQDBrazfwR4BQCN7BpZ3O///0EMTvQAAAIEApZa1vt21cb3Zu932GWf6MGGDMdwNIgtgd5vOzERZnKtII8K+LIQBY3E6jSLYJPN5MbFYjbKK1CN1mLx4qqhQl7qxXSfuJKjhuI86R4bS7zzhDDcINangrMT3v1tZAgS5ec59zoSruX80nGBCR12tGSnbFrM1lJM6+rarAJzmT7sAAACBAOX6U5gAr7zzdWVNxoiSR1Ms8Ic+X46Muf2WFoXWezrvg3YXd+rRoYCFavy5qctKCHqMiJ7Qo6+JZiW8/LiWYyifkF30ZgjEnjOOF1et6dtkSpsvzxkbk8nx6eFCKVMy1LEF4EuNVZEtwL/r48ZSZt9pr2UeHGcuEQGZKmKpPjpp",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAeuHMimmx98kOLod5tb+a6EjmXHZ8WfSBEsMup0AZ83/3CqFJIg1Zwm+SVnv+XIJZXUeNDjKHtUlilNu3V4cFI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILrTvGtds7GsG1o2C5U8uRR0iLx2EuZzP5haYJr0jpi1",
+  "sshfp_dsa": "SSHFP 2 1 e3efb8be356521016cb3a5a4f61493fb984dab41\nSSHFP 2 2 60b2b39530f973f8ff9bf2ef1bb5bda6eefc62fc9ca6bd0d8b8462b7d4c10374",
+  "sshfp_ecdsa": "SSHFP 3 1 ea0c4b2f49f7f91b09692199b133e6bb7e865742\nSSHFP 3 2 e0172035e11db0adee2f64277971e1fca7f3de227d4d8db994ba94793f5d6667",
+  "sshfp_ed25519": "SSHFP 4 1 dc949f6423b504023f5dbdc0dfae61d10cd74d84\nSSHFP 4 2 1dcf5c9e9a05380deb0b68a84fd272ddc352488fe4cc5b4bdefc5626499b44b3",
+  "sshfp_rsa": "SSHFP 1 1 244a9c70ccb869fc96add7a866c3aed05dbb9d3f\nSSHFP 1 2 8578f9a0e6dd240ddbf5cb9af9bcf61209cb8393fe8b3aea1be85217cac75aaf",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDs/xGIHmJejDMTa5BjEaGGsUziKZIaJ3dTbGBDLsLjRnNwyoUjhjKitrNuABEZSKubDM4yYHwGEfTxhu/i5JdwTIkrY3gO27bm/5fC12rglH3UBNKZyOoD3ogVtphmiCBFzRBkCvatiVCBw+jupK0h39wu+4iiuOZhr6JOcwOYARTTS7dwKbzLXhYYyuLzHbBwm921pJZCzfwB/YMSATvzzVsUq7qVxg5p+8J92L+pUBiT1V9+r+G3M/fE34KXB+wPDrYMLONhkkaBt1JfTOie+tBs+VHA7FvMxZvGcTd4NXIjhBHPBv2ngypBB6alVO35Borl+6KeBIF5ztPRJW0H",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 964,
+    "uptime": "0:16 hours"
+  },
+  "timezone": "CEST",
+  "uptime": "0:16 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 964,
+  "virtual": "vmm"
+}


### PR DESCRIPTION
manually created output of 

```
facter32 --show-legacy -p -j
```

from a fresh, clean VM.