### PR TITLE
get_facts.sh: Drop support for systems with Ruby 2.2

### DIFF
--- a/facts/get_facts.sh
+++ b/facts/get_facts.sh
@@ -244,12 +244,9 @@ hardwaremodel=$(facter hardwaremodel)
 
 PATH=/opt/puppetlabs/puppet/bin:$PATH
 
-if [ "$(ruby -e 'puts Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3")')" = "true" ]; then
-    gem install bundler --no-document --no-format-executable
-else
-    gem install bundler --version '~> 1.0' --no-ri --no-rdoc --no-format-executable
-fi
-bundle install --path vendor/bundler
+gem install bundler --no-document --no-format-executable
+bundle config set path 'vendor/bundler'
+bundle install
 
 for version in 4.0.0 4.1.0 4.2.0 4.3.0 4.4.0 4.5.0; do
   FACTER_GEM_VERSION="~> ${version}" bundle update


### PR DESCRIPTION
That's really ancient and we don't generate factsets for those platforms anymore.