### PR TITLE
Load puppet versions from shared file & Add missing factsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,22 +100,22 @@ FacterDB::get_facts('osfamily=Debian')
 | Scientific 7             |  1  |     |  1  |     |     |     |     |     |
 | Solaris 11               |  1  |     |     |     |     |     |     |     |
 | Ubuntu 18.04             |  1  |  1  |  1  |  1  |  1  |  1  |     |     |
-| Ubuntu 20.04             |  1  |  1  |  1  |  1  |  1  |  1  |     |     |
+| Ubuntu 20.04             |  1  |  1  |  1  |  1  |  1  |  1  |  1  |  1  |
 | Ubuntu 21.04             |  1  |  1  |  1  |     |     |     |     |     |
 | Ubuntu 21.10             |  1  |  1  |  1  |     |     |     |     |     |
 | Ubuntu 22.04             |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | Ubuntu 22.10             |     |     |  1  |     |     |     |     |     |
-| Windows 10               |     |     |  1  |  1  |  1  |     |  1  |  1  |
+| Windows 10               |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
+| Windows 11               |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | Windows Server 2012      |     |     |  1  |  1  |  1  |     |     |     |
 | Windows Server 2012 R2   |     |     |  1  |  1  |  1  |     |     |     |
 | Windows Server 2016      |     |     |  1  |  1  |  1  |     |     |     |
 | Windows Server 2016 Core |     |     |  1  |  1  |  1  |     |     |     |
-| Windows Server 2019      |     |     |  1  |  1  |  1  |     |  1  |  1  |
+| Windows Server 2019      |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | Windows Server 2019 Core |     |     |  1  |  1  |  1  |     |     |     |
-| Windows Server 2022      |     |     |  1  |  1  |  1  |     |  1  |  1  |
+| Windows Server 2022      |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | Windows Server 2022 Core |     |     |  1  |  1  |  1  |     |     |     |
-| openSUSE 15              |  1  |  1  |  1  |  1  |  1  |  1  |     |     |
-| windows 11               |     |     |  1  |  1  |  1  |     |  1  |  1  |
+| openSUSE 15              |  1  |  1  |  1  |  1  |  1  |  1  |     |  1  |
 
 Where the number (1, 2 etc.) are the number of factsets for that OS and facter combination (e.g., x86_64 and i386 architectures).
 

--- a/Rakefile
+++ b/Rakefile
@@ -78,8 +78,8 @@ def factset_to_os_label(fs)
     db_filename = fs[:_facterdb_filename] || 'there_is_no_filename'
     label = if /windows-10-/.match?(db_filename)
               'Windows 10'
-            elsif /windows-7-/.match?(db_filename)
-              'Windows 7'
+            elsif /windows-11-/.match?(db_filename)
+              'Windows 11'
             elsif /windows-8[\d.]*-/.match?(db_filename)
               "Windows #{os__rel.sub('6.2.9200', '8').sub('6.3.9600', '8.1')}"
             elsif /windows-.+-core-/.match?(db_filename)

--- a/facts/4.5/windows-10-x86_64.facts
+++ b/facts/4.5/windows-10-x86_64.facts
@@ -1,0 +1,227 @@
+{
+  "aio_agent_version": "8.4.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B"
+    }
+  },
+  "domain": "example.com",
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.5.2",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "FOO\\vagrant",
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "interfaces": "Ethernet",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::4c6a:201b:6dd8:dfcc",
+  "ipaddress6_Ethernet": "fe80::4c6a:201b:6dd8:dfcc",
+  "ipaddress_Ethernet": "10.0.2.15",
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.19045",
+  "kernelversion": "10.0.19045",
+  "macaddress": "08:00:27:85:56:BC",
+  "macaddress_Ethernet": "08:00:27:85:56:BC",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "2.46 GiB",
+      "available_bytes": 2636947456,
+      "capacity": "38.36%",
+      "total": "3.98 GiB",
+      "total_bytes": 4277866496,
+      "used": "1.53 GiB",
+      "used_bytes": 1640919040
+    }
+  },
+  "memoryfree": "2.46 GiB",
+  "memoryfree_mb": 2514.7890625,
+  "memorysize": "3.98 GiB",
+  "memorysize_mb": 4079.69140625,
+  "mtu_Ethernet": 1500,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet": "255.255.255.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_Ethernet": "fe80::",
+  "network_Ethernet": "10.0.2.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::4c6a:201b:6dd8:dfcc",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::4c6a:201b:6dd8:dfcc",
+        "mac": "08:00:27:85:56:BC",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::4c6a:201b:6dd8:dfcc",
+    "mac": "08:00:27:85:56:BC",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "Ethernet",
+    "scope6": "link"
+  },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "10",
+      "major": "10"
+    },
+    "windows": {
+      "display_version": "22H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "22H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "puppetversion": "8.4.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.2"
+  },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.2",
+  "scope6": "link",
+  "scope6_Ethernet": "link",
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 2881c8a0dd7619743804d8eacbe84f6ed6710c5c",
+        "sha256": "SSHFP 2 2 7093fa18285ea8c300c8e7a2f02806858b916d11e290107f313f2035d29885ec"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBALRVpVrInQNBmpTrjs7+E5PpIimZKMOZVqe81FYEY34q6q/No1LjgoNFj4RrGfD6YRMNtrKPSH0Er7PnkawVH+b5j85utXSNl3Lg7nLfSdrETbHzJgTWDRMhuzfmQ2E3sJUkVyDt07DQT6GPSd9dhoDY6uYU+sPjGYmChB1UdUZXAAAAFQDeBA9SXKvk14OISVneBt3WhjpHUwAAAH8ZQDtMdhihhqcQ6nHyA+belgHx+HP0pJ+wdwwvsmxnyrllqInJZ/+wGv6Gt0lqGaR0jDAwX5vhEnfTlFi5EPqBXi5Hv1Thv/3QnoVbINF5DkN/b0pnhc2w/wS7H6KhMQAJOxOEk1YlDJxxsmdULe7tpE7EASbSOV2QpDvq906dAAAAgGB+xiD1+xP1Q6DhOYPWkd+zubTBZvhtOivSc2GupaHuZcjqnMEXsF5M++pVjmqXPaM3XvZc2mMAuReo64AqSoSar3QlRTAD+/JxcSXo+uBMN9PAguGyv0O4RYQPxnHl/t4JDjw20eJgmFjH7BuaIRvIm8UH3aVFOUNmT4PLAFQ2",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 51cf57dae34addd4770d3be0c6e994143a324fa1",
+        "sha256": "SSHFP 3 2 b0bf51964da6640bd498ce286604ec25fa0e4477944f37a123289628d9be2042"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAIZL0c75xKTmUlbJOiVjPooRCWxUuA8FI7E6n+LRVkZnz9RCZnXmOfPwJQRfISSxNL3D9l5hdWMNo2QEA25p1M=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984",
+        "sha256": "SSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOboWujRPKTjO4E35fHRpR9DLVqZb4oGYGWEJ9FwKMz/",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b",
+        "sha256": "SSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBALRVpVrInQNBmpTrjs7+E5PpIimZKMOZVqe81FYEY34q6q/No1LjgoNFj4RrGfD6YRMNtrKPSH0Er7PnkawVH+b5j85utXSNl3Lg7nLfSdrETbHzJgTWDRMhuzfmQ2E3sJUkVyDt07DQT6GPSd9dhoDY6uYU+sPjGYmChB1UdUZXAAAAFQDeBA9SXKvk14OISVneBt3WhjpHUwAAAH8ZQDtMdhihhqcQ6nHyA+belgHx+HP0pJ+wdwwvsmxnyrllqInJZ/+wGv6Gt0lqGaR0jDAwX5vhEnfTlFi5EPqBXi5Hv1Thv/3QnoVbINF5DkN/b0pnhc2w/wS7H6KhMQAJOxOEk1YlDJxxsmdULe7tpE7EASbSOV2QpDvq906dAAAAgGB+xiD1+xP1Q6DhOYPWkd+zubTBZvhtOivSc2GupaHuZcjqnMEXsF5M++pVjmqXPaM3XvZc2mMAuReo64AqSoSar3QlRTAD+/JxcSXo+uBMN9PAguGyv0O4RYQPxnHl/t4JDjw20eJgmFjH7BuaIRvIm8UH3aVFOUNmT4PLAFQ2",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAIZL0c75xKTmUlbJOiVjPooRCWxUuA8FI7E6n+LRVkZnz9RCZnXmOfPwJQRfISSxNL3D9l5hdWMNo2QEA25p1M=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOboWujRPKTjO4E35fHRpR9DLVqZb4oGYGWEJ9FwKMz/",
+  "sshfp_dsa": "SSHFP 2 1 2881c8a0dd7619743804d8eacbe84f6ed6710c5c\nSSHFP 2 2 7093fa18285ea8c300c8e7a2f02806858b916d11e290107f313f2035d29885ec",
+  "sshfp_ecdsa": "SSHFP 3 1 51cf57dae34addd4770d3be0c6e994143a324fa1\nSSHFP 3 2 b0bf51964da6640bd498ce286604ec25fa0e4477944f37a123289628d9be2042",
+  "sshfp_ed25519": "SSHFP 4 1 5b2b28c04b8a81b54399e20e2d36946298ed0984\nSSHFP 4 2 ee29a9053223bb924a4da7a89d16be7f041d9dd422428a31d1c3694b57d7a05e",
+  "sshfp_rsa": "SSHFP 1 1 31acd9fc22a72d0cad2f671cb8fb61e60a40172b\nSSHFP 1 2 35c2e8c6c2416d20539b2c42afff5b21c9b4f6795dbab497038d1d369d76771b",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBaNeXcnDCdoHwqqk6NjPsbHQ25/btQOzW9UzeV7AIF5lFqeshEIvyJXnSnQbgO770dNMcsTi4/lXbTs/0GsrLFQwZL/h0a+hDO0Nb8ZecNsev82Jnhmxw0ikMLfRysdPePhQxKeHD8T8Q/X20TWvpHQ8eJ47P2jHEB6muSP/9eCTSQzlvZ90a4CnyiJa0ambx8qw9nrLnA8pXH3xiHvhDi9FwFbUlkqt49EzayglsumIhC2VZPvJpylT4dIcMPAkpPHfjCKtjfKTU32EGygDuFtCw9KreUw7eOAPqoRBYSH8TEl/pxBEY32Wo3l5GImVMx7JRKdv89nzB2wB6v8630F9/07WczAkeeCoJ9vW+JRPvNngSeRKvR2E5QEAkHu6d7zT0BFXVocDI5P+NFlmgj87vliBuX6O8fVWLWOGgsQLaMbDuUI5VXI475llGU/hrEFwsQjpsHEu+A1UYJgvhge3TRzVYwB/7A4m9+MPwTyKD45WhEp3vMoV3dTKzleU=",
+  "system32": "C:\\Windows\\system32",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 555,
+    "uptime": "0:09 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "uptime": "0:09 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 555,
+  "uuid": "6B456DEB-9630-430D-9F85-AEBD695A160B",
+  "virtual": "virtualbox",
+  "windows_display_version": "22H2",
+  "windows_edition_id": "EnterpriseEval",
+  "windows_installation_type": "Client",
+  "windows_product_name": "Windows 10 Enterprise Evaluation",
+  "windows_release_id": "22H2"
+}

--- a/facts/4.5/windows-11-x86_64.facts
+++ b/facts/4.5/windows-11-x86_64.facts
@@ -1,0 +1,227 @@
+{
+  "aio_agent_version": "8.4.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E"
+    }
+  },
+  "domain": "example.com",
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.5.2",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "FOO\\vagrant",
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "interfaces": "Ethernet",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::f72f:511:e1c3:e451",
+  "ipaddress6_Ethernet": "fe80::f72f:511:e1c3:e451",
+  "ipaddress_Ethernet": "10.0.2.15",
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.22631",
+  "kernelversion": "10.0.22631",
+  "macaddress": "08:00:27:02:6D:35",
+  "macaddress_Ethernet": "08:00:27:02:6D:35",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "2.44 GiB",
+      "available_bytes": 2615238656,
+      "capacity": "38.87%",
+      "total": "3.98 GiB",
+      "total_bytes": 4277866496,
+      "used": "1.55 GiB",
+      "used_bytes": 1662627840
+    }
+  },
+  "memoryfree": "2.44 GiB",
+  "memoryfree_mb": 2494.0859375,
+  "memorysize": "3.98 GiB",
+  "memorysize_mb": 4079.69140625,
+  "mtu_Ethernet": 1500,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet": "255.255.255.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_Ethernet": "fe80::",
+  "network_Ethernet": "10.0.2.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::f72f:511:e1c3:e451",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::f72f:511:e1c3:e451",
+        "mac": "08:00:27:02:6D:35",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::f72f:511:e1c3:e451",
+    "mac": "08:00:27:02:6D:35",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "Ethernet",
+    "scope6": "link"
+  },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "11",
+  "operatingsystemrelease": "11",
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "11",
+      "major": "11"
+    },
+    "windows": {
+      "display_version": "23H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "23H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "puppetversion": "8.4.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.2"
+  },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.2",
+  "scope6": "link",
+  "scope6_Ethernet": "link",
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a4d0b5da381b55ca22e7a86c1025ec4f577fec25",
+        "sha256": "SSHFP 2 2 144506486139101c3e4a03662ee688586c30fa60c331aade4bcda91a764f8539"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAI3em7R+cewtxACwC/7mk9KKNmqY1iOZFnmn5HpgnzIX6x5nona7smAcWT9GZJQcGXno2mgYqD3KZvUIJsO6Ic1LMC11Y3ckRpFpAy0PMcEmkRKt2XCyJ+e69MyolxHUKXR/Kk22bJW2Oh9kUC6UqiVzSpcY1h1feuEoAVnPnTAbAAAAFQCjVjFDjfDqkyuR2+XwKJrIPdIKbwAAAIB9kVztpCZ/BCeu3ixyYsSyOnBONZ22oWq97qCt14B13OoJdy/79AOKhj1pO5Q3gtc4CMjO+4z6L912/ycvfL5UdKOV2Te8cY8rtfQbaM8ZQ4qzQgDX9TORwPWwxIvkWPFnVZZxGhFTw+341l/KdYNqgOGdRyB3NK5GfP32KQIxMQAAAIAolTOZTUbwf5EXa8t/IoFGwqs5ZXC1YfjIyYT879SdfSWH0wLfToqo0gK/RSXETvwjzGuf8zFrxKYzo1iAlF2t2/b7Vdzsx1Q3km5xfuZNlArYmwOwggDkDrrs9JTsv0m1QVcIAsqh1fOpHJv/w3Gck+cNRgXcxa/FehYxCaZKAg==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 b9a6d2b12b41ca5c91d33add173d83e47020423c",
+        "sha256": "SSHFP 3 2 b3c7cdacf79d95b7351700a0938145659d10d94676d3898360af34a17b15d402"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMbjFmfhjUl/5QLs32DQ9byMwb3rBXvx9UTrA361BIFtbOWil9gUmHzyR0rkVgZCG+/QJGw1ZjSE7DWjA4YZzY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba",
+        "sha256": "SSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIEcObPNrOPl2R1+asAYZ+ChutobkeVTzpt92nAbMe7AL",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641",
+        "sha256": "SSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAI3em7R+cewtxACwC/7mk9KKNmqY1iOZFnmn5HpgnzIX6x5nona7smAcWT9GZJQcGXno2mgYqD3KZvUIJsO6Ic1LMC11Y3ckRpFpAy0PMcEmkRKt2XCyJ+e69MyolxHUKXR/Kk22bJW2Oh9kUC6UqiVzSpcY1h1feuEoAVnPnTAbAAAAFQCjVjFDjfDqkyuR2+XwKJrIPdIKbwAAAIB9kVztpCZ/BCeu3ixyYsSyOnBONZ22oWq97qCt14B13OoJdy/79AOKhj1pO5Q3gtc4CMjO+4z6L912/ycvfL5UdKOV2Te8cY8rtfQbaM8ZQ4qzQgDX9TORwPWwxIvkWPFnVZZxGhFTw+341l/KdYNqgOGdRyB3NK5GfP32KQIxMQAAAIAolTOZTUbwf5EXa8t/IoFGwqs5ZXC1YfjIyYT879SdfSWH0wLfToqo0gK/RSXETvwjzGuf8zFrxKYzo1iAlF2t2/b7Vdzsx1Q3km5xfuZNlArYmwOwggDkDrrs9JTsv0m1QVcIAsqh1fOpHJv/w3Gck+cNRgXcxa/FehYxCaZKAg==",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMbjFmfhjUl/5QLs32DQ9byMwb3rBXvx9UTrA361BIFtbOWil9gUmHzyR0rkVgZCG+/QJGw1ZjSE7DWjA4YZzY=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIEcObPNrOPl2R1+asAYZ+ChutobkeVTzpt92nAbMe7AL",
+  "sshfp_dsa": "SSHFP 2 1 a4d0b5da381b55ca22e7a86c1025ec4f577fec25\nSSHFP 2 2 144506486139101c3e4a03662ee688586c30fa60c331aade4bcda91a764f8539",
+  "sshfp_ecdsa": "SSHFP 3 1 b9a6d2b12b41ca5c91d33add173d83e47020423c\nSSHFP 3 2 b3c7cdacf79d95b7351700a0938145659d10d94676d3898360af34a17b15d402",
+  "sshfp_ed25519": "SSHFP 4 1 e4feb7a0cf8595bd25cb289d34ce00c34a4305ba\nSSHFP 4 2 f34b7083851d17408228ebd6e6c8810546d754422c2610deece70fb00ba67b34",
+  "sshfp_rsa": "SSHFP 1 1 97b9f1dd63e212d5c8fa5a67adc3181553359641\nSSHFP 1 2 d4fd0cb9f4a5708df564e31936f5da0212d5d44a34d82d1686217fd844560ce6",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDPObcF1zh9ZSz1t6Mr0tsf6Ahx2/JPw+MMHbazirNyqeKotcsI6eibmGfnBu6aGhdvvMg9OPmxT1jdIevFtsTfVRym3cQ0nzJ5BacUQhKmIHuJ9zH18Et0BE4KgAsCLp7YD5kdB2T5FkHTrToQpH9vWGnCoYcXhK+4bYINxXwyQGSErPOwG+3154DstjdF4AZn6UQge7N0+F3lX7yWoGl5+QZxMU8QWbTahemvxscZcujy07sUI2sHBHY3jfxhrw4lfS9xani92bOv/D9+Tu+dPFwbu/bItyinNyyghtfqzMxcbe3Ukf1a5nP8Bz3fmW3YJV0Q6DLqjKqGmNwUWQ5bj5H0hqJdtdC2qmfaTi602/bseTVClsxZ7g7HBOJXpgOTVew04lybsAwtup+J1qtQX7ToGtm2vQpMwUUaJwabN/KVlhnA7bwWf5diN0YRqRmGWWyAkeVzJGkIfHrOPEh0mEf9R7VI3QePqLxatrnzPoeRRuI9+Ez7wMUM10nU4tE=",
+  "system32": "C:\\Windows\\system32",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 334,
+    "uptime": "0:05 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "uptime": "0:05 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 334,
+  "uuid": "128B9558-F609-41F5-A88F-5F84C5DC854E",
+  "virtual": "virtualbox",
+  "windows_display_version": "23H2",
+  "windows_edition_id": "EnterpriseEval",
+  "windows_installation_type": "Client",
+  "windows_product_name": "Windows 10 Enterprise Evaluation",
+  "windows_release_id": "23H2"
+}

--- a/facts/4.5/windows-2019-x86_64.facts
+++ b/facts/4.5/windows-2019-x86_64.facts
@@ -1,0 +1,225 @@
+{
+  "aio_agent_version": "8.4.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "E9E43331-3478-4C89-9186-895D4580BB80"
+    }
+  },
+  "domain": "example.com",
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.5.2",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "FOO\\vagrant",
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "interfaces": "Ethernet",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::c2c9:fe72:6f76:9134",
+  "ipaddress6_Ethernet": "fe80::c2c9:fe72:6f76:9134",
+  "ipaddress_Ethernet": "10.0.2.15",
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.17763",
+  "kernelversion": "10.0.17763",
+  "macaddress": "08:00:27:E5:87:1C",
+  "macaddress_Ethernet": "08:00:27:E5:87:1C",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "943.78 MiB",
+      "available_bytes": 989622272,
+      "capacity": "53.55%",
+      "total": "1.98 GiB",
+      "total_bytes": 2130382848,
+      "used": "1.06 GiB",
+      "used_bytes": 1140760576
+    }
+  },
+  "memoryfree": "943.78 MiB",
+  "memoryfree_mb": 943.77734375,
+  "memorysize": "1.98 GiB",
+  "memorysize_mb": 2031.69140625,
+  "mtu_Ethernet": 1500,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet": "255.255.255.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_Ethernet": "fe80::",
+  "network_Ethernet": "10.0.2.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::c2c9:fe72:6f76:9134",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::c2c9:fe72:6f76:9134",
+        "mac": "08:00:27:E5:87:1C",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::c2c9:fe72:6f76:9134",
+    "mac": "08:00:27:E5:87:1C",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "Ethernet",
+    "scope6": "link"
+  },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2019",
+  "operatingsystemrelease": "2019",
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2019",
+      "major": "2019"
+    },
+    "windows": {
+      "edition_id": "ServerStandardEval",
+      "installation_type": "Server Core",
+      "product_name": "Windows Server 2019 Standard Evaluation",
+      "release_id": "1809",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "puppetversion": "8.4.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.2"
+  },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.2",
+  "scope6": "link",
+  "scope6_Ethernet": "link",
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 da3d3724f7f8b0e3ab30ca7349ef9efda8eb0319",
+        "sha256": "SSHFP 2 2 55c4b06c901fd0e622352214f4a9a34dcf36ab4652af57409c3651b1ada25ca2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBANLeFfA0TRjCj9OMRJzRljDStUT5inisMSIDkh65OpEisy01gojpnoDwBZH31C+msB9qKHfwaLkoooemdigu7hvHwx82l87mwx7OfJ41IIx7z9QuZQF/v0NJ9eRDamVScg8i6raw7hZXA+nN4xWbGGbnVjncyOxFZ4nsg09WnyzzAAAAFQCJcNeQH8d8/CdsdJfdGbXF4oEjRwAAAIBDvwu4h5JU8IhZEgXAtvBe0O+p8RoXu7+myR6itehHyo8bKgAHOdH/pGvYffItiBX+5uMphJ2aBAV25ziR1HTc6cllpxNVc92cx+hspb4sjSWMBLLC2k0qB+DUMtIsYv4koQXtOkc723aKSTDt6rTpOsKz74KoH2AEChekgBX/DQAAAIBbWLobKbZEIEudV2UfssezAm/4QaFFMukcozX/kHjtjJXVIzukHr4FwpBjOVcHMggyDB58oVtW9DurJkArqO4SMMChP0EW724bLGVN1rpQPYD5PoCB3WMKSW9C4aoWdh6tQOFWBPAeD0rm5qAAtdGohGWSnQXjeUTlHSlb4V7BWw==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 a4cebde0c5367b32b31e3dd6597c88aa20bb139c",
+        "sha256": "SSHFP 3 2 a999e89c223d66265c6baa4a835b946d0862a7d2e0243f57803fd4478dc794e0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJxt8oDeYlVoO5UREubI3+tcoLyWkPeWptxMLYMyVYTVK9i68m0246r/KmteLyD3DN2rnZyV6YZ3IjdfgBDkHR4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812",
+        "sha256": "SSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIDo2aL7+qAqwoih5z11JEsJg16mCMNEWnG9QFOHgA3l0",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d",
+        "sha256": "SSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBANLeFfA0TRjCj9OMRJzRljDStUT5inisMSIDkh65OpEisy01gojpnoDwBZH31C+msB9qKHfwaLkoooemdigu7hvHwx82l87mwx7OfJ41IIx7z9QuZQF/v0NJ9eRDamVScg8i6raw7hZXA+nN4xWbGGbnVjncyOxFZ4nsg09WnyzzAAAAFQCJcNeQH8d8/CdsdJfdGbXF4oEjRwAAAIBDvwu4h5JU8IhZEgXAtvBe0O+p8RoXu7+myR6itehHyo8bKgAHOdH/pGvYffItiBX+5uMphJ2aBAV25ziR1HTc6cllpxNVc92cx+hspb4sjSWMBLLC2k0qB+DUMtIsYv4koQXtOkc723aKSTDt6rTpOsKz74KoH2AEChekgBX/DQAAAIBbWLobKbZEIEudV2UfssezAm/4QaFFMukcozX/kHjtjJXVIzukHr4FwpBjOVcHMggyDB58oVtW9DurJkArqO4SMMChP0EW724bLGVN1rpQPYD5PoCB3WMKSW9C4aoWdh6tQOFWBPAeD0rm5qAAtdGohGWSnQXjeUTlHSlb4V7BWw==",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJxt8oDeYlVoO5UREubI3+tcoLyWkPeWptxMLYMyVYTVK9i68m0246r/KmteLyD3DN2rnZyV6YZ3IjdfgBDkHR4=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIDo2aL7+qAqwoih5z11JEsJg16mCMNEWnG9QFOHgA3l0",
+  "sshfp_dsa": "SSHFP 2 1 da3d3724f7f8b0e3ab30ca7349ef9efda8eb0319\nSSHFP 2 2 55c4b06c901fd0e622352214f4a9a34dcf36ab4652af57409c3651b1ada25ca2",
+  "sshfp_ecdsa": "SSHFP 3 1 a4cebde0c5367b32b31e3dd6597c88aa20bb139c\nSSHFP 3 2 a999e89c223d66265c6baa4a835b946d0862a7d2e0243f57803fd4478dc794e0",
+  "sshfp_ed25519": "SSHFP 4 1 9f196515ee27ca6ccee218024bfeb5b0a99d7812\nSSHFP 4 2 427cf51cb6b2a4f5eea42a9b26c761b443b9c4dff2218b24128525d2de39fe74",
+  "sshfp_rsa": "SSHFP 1 1 3596c7925dde9b4364b40ad238a04c8818100f3d\nSSHFP 1 2 f5085e8839097058fb84b33775337f2de0d77df772765907e697e2d7f5b4e32b",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gv55+SwnN/BrQPIUXbVGip65xZA3RnbyxFe5wKxHxkmfWsPNhuojDOFLpwKKU1ugNPNuTIChGkI0FyQYU1Ch4Sn4/zk5WN6JMdCP62L/nOMu8LuyTQbzJJyhIhC1r3/kfY2OyrVolZBCCmoSdSFSh39VwapMmcrizMALc3r1g9uLjBP/PZcgffWODA04c5GhX8KAEKQbNGbCXRvI56wHQjmM8QG53we4BfBsQoDyV7O/zU1Xl4ofvfIDWTYWpbOFNHfA4/FvjwaqekWIU4cFoenX+6xi7gzUgXRalYQmA5VZcw/Lo5YExMi2CSkQyUxdjbV9WSGcVgFuBaNRPvbwgPSLZx7+tlsaDh/5hZcVTb9n2siHyi9bX6V3gcIZ0f9evo2lNOi59bZ5bxcI/yttZ9/oz1gRqiwbR9ABq0/u01tjZbvBp8REwffnAQcWWlCj8bpsoSSM5Tgvd14sJ1Ajy88IjZ3MWvZkEWDxiZOWRmh2azL/qWXrdbPI2gudJHk=",
+  "system32": "C:\\Windows\\system32",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 699,
+    "uptime": "0:11 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "uptime": "0:11 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 699,
+  "uuid": "E9E43331-3478-4C89-9186-895D4580BB80",
+  "virtual": "virtualbox",
+  "windows_edition_id": "ServerStandardEval",
+  "windows_installation_type": "Server Core",
+  "windows_product_name": "Windows Server 2019 Standard Evaluation",
+  "windows_release_id": "1809"
+}

--- a/facts/4.5/windows-2022-x86_64.facts
+++ b/facts/4.5/windows-2022-x86_64.facts
@@ -1,0 +1,227 @@
+{
+  "aio_agent_version": "8.4.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063"
+    }
+  },
+  "domain": "example.com",
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.5.2",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "FOO\\vagrant",
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "interfaces": "Ethernet",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::8d97:e947:bec7:8686",
+  "ipaddress6_Ethernet": "fe80::8d97:e947:bec7:8686",
+  "ipaddress_Ethernet": "10.0.2.15",
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.20348",
+  "kernelversion": "10.0.20348",
+  "macaddress": "08:00:27:E7:59:F0",
+  "macaddress_Ethernet": "08:00:27:E7:59:F0",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "899.27 MiB",
+      "available_bytes": 942952448,
+      "capacity": "55.74%",
+      "total": "1.98 GiB",
+      "total_bytes": 2130382848,
+      "used": "1.11 GiB",
+      "used_bytes": 1187430400
+    }
+  },
+  "memoryfree": "899.27 MiB",
+  "memoryfree_mb": 899.26953125,
+  "memorysize": "1.98 GiB",
+  "memorysize_mb": 2031.69140625,
+  "mtu_Ethernet": 1500,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet": "255.255.255.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_Ethernet": "fe80::",
+  "network_Ethernet": "10.0.2.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::8d97:e947:bec7:8686",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::8d97:e947:bec7:8686",
+        "mac": "08:00:27:E7:59:F0",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::8d97:e947:bec7:8686",
+    "mac": "08:00:27:E7:59:F0",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "Ethernet",
+    "scope6": "link"
+  },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2022",
+  "operatingsystemrelease": "2022",
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2022",
+      "major": "2022"
+    },
+    "windows": {
+      "display_version": "21H2",
+      "edition_id": "ServerStandardEval",
+      "installation_type": "Server Core",
+      "product_name": "Windows Server 2022 Standard Evaluation",
+      "release_id": "21H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "puppetversion": "8.4.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.2"
+  },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.2",
+  "scope6": "link",
+  "scope6_Ethernet": "link",
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 2cbf142ec3e5298f32eb0fcccf139ce09d42e534",
+        "sha256": "SSHFP 2 2 7c39b6025bf87f7828dac9370dc4374061fa9b643e1fdcaf86ba55cea66b831a"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAOmczeAhgWVjwzCJYyJ38DOE98Xiaw45rmEULqbq6c2iy9YgTEp2DRl/AmOQNosKg1+e/DtrHgqWdIHQplipyOCd6wbJ131Z3PgmMcJqy4XAyhZcaa2wkHdUic0P+7qD1HengkIgquuizJzPKnX1klM2e1QgUeuXZT/ULRW9vI8NAAAAFQD/jjjBCL+7QwI+8iQYAKtp5rW/dwAAAIEAsVXIkqYxA9PgeklIXuchjvTsIAnzFeixSa5p51xCTDBll91QEFX3OtzK3Vp2puJDXBvwymuPnBCaW31AepDnWv4m3YmFWd3s6ZIp8qPbi1UfhkoIH11gwcz4kQT5h6gBbA717d+1DAAw9W6174Ju1dKdoqg86ZNtA5QfgBZ06xwAAACBANZ1rECCGE2HVWbxDBHf6mAv5yoBRNUbPWQ3DYM5qLdYhqPCFmcRdaxIjOtCuqutviphOYEdEWY//jR86GkPGJZeK5Sg6+ol0eZTDNox933GeNuuLTg57F77ODTfeEpYgPNTlklG+MI/V0xjpgiaN+aqfyCmPUh6X0m+epYNXLIJ",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 3bd1e5d4b841b0150d1d9d1ae1e926c0f8c01baf",
+        "sha256": "SSHFP 3 2 f49774b85c325c1b3a03ca07d43b59bc0483c1bed307e1e0eda8146a7f8a32d3"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdzf7SfxY+LVZayjebjV98AK/c7sFT6rOvVu1pKJyaAGKJvERyVlay9aUOo5EZbGqud61jYpLXrAlGuOQZyWeg=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c",
+        "sha256": "SSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIPOwOYrxf49nywRDLItAiMup1peRQkpfykjDknfisRzq",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c",
+        "sha256": "SSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAOmczeAhgWVjwzCJYyJ38DOE98Xiaw45rmEULqbq6c2iy9YgTEp2DRl/AmOQNosKg1+e/DtrHgqWdIHQplipyOCd6wbJ131Z3PgmMcJqy4XAyhZcaa2wkHdUic0P+7qD1HengkIgquuizJzPKnX1klM2e1QgUeuXZT/ULRW9vI8NAAAAFQD/jjjBCL+7QwI+8iQYAKtp5rW/dwAAAIEAsVXIkqYxA9PgeklIXuchjvTsIAnzFeixSa5p51xCTDBll91QEFX3OtzK3Vp2puJDXBvwymuPnBCaW31AepDnWv4m3YmFWd3s6ZIp8qPbi1UfhkoIH11gwcz4kQT5h6gBbA717d+1DAAw9W6174Ju1dKdoqg86ZNtA5QfgBZ06xwAAACBANZ1rECCGE2HVWbxDBHf6mAv5yoBRNUbPWQ3DYM5qLdYhqPCFmcRdaxIjOtCuqutviphOYEdEWY//jR86GkPGJZeK5Sg6+ol0eZTDNox933GeNuuLTg57F77ODTfeEpYgPNTlklG+MI/V0xjpgiaN+aqfyCmPUh6X0m+epYNXLIJ",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdzf7SfxY+LVZayjebjV98AK/c7sFT6rOvVu1pKJyaAGKJvERyVlay9aUOo5EZbGqud61jYpLXrAlGuOQZyWeg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIPOwOYrxf49nywRDLItAiMup1peRQkpfykjDknfisRzq",
+  "sshfp_dsa": "SSHFP 2 1 2cbf142ec3e5298f32eb0fcccf139ce09d42e534\nSSHFP 2 2 7c39b6025bf87f7828dac9370dc4374061fa9b643e1fdcaf86ba55cea66b831a",
+  "sshfp_ecdsa": "SSHFP 3 1 3bd1e5d4b841b0150d1d9d1ae1e926c0f8c01baf\nSSHFP 3 2 f49774b85c325c1b3a03ca07d43b59bc0483c1bed307e1e0eda8146a7f8a32d3",
+  "sshfp_ed25519": "SSHFP 4 1 d90c588d7e89b743439d6bbde8cbf68de80f554c\nSSHFP 4 2 4a3633cdbef6f2e3d7aebacb4cd127890cdb0d05a8fffa36047a2da574008117",
+  "sshfp_rsa": "SSHFP 1 1 c9f7a8861f449e575242f99981ed7580d609f86c\nSSHFP 1 2 5f9ff10646bb92e2f762c650f1f4486331b2848960ab8519031f1fdf1bd92d19",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDQfE6HJW1DZInpdu3xQG1ok0bY+IK2Jhfk3kGd087eE8nuzm1O0JLe5A9elSLCe1I63MTxadw/ZI48DiAnd4q8MckaqU2bE7ycfO1N6KLvBIZ6bmlWR+XpW/0rxLD3aP/lvuu7R731PdgfH5APDyyqYLVdPI1JdvfopJf/55gJqjdZkNE4S5OGUqXEuiwPYL56OgNntwqvoRDvOLQ8DDPNlcz/PGR0tIxhakUM7cPhkBYSZWvTnoJQCJcyx9OE7li9dH0ZnfQ2wezm0cro2Nh3enRN0yeHZ69CvWMoMbotxlKDdM0Gyn7rEvP/9JVr9Mll9UjqO8qbFJYc4E0QjmMQNrEjH9d+F8JsavMh9azZ9f4X2vY83A658RnbweJIscITmIeqPiyyoWLDDJ5XniatYTfpMXKk5SpkvRf7l/LzywK0NsCRioOppOw+mxHcsuDgPYiCmkLq7LYbC6FMZc/PtqpA+UNnxxTsnOfTtIfSyrkIo+LdBPcpxtkiBCZ5AFU=",
+  "system32": "C:\\Windows\\system32",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 300,
+    "uptime": "0:05 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "uptime": "0:05 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 300,
+  "uuid": "F2FE13B6-2E77-4300-B709-3654FF7B6063",
+  "virtual": "virtualbox",
+  "windows_display_version": "21H2",
+  "windows_edition_id": "ServerStandardEval",
+  "windows_installation_type": "Server Core",
+  "windows_product_name": "Windows Server 2022 Standard Evaluation",
+  "windows_release_id": "21H2"
+}

--- a/facts/4.6/ubuntu-20.04-x86_64.facts
+++ b/facts/4.6/ubuntu-20.04-x86_64.facts
@@ -1,0 +1,655 @@
+{
+  "aio_agent_version": "8.5.1",
+  "architecture": "amd64",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "augeasversion": "1.14.1",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "VBOX",
+  "blockdevice_sdb_model": "HARDDISK",
+  "blockdevice_sdb_size": 10485760,
+  "blockdevice_sdb_vendor": "VBOX",
+  "blockdevices": "sdb,sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "enp0s3": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "disks": {
+    "sda": {
+      "model": "HARDDISK",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "VBOX"
+    },
+    "sdb": {
+      "model": "HARDDISK",
+      "size": "10.00 MiB",
+      "size_bytes": 10485760,
+      "type": "hdd",
+      "vendor": "VBOX"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.6.1",
+  "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "enp0s3,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::e9:94ff:fee1:d413",
+  "ipaddress6_enp0s3": "fe80::e9:94ff:fee1:d413",
+  "ipaddress6_lo": "::1",
+  "ipaddress_enp0s3": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.4",
+  "kernelrelease": "5.4.0-173-generic",
+  "kernelversion": "5.4.0",
+  "load_averages": {
+    "15m": 0.11,
+    "1m": 0.82,
+    "5m": 0.3
+  },
+  "lsbdistcodename": "focal",
+  "lsbdistdescription": "Ubuntu 20.04.6 LTS",
+  "lsbdistid": "Ubuntu",
+  "lsbdistrelease": "20.04",
+  "lsbmajdistrelease": "20.04",
+  "macaddress": "02:e9:94:e1:d4:13",
+  "macaddress_enp0s3": "02:e9:94:e1:d4:13",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "587.93 MiB",
+      "available_bytes": 616488960,
+      "capacity": "39.07%",
+      "total": "964.86 MiB",
+      "total_bytes": 1011732480,
+      "used": "376.93 MiB",
+      "used_bytes": 395243520
+    }
+  },
+  "memoryfree": "587.93 MiB",
+  "memoryfree_mb": 587.9296875,
+  "memorysize": "964.86 MiB",
+  "memorysize_mb": 964.86328125,
+  "mountpoints": {
+    "/": {
+      "available": "36.75 GiB",
+      "available_bytes": 39462391808,
+      "capacity": "5.00%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "38.70 GiB",
+      "size_bytes": 41555521536,
+      "used": "1.93 GiB",
+      "used_bytes": 2076352512
+    },
+    "/dev": {
+      "available": "465.45 MiB",
+      "available_bytes": 488058880,
+      "capacity": "0%",
+      "device": "udev",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "size=476620k",
+        "nr_inodes=119155",
+        "mode=755"
+      ],
+      "size": "465.45 MiB",
+      "size_bytes": 488058880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "482.43 MiB",
+      "available_bytes": 505864192,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "482.43 MiB",
+      "size_bytes": 505864192,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "95.52 MiB",
+      "available_bytes": 100155392,
+      "capacity": "1.01%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=98804k",
+        "mode=755"
+      ],
+      "size": "96.49 MiB",
+      "size_bytes": 101175296,
+      "used": "996.00 KiB",
+      "used_bytes": 1019904
+    },
+    "/run/lock": {
+      "available": "5.00 MiB",
+      "available_bytes": 5242880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=5120k"
+      ],
+      "size": "5.00 MiB",
+      "size_bytes": 5242880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/snapd/ns": {
+      "available": "95.52 MiB",
+      "available_bytes": 100155392,
+      "capacity": "1.01%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=98804k",
+        "mode=755"
+      ],
+      "size": "96.49 MiB",
+      "size_bytes": 101175296,
+      "used": "996.00 KiB",
+      "used_bytes": 1019904
+    },
+    "/run/snapd/ns/lxd.mnt": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "nsfs",
+      "filesystem": "nsfs",
+      "options": [
+        "rw"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.48 MiB",
+      "available_bytes": 101171200,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98800k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "96.48 MiB",
+      "size_bytes": 101171200,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/snap/core20/2182": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop2",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "64.00 MiB",
+      "used_bytes": 67108864
+    },
+    "/snap/lxd/24061": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop0",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "91.88 MiB",
+      "size_bytes": 96337920,
+      "used": "91.88 MiB",
+      "used_bytes": 96337920
+    },
+    "/snap/snapd/21184": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop1",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "39.13 MiB",
+      "size_bytes": 41025536,
+      "used": "39.13 MiB",
+      "used_bytes": 41025536
+    },
+    "/sys/fs/cgroup": {
+      "available": "482.43 MiB",
+      "available_bytes": 505864192,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "482.43 MiB",
+      "size_bytes": 505864192,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "66.50 GiB",
+      "available_bytes": 71405727744,
+      "capacity": "4.91%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "69.94 GiB",
+      "size_bytes": 75094818816,
+      "used": "3.44 GiB",
+      "used_bytes": 3689091072
+    }
+  },
+  "mtu_enp0s3": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_enp0s3": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_enp0s3": "fe80::",
+  "network6_lo": "::1",
+  "network_enp0s3": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "enp0s3": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::e9:94ff:fee1:d413",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::e9:94ff:fee1:d413",
+        "mac": "02:e9:94:e1:d4:13",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::e9:94ff:fee1:d413",
+    "mac": "02:e9:94:e1:d4:13",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "enp0s3",
+    "scope6": "link"
+  },
+  "operatingsystem": "Ubuntu",
+  "operatingsystemmajrelease": "20.04",
+  "operatingsystemrelease": "20.04",
+  "os": {
+    "architecture": "amd64",
+    "distro": {
+      "codename": "focal",
+      "description": "Ubuntu 20.04.6 LTS",
+      "id": "Ubuntu",
+      "release": {
+        "full": "20.04",
+        "major": "20.04"
+      }
+    },
+    "family": "Debian",
+    "hardware": "x86_64",
+    "name": "Ubuntu",
+    "release": {
+      "full": "20.04",
+      "major": "20.04"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "osfamily": "Debian",
+  "partitions": {
+    "/dev/loop0": {
+      "backing_file": "/var/lib/snapd/snaps/lxd_24061.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/lxd/24061",
+      "size": "91.83 MiB",
+      "size_bytes": 96292864
+    },
+    "/dev/loop1": {
+      "backing_file": "/var/lib/snapd/snaps/snapd_21184.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/snapd/21184",
+      "size": "39.10 MiB",
+      "size_bytes": 40996864
+    },
+    "/dev/loop2": {
+      "backing_file": "/var/lib/snapd/snaps/core20_2182.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/core20/2182",
+      "size": "63.91 MiB",
+      "size_bytes": 67010560
+    },
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "cloudimg-rootfs",
+      "mount": "/",
+      "partuuid": "90b16b70-01",
+      "size": "40.00 GiB",
+      "size_bytes": 42948607488,
+      "uuid": "840239b4-984e-441d-9d80-d2f9e890129a"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "speed": "3.20 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "puppetversion": "8.5.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.3"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.3",
+  "scope6": "link",
+  "scope6_enp0s3": "link",
+  "scope6_lo": "host",
+  "selinux": false,
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 5c6fcc04c3b45a379e0c67fe378942a999a89c24",
+        "sha256": "SSHFP 2 2 512e7148f98729224cbde8eaf2587bfd51081f2ae5192db1e22bfcca4cfff2f2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAM0o+WuKIcCpjxscnJ7vw2nHx2dktGa79k6/IgxVEAOJqNZNE/YVMeMVR5OUfPWymF9gRs1LtM0YO5bVuCKdIls2AsImRJGlTHAhx7wut7xh+giXu7PaFdX6WHkJ/khrrGLfDFlvZKnZ3gTW8oRiiTBNaWAkdwvAovJiKwoMdqZVAAAAFQCbdy73nnbg9bqnbgfa+rStxARBcQAAAIAxm/LoUa1Ptz87aasVWVQPLsHWAfrBAQoHqm2o13hz70KC0oy+uUaWYJ8DXjdO7xjWZh03Eo5f4VK2XVn5NMOk7ya9AyTpt3k/+eBDd1LieZHxw5rHi4FFt5cc26mcXStcPFeKJwOpIKrUts9Ai5J2QwYKnjgvb9h2YROlAb44XgAAAIEAjWe/l/MHtO+pj6/0a5iWgi6W3J4x0vV+p3B9qxdhHTLFucgX9JRk1j91jt4KYdKMa15Ao7ZevBnYxSIrjbFYKrfvoGarJS6PyqOmzOA6Ugo9LFWEtmfyWz4pE9d3lUblgz+Rqqj7UdynAr6tD9rsXW/2yupzv7v6FwOpwoz8hFU=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 9f5c7a00195b95bf0d500f04f60d73a1a21bfafc",
+        "sha256": "SSHFP 3 2 26cf83c0bf201a3dc1cf54d9940ed016c2616a97732a4a1e494b5146c7e64de0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdcZSewqojLu9WBiYzdl1u8HOyeZImhj0/EgTT3jFy1dY9eup9+ubLIrw7SqALsn9U7gyN0z++1pDYU4BAmWvQ=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 634c26f1d899d60285740399f9a7767c12b4ef82",
+        "sha256": "SSHFP 4 2 be86d52c09eeecef6c7f831066bc4b3402dc06bc5f5bd2ba599c9a4f56037ba1"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIA+VOqzE5Oji6OYO9luw1Nu/2OwHews7xP0xofzY6dyb",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 1f37a0ff0e197d4da1694e681939e6242fcc38a5",
+        "sha256": "SSHFP 1 2 cc48d857cd264b6d51f348ef861f3c1bb1cc3b5378841ff6e89dc2232f4d5222"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDYPpqBmRKrOIp0QqIvI7rTY+aiXJ5WwixbYCXydSL7RiyfBTFvsxeAb+o3p+kFcvKgBOCXjBwdjaz44zxo40jANWEPzDRjzVTtf0yj0Q8vySzAqjXwD9RpRF2N3RHq9GFh6hDs0TKAP71rfH2hVjFDdkPRUXLXMWuSndNkoPf6BRsb7+NToPOFrRKPiJlR7+Hpg4i4+WruxCjkZ1r/woTtguKMqfFIaRAhNsVBUdjzqpsQrO9trn1ttIk2pKNukQ4o+SXpc8Wxl/QN3Cy+Tf6SUiiHvZdi/ewCzG3uOSk8RxIM7VKp6DSzM8e8HEyDdj/2JatiCrTGsd0RtwmCl04yPFdWcdVXlG7WxPl3O/cF4ScA5GjGcTicUPUm1N8MX0mbzIn0wRsjJZ+UgomBH7sruP23P4lSfm2vfKdU2EKKdEeHRMc65vDgHPPN2gjmtJa2ANWrGylW3yBtf+2eH8BxluiLdiWbo9PsaDZ/wVUP39SUDloPbmqxGmp+s16auuk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAM0o+WuKIcCpjxscnJ7vw2nHx2dktGa79k6/IgxVEAOJqNZNE/YVMeMVR5OUfPWymF9gRs1LtM0YO5bVuCKdIls2AsImRJGlTHAhx7wut7xh+giXu7PaFdX6WHkJ/khrrGLfDFlvZKnZ3gTW8oRiiTBNaWAkdwvAovJiKwoMdqZVAAAAFQCbdy73nnbg9bqnbgfa+rStxARBcQAAAIAxm/LoUa1Ptz87aasVWVQPLsHWAfrBAQoHqm2o13hz70KC0oy+uUaWYJ8DXjdO7xjWZh03Eo5f4VK2XVn5NMOk7ya9AyTpt3k/+eBDd1LieZHxw5rHi4FFt5cc26mcXStcPFeKJwOpIKrUts9Ai5J2QwYKnjgvb9h2YROlAb44XgAAAIEAjWe/l/MHtO+pj6/0a5iWgi6W3J4x0vV+p3B9qxdhHTLFucgX9JRk1j91jt4KYdKMa15Ao7ZevBnYxSIrjbFYKrfvoGarJS6PyqOmzOA6Ugo9LFWEtmfyWz4pE9d3lUblgz+Rqqj7UdynAr6tD9rsXW/2yupzv7v6FwOpwoz8hFU=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdcZSewqojLu9WBiYzdl1u8HOyeZImhj0/EgTT3jFy1dY9eup9+ubLIrw7SqALsn9U7gyN0z++1pDYU4BAmWvQ=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIA+VOqzE5Oji6OYO9luw1Nu/2OwHews7xP0xofzY6dyb",
+  "sshfp_dsa": "SSHFP 2 1 5c6fcc04c3b45a379e0c67fe378942a999a89c24\nSSHFP 2 2 512e7148f98729224cbde8eaf2587bfd51081f2ae5192db1e22bfcca4cfff2f2",
+  "sshfp_ecdsa": "SSHFP 3 1 9f5c7a00195b95bf0d500f04f60d73a1a21bfafc\nSSHFP 3 2 26cf83c0bf201a3dc1cf54d9940ed016c2616a97732a4a1e494b5146c7e64de0",
+  "sshfp_ed25519": "SSHFP 4 1 634c26f1d899d60285740399f9a7767c12b4ef82\nSSHFP 4 2 be86d52c09eeecef6c7f831066bc4b3402dc06bc5f5bd2ba599c9a4f56037ba1",
+  "sshfp_rsa": "SSHFP 1 1 1f37a0ff0e197d4da1694e681939e6242fcc38a5\nSSHFP 1 2 cc48d857cd264b6d51f348ef861f3c1bb1cc3b5378841ff6e89dc2232f4d5222",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDYPpqBmRKrOIp0QqIvI7rTY+aiXJ5WwixbYCXydSL7RiyfBTFvsxeAb+o3p+kFcvKgBOCXjBwdjaz44zxo40jANWEPzDRjzVTtf0yj0Q8vySzAqjXwD9RpRF2N3RHq9GFh6hDs0TKAP71rfH2hVjFDdkPRUXLXMWuSndNkoPf6BRsb7+NToPOFrRKPiJlR7+Hpg4i4+WruxCjkZ1r/woTtguKMqfFIaRAhNsVBUdjzqpsQrO9trn1ttIk2pKNukQ4o+SXpc8Wxl/QN3Cy+Tf6SUiiHvZdi/ewCzG3uOSk8RxIM7VKp6DSzM8e8HEyDdj/2JatiCrTGsd0RtwmCl04yPFdWcdVXlG7WxPl3O/cF4ScA5GjGcTicUPUm1N8MX0mbzIn0wRsjJZ+UgomBH7sruP23P4lSfm2vfKdU2EKKdEeHRMc65vDgHPPN2gjmtJa2ANWrGylW3yBtf+2eH8BxluiLdiWbo9PsaDZ/wVUP39SUDloPbmqxGmp+s16auuk=",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 94,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:01 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 94,
+  "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/opensuse-15-x86_64.facts
+++ b/facts/4.7/opensuse-15-x86_64.facts
@@ -1,0 +1,541 @@
+{
+  "aio_agent_version": "8.6.0",
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "augeasversion": "1.14.1",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 45097156608,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb981d6b5-7ce9f28b",
+      "size": "42.00 GiB",
+      "size_bytes": 45097156608,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "95ee16a2-96bf-c74e-8bc9-b20f4e0d8454",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.7.0",
+  "filesystems": "ext2,ext3,ext4",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:fe02:113f",
+  "ipaddress6_eth0": "fe80::a00:27ff:fe02:113f",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.21-150400.24.97-default",
+  "kernelversion": "5.14.21",
+  "load_averages": {
+    "15m": 0.11,
+    "1m": 0.76,
+    "5m": 0.3
+  },
+  "lsbdistrelease": "15.4",
+  "lsbmajdistrelease": "15",
+  "lsbminordistrelease": "4",
+  "macaddress": "08:00:27:02:11:3f",
+  "macaddress_eth0": "08:00:27:02:11:3f",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "672.99 MiB",
+      "available_bytes": 705683456,
+      "capacity": "29.21%",
+      "total": "950.71 MiB",
+      "total_bytes": 996888576,
+      "used": "277.71 MiB",
+      "used_bytes": 291205120
+    }
+  },
+  "memoryfree": "672.99 MiB",
+  "memoryfree_mb": 672.9921875,
+  "memorysize": "950.71 MiB",
+  "memorysize_mb": 950.70703125,
+  "mountpoints": {
+    "/": {
+      "available": "37.50 GiB",
+      "available_bytes": 40260124672,
+      "capacity": "3.68%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "41.04 GiB",
+      "size_bytes": 44069601280,
+      "used": "1.43 GiB",
+      "used_bytes": 1537896448
+    },
+    "/dev": {
+      "available": "3.99 MiB",
+      "available_bytes": 4186112,
+      "capacity": "0.20%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=1048576",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "8.00 KiB",
+      "used_bytes": 8192
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "475.35 MiB",
+      "available_bytes": 498438144,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "475.35 MiB",
+      "size_bytes": 498442240,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/run": {
+      "available": "184.81 MiB",
+      "available_bytes": 193785856,
+      "capacity": "2.81%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "size=194708k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "190.14 MiB",
+      "size_bytes": 199380992,
+      "used": "5.34 MiB",
+      "used_bytes": 5595136
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "95.07 MiB",
+      "available_bytes": 99684352,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=97352k",
+        "nr_inodes=24338",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "95.07 MiB",
+      "size_bytes": 99688448,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/sys/fs/cgroup": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "size=4096k",
+        "nr_inodes=1024",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "66.50 GiB",
+      "available_bytes": 71398875136,
+      "capacity": "4.92%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "69.94 GiB",
+      "size_bytes": 75094818816,
+      "used": "3.44 GiB",
+      "used_bytes": 3695943680
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::a00:27ff:fe02:113f",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::a00:27ff:fe02:113f",
+        "mac": "08:00:27:02:11:3f",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::a00:27ff:fe02:113f",
+    "mac": "08:00:27:02:11:3f",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "openSUSE",
+  "operatingsystemmajrelease": "15",
+  "operatingsystemrelease": "15.4",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "openSUSE Leap 15.4",
+      "id": "SUSE",
+      "release": {
+        "full": "15.4",
+        "major": "15",
+        "minor": "4"
+      }
+    },
+    "family": "Suse",
+    "hardware": "x86_64",
+    "name": "openSUSE",
+    "release": {
+      "full": "15.4",
+      "major": "15",
+      "minor": "4"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "osfamily": "Suse",
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "ROOT",
+      "mount": "/",
+      "partuuid": "2e122852-01",
+      "size": "42.00 GiB",
+      "size_bytes": 45096108032,
+      "uuid": "0eb354dc-0c5a-4d9e-acae-1c54ed672cf0"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 1,
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "x86_64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "speed": "3.20 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "puppetversion": "8.6.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.3"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.3",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": false,
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 bad7237d7d5a3e8b090715267803e1e6e4358f84",
+        "sha256": "SSHFP 2 2 c0d10ffacd6aa18939455b98419d4183708f28f8b9a49d7a9a6e81dcff88137e"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBANIz5QA+Tw5pQB1UmIRucUnzo08JygBAyl1jy/xOwehZjrZ9/MtpDK8b+nppKRQQwP/VWQ/Wdh8gTe1Ws7p7u84NRwBw6jeSN/HM5SxHVpmUfjM4T+V1ZptOvIL6h6fdQsQVY5x4Uczuns/H8T1jRYA3o9Rk0kqTZCIy7oA/c68rAAAAFQDK3HqcL+n7pgLXLaayL6i3kJlz0QAAAIAIFVZ1zkU2PRykgebmUzDNt17i//V2pA83kksZ2TMfX6lB34aloKR2u7MnCSXFlgfhhY8yZzXPcoWqu3zgUphLP6zrBnjEWlGci3S4NPsDjxzWzI5KsNy/nx1FfaHMo+WpjFbfgsd4xpCbSQquuwz6s8el1UdK/qS6MwpkiAPUfAAAAIEAuuPiQDD6eGN54UA0HHIUwuD5hOcK2t3anmzF6dTgoT50VtX5dUtZ+Qy5vLQC9by+Oz/6Z1Y1pDAGgbC+XGkc6sroP9bQW5M5rf9KqC17f3TPz2VgLxEgEXhgW4ED7uAcJmD22uF5oWSH4uzeKaqIVNLwV7yNvHdjzYscoAiKcOY=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 f940b672a615cdd6576ca8498db5fa033e4ec4e4",
+        "sha256": "SSHFP 3 2 cb822d913ab86622d223ccdac08719d224f67d5d02457a0a8aea7db368feaf0e"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFqtfR6lz96epm4clhNAAz8hjd275fEsNXxHrM69S5BJt8J+yUrxpTc33lyBKZgFtaejVbRgF4Muy0HF6iiuPVA=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 40d5500f8f62c1738637c0440c0c4fb6de87ccb4",
+        "sha256": "SSHFP 4 2 69861eec104049d63e9f1af170a647ffb0310925efedd22f0422f4214938091a"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIC+uNFIyNT3dRDMrsj+OqvNIpCoxh/SixM5SRs8QKCnO",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 1cecb5685a580b675c03880e231f292f28303b58",
+        "sha256": "SSHFP 1 2 6fbaee33b3638ee9e65fb303f931d20955a968ef21e2afaa39edd9160c7ab92b"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9sb5Cy/8HpY6Ct1fuwqnfxsVA3EetWxeJ36Mi+xpeWCtAgBMmEGi+60i1N/xqSAchVPNRLPOMXNwGcG2VfGxEBTCDsXCMZ8vFriUbskG7AfmavPjet2meAcrST9Wp6Tfl14bKajs73sz3dPcEslKMO8ur96GqRlYU7c1lw4Og/E/HlBJc2WIvP+aketnIw8g65vGtW9OiUf7j6+AbAVQiZH4FDXkl+lYw5gKsNJl53EonsLEWnMsfGwGwzNFDT+0wHcirBiOOZeKp132Ak72hnZE1m0KVccAX7WDUSazyvFrJaXpJMtWCLZ/ssG003xSadN/mMo4DlhibGGU9UP5o8rKZwF34UHVRKlrLOdxPcq15Xrv3BgF9zTt4T0d+WUqufapt3vdrz3pD7kVFCJ2b5F4jNhTJbI4nJWb8hM+V8TFco3EHa4wfGwe/eYQiu+k8KBmeNl3oW9ERkBlulNU3Twj4ltn7WhslD27W7spOjOQ7WBnUdu5RlzNhffoSkBs=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBANIz5QA+Tw5pQB1UmIRucUnzo08JygBAyl1jy/xOwehZjrZ9/MtpDK8b+nppKRQQwP/VWQ/Wdh8gTe1Ws7p7u84NRwBw6jeSN/HM5SxHVpmUfjM4T+V1ZptOvIL6h6fdQsQVY5x4Uczuns/H8T1jRYA3o9Rk0kqTZCIy7oA/c68rAAAAFQDK3HqcL+n7pgLXLaayL6i3kJlz0QAAAIAIFVZ1zkU2PRykgebmUzDNt17i//V2pA83kksZ2TMfX6lB34aloKR2u7MnCSXFlgfhhY8yZzXPcoWqu3zgUphLP6zrBnjEWlGci3S4NPsDjxzWzI5KsNy/nx1FfaHMo+WpjFbfgsd4xpCbSQquuwz6s8el1UdK/qS6MwpkiAPUfAAAAIEAuuPiQDD6eGN54UA0HHIUwuD5hOcK2t3anmzF6dTgoT50VtX5dUtZ+Qy5vLQC9by+Oz/6Z1Y1pDAGgbC+XGkc6sroP9bQW5M5rf9KqC17f3TPz2VgLxEgEXhgW4ED7uAcJmD22uF5oWSH4uzeKaqIVNLwV7yNvHdjzYscoAiKcOY=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFqtfR6lz96epm4clhNAAz8hjd275fEsNXxHrM69S5BJt8J+yUrxpTc33lyBKZgFtaejVbRgF4Muy0HF6iiuPVA=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIC+uNFIyNT3dRDMrsj+OqvNIpCoxh/SixM5SRs8QKCnO",
+  "sshfp_dsa": "SSHFP 2 1 bad7237d7d5a3e8b090715267803e1e6e4358f84\nSSHFP 2 2 c0d10ffacd6aa18939455b98419d4183708f28f8b9a49d7a9a6e81dcff88137e",
+  "sshfp_ecdsa": "SSHFP 3 1 f940b672a615cdd6576ca8498db5fa033e4ec4e4\nSSHFP 3 2 cb822d913ab86622d223ccdac08719d224f67d5d02457a0a8aea7db368feaf0e",
+  "sshfp_ed25519": "SSHFP 4 1 40d5500f8f62c1738637c0440c0c4fb6de87ccb4\nSSHFP 4 2 69861eec104049d63e9f1af170a647ffb0310925efedd22f0422f4214938091a",
+  "sshfp_rsa": "SSHFP 1 1 1cecb5685a580b675c03880e231f292f28303b58\nSSHFP 1 2 6fbaee33b3638ee9e65fb303f931d20955a968ef21e2afaa39edd9160c7ab92b",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC9sb5Cy/8HpY6Ct1fuwqnfxsVA3EetWxeJ36Mi+xpeWCtAgBMmEGi+60i1N/xqSAchVPNRLPOMXNwGcG2VfGxEBTCDsXCMZ8vFriUbskG7AfmavPjet2meAcrST9Wp6Tfl14bKajs73sz3dPcEslKMO8ur96GqRlYU7c1lw4Og/E/HlBJc2WIvP+aketnIw8g65vGtW9OiUf7j6+AbAVQiZH4FDXkl+lYw5gKsNJl53EonsLEWnMsfGwGwzNFDT+0wHcirBiOOZeKp132Ak72hnZE1m0KVccAX7WDUSazyvFrJaXpJMtWCLZ/ssG003xSadN/mMo4DlhibGGU9UP5o8rKZwF34UHVRKlrLOdxPcq15Xrv3BgF9zTt4T0d+WUqufapt3vdrz3pD7kVFCJ2b5F4jNhTJbI4nJWb8hM+V8TFco3EHa4wfGwe/eYQiu+k8KBmeNl3oW9ERkBlulNU3Twj4ltn7WhslD27W7spOjOQ7WBnUdu5RlzNhffoSkBs=",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 164,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:02 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 164,
+  "uuid": "95ee16a2-96bf-c74e-8bc9-b20f4e0d8454",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/ubuntu-20.04-x86_64.facts
+++ b/facts/4.7/ubuntu-20.04-x86_64.facts
@@ -1,0 +1,655 @@
+{
+  "aio_agent_version": "8.6.0",
+  "architecture": "amd64",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "augeasversion": "1.14.1",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "VBOX",
+  "blockdevice_sdb_model": "HARDDISK",
+  "blockdevice_sdb_size": 10485760,
+  "blockdevice_sdb_vendor": "VBOX",
+  "blockdevices": "sdb,sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "enp0s3": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
+  "disks": {
+    "sda": {
+      "model": "HARDDISK",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "VBOX"
+    },
+    "sdb": {
+      "model": "HARDDISK",
+      "size": "10.00 MiB",
+      "size_bytes": 10485760,
+      "type": "hdd",
+      "vendor": "VBOX"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.7.0",
+  "filesystems": "btrfs,ext2,ext3,ext4,iso9660,squashfs,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "161095",
+      "version": "7.0.14"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "enp0s3,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::e9:94ff:fee1:d413",
+  "ipaddress6_enp0s3": "fe80::e9:94ff:fee1:d413",
+  "ipaddress6_lo": "::1",
+  "ipaddress_enp0s3": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.4",
+  "kernelrelease": "5.4.0-173-generic",
+  "kernelversion": "5.4.0",
+  "load_averages": {
+    "15m": 0.09,
+    "1m": 0.76,
+    "5m": 0.26
+  },
+  "lsbdistcodename": "focal",
+  "lsbdistdescription": "Ubuntu 20.04.6 LTS",
+  "lsbdistid": "Ubuntu",
+  "lsbdistrelease": "20.04",
+  "lsbmajdistrelease": "20.04",
+  "macaddress": "02:e9:94:e1:d4:13",
+  "macaddress_enp0s3": "02:e9:94:e1:d4:13",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "system": {
+      "available": "592.66 MiB",
+      "available_bytes": 621445120,
+      "capacity": "38.58%",
+      "total": "964.86 MiB",
+      "total_bytes": 1011732480,
+      "used": "372.21 MiB",
+      "used_bytes": 390287360
+    }
+  },
+  "memoryfree": "592.66 MiB",
+  "memoryfree_mb": 592.65625,
+  "memorysize": "964.86 MiB",
+  "memorysize_mb": 964.86328125,
+  "mountpoints": {
+    "/": {
+      "available": "36.79 GiB",
+      "available_bytes": 39498289152,
+      "capacity": "4.91%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "38.70 GiB",
+      "size_bytes": 41555521536,
+      "used": "1.90 GiB",
+      "used_bytes": 2040455168
+    },
+    "/dev": {
+      "available": "465.45 MiB",
+      "available_bytes": 488058880,
+      "capacity": "0%",
+      "device": "udev",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "size=476620k",
+        "nr_inodes=119155",
+        "mode=755"
+      ],
+      "size": "465.45 MiB",
+      "size_bytes": 488058880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "482.43 MiB",
+      "available_bytes": 505864192,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "482.43 MiB",
+      "size_bytes": 505864192,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "95.52 MiB",
+      "available_bytes": 100155392,
+      "capacity": "1.01%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=98804k",
+        "mode=755"
+      ],
+      "size": "96.49 MiB",
+      "size_bytes": 101175296,
+      "used": "996.00 KiB",
+      "used_bytes": 1019904
+    },
+    "/run/lock": {
+      "available": "5.00 MiB",
+      "available_bytes": 5242880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=5120k"
+      ],
+      "size": "5.00 MiB",
+      "size_bytes": 5242880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/snapd/ns": {
+      "available": "95.52 MiB",
+      "available_bytes": 100155392,
+      "capacity": "1.01%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=98804k",
+        "mode=755"
+      ],
+      "size": "96.49 MiB",
+      "size_bytes": 101175296,
+      "used": "996.00 KiB",
+      "used_bytes": 1019904
+    },
+    "/run/snapd/ns/lxd.mnt": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "nsfs",
+      "filesystem": "nsfs",
+      "options": [
+        "rw"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.48 MiB",
+      "available_bytes": 101171200,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98800k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "96.48 MiB",
+      "size_bytes": 101171200,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/snap/core20/2182": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop2",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "64.00 MiB",
+      "size_bytes": 67108864,
+      "used": "64.00 MiB",
+      "used_bytes": 67108864
+    },
+    "/snap/lxd/24061": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop0",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "91.88 MiB",
+      "size_bytes": 96337920,
+      "used": "91.88 MiB",
+      "used_bytes": 96337920
+    },
+    "/snap/snapd/21184": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "/dev/loop1",
+      "filesystem": "squashfs",
+      "options": [
+        "ro",
+        "nodev",
+        "relatime"
+      ],
+      "size": "39.13 MiB",
+      "size_bytes": 41025536,
+      "used": "39.13 MiB",
+      "used_bytes": 41025536
+    },
+    "/sys/fs/cgroup": {
+      "available": "482.43 MiB",
+      "available_bytes": 505864192,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "482.43 MiB",
+      "size_bytes": 505864192,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "66.50 GiB",
+      "available_bytes": 71405768704,
+      "capacity": "4.91%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "69.94 GiB",
+      "size_bytes": 75094818816,
+      "used": "3.44 GiB",
+      "used_bytes": 3689050112
+    }
+  },
+  "mtu_enp0s3": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_enp0s3": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_enp0s3": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_enp0s3": "fe80::",
+  "network6_lo": "::1",
+  "network_enp0s3": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "enp0s3": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::e9:94ff:fee1:d413",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::e9:94ff:fee1:d413",
+        "mac": "02:e9:94:e1:d4:13",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::e9:94ff:fee1:d413",
+    "mac": "02:e9:94:e1:d4:13",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "enp0s3",
+    "scope6": "link"
+  },
+  "operatingsystem": "Ubuntu",
+  "operatingsystemmajrelease": "20.04",
+  "operatingsystemrelease": "20.04",
+  "os": {
+    "architecture": "amd64",
+    "distro": {
+      "codename": "focal",
+      "description": "Ubuntu 20.04.6 LTS",
+      "id": "Ubuntu",
+      "release": {
+        "full": "20.04",
+        "major": "20.04"
+      }
+    },
+    "family": "Debian",
+    "hardware": "x86_64",
+    "name": "Ubuntu",
+    "release": {
+      "full": "20.04",
+      "major": "20.04"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "osfamily": "Debian",
+  "partitions": {
+    "/dev/loop0": {
+      "backing_file": "/var/lib/snapd/snaps/lxd_24061.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/lxd/24061",
+      "size": "91.83 MiB",
+      "size_bytes": 96292864
+    },
+    "/dev/loop1": {
+      "backing_file": "/var/lib/snapd/snaps/snapd_21184.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/snapd/21184",
+      "size": "39.10 MiB",
+      "size_bytes": 40996864
+    },
+    "/dev/loop2": {
+      "backing_file": "/var/lib/snapd/snaps/core20_2182.snap",
+      "filesystem": "squashfs",
+      "mount": "/snap/core20/2182",
+      "size": "63.91 MiB",
+      "size_bytes": 67010560
+    },
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "cloudimg-rootfs",
+      "mount": "/",
+      "partuuid": "90b16b70-01",
+      "size": "40.00 GiB",
+      "size_bytes": 42948607488,
+      "uuid": "840239b4-984e-441d-9d80-d2f9e890129a"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+  "processorcount": 2,
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz",
+      "Intel(R) Xeon(R) CPU E5-2667 v3 @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "speed": "3.20 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "puppetversion": "8.6.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.3"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+  "rubyversion": "3.2.3",
+  "scope6": "link",
+  "scope6_enp0s3": "link",
+  "scope6_lo": "host",
+  "selinux": false,
+  "serialnumber": "0",
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 5c6fcc04c3b45a379e0c67fe378942a999a89c24",
+        "sha256": "SSHFP 2 2 512e7148f98729224cbde8eaf2587bfd51081f2ae5192db1e22bfcca4cfff2f2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAM0o+WuKIcCpjxscnJ7vw2nHx2dktGa79k6/IgxVEAOJqNZNE/YVMeMVR5OUfPWymF9gRs1LtM0YO5bVuCKdIls2AsImRJGlTHAhx7wut7xh+giXu7PaFdX6WHkJ/khrrGLfDFlvZKnZ3gTW8oRiiTBNaWAkdwvAovJiKwoMdqZVAAAAFQCbdy73nnbg9bqnbgfa+rStxARBcQAAAIAxm/LoUa1Ptz87aasVWVQPLsHWAfrBAQoHqm2o13hz70KC0oy+uUaWYJ8DXjdO7xjWZh03Eo5f4VK2XVn5NMOk7ya9AyTpt3k/+eBDd1LieZHxw5rHi4FFt5cc26mcXStcPFeKJwOpIKrUts9Ai5J2QwYKnjgvb9h2YROlAb44XgAAAIEAjWe/l/MHtO+pj6/0a5iWgi6W3J4x0vV+p3B9qxdhHTLFucgX9JRk1j91jt4KYdKMa15Ao7ZevBnYxSIrjbFYKrfvoGarJS6PyqOmzOA6Ugo9LFWEtmfyWz4pE9d3lUblgz+Rqqj7UdynAr6tD9rsXW/2yupzv7v6FwOpwoz8hFU=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 9f5c7a00195b95bf0d500f04f60d73a1a21bfafc",
+        "sha256": "SSHFP 3 2 26cf83c0bf201a3dc1cf54d9940ed016c2616a97732a4a1e494b5146c7e64de0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdcZSewqojLu9WBiYzdl1u8HOyeZImhj0/EgTT3jFy1dY9eup9+ubLIrw7SqALsn9U7gyN0z++1pDYU4BAmWvQ=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 634c26f1d899d60285740399f9a7767c12b4ef82",
+        "sha256": "SSHFP 4 2 be86d52c09eeecef6c7f831066bc4b3402dc06bc5f5bd2ba599c9a4f56037ba1"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIA+VOqzE5Oji6OYO9luw1Nu/2OwHews7xP0xofzY6dyb",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 1f37a0ff0e197d4da1694e681939e6242fcc38a5",
+        "sha256": "SSHFP 1 2 cc48d857cd264b6d51f348ef861f3c1bb1cc3b5378841ff6e89dc2232f4d5222"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDYPpqBmRKrOIp0QqIvI7rTY+aiXJ5WwixbYCXydSL7RiyfBTFvsxeAb+o3p+kFcvKgBOCXjBwdjaz44zxo40jANWEPzDRjzVTtf0yj0Q8vySzAqjXwD9RpRF2N3RHq9GFh6hDs0TKAP71rfH2hVjFDdkPRUXLXMWuSndNkoPf6BRsb7+NToPOFrRKPiJlR7+Hpg4i4+WruxCjkZ1r/woTtguKMqfFIaRAhNsVBUdjzqpsQrO9trn1ttIk2pKNukQ4o+SXpc8Wxl/QN3Cy+Tf6SUiiHvZdi/ewCzG3uOSk8RxIM7VKp6DSzM8e8HEyDdj/2JatiCrTGsd0RtwmCl04yPFdWcdVXlG7WxPl3O/cF4ScA5GjGcTicUPUm1N8MX0mbzIn0wRsjJZ+UgomBH7sruP23P4lSfm2vfKdU2EKKdEeHRMc65vDgHPPN2gjmtJa2ANWrGylW3yBtf+2eH8BxluiLdiWbo9PsaDZ/wVUP39SUDloPbmqxGmp+s16auuk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAM0o+WuKIcCpjxscnJ7vw2nHx2dktGa79k6/IgxVEAOJqNZNE/YVMeMVR5OUfPWymF9gRs1LtM0YO5bVuCKdIls2AsImRJGlTHAhx7wut7xh+giXu7PaFdX6WHkJ/khrrGLfDFlvZKnZ3gTW8oRiiTBNaWAkdwvAovJiKwoMdqZVAAAAFQCbdy73nnbg9bqnbgfa+rStxARBcQAAAIAxm/LoUa1Ptz87aasVWVQPLsHWAfrBAQoHqm2o13hz70KC0oy+uUaWYJ8DXjdO7xjWZh03Eo5f4VK2XVn5NMOk7ya9AyTpt3k/+eBDd1LieZHxw5rHi4FFt5cc26mcXStcPFeKJwOpIKrUts9Ai5J2QwYKnjgvb9h2YROlAb44XgAAAIEAjWe/l/MHtO+pj6/0a5iWgi6W3J4x0vV+p3B9qxdhHTLFucgX9JRk1j91jt4KYdKMa15Ao7ZevBnYxSIrjbFYKrfvoGarJS6PyqOmzOA6Ugo9LFWEtmfyWz4pE9d3lUblgz+Rqqj7UdynAr6tD9rsXW/2yupzv7v6FwOpwoz8hFU=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKdcZSewqojLu9WBiYzdl1u8HOyeZImhj0/EgTT3jFy1dY9eup9+ubLIrw7SqALsn9U7gyN0z++1pDYU4BAmWvQ=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIA+VOqzE5Oji6OYO9luw1Nu/2OwHews7xP0xofzY6dyb",
+  "sshfp_dsa": "SSHFP 2 1 5c6fcc04c3b45a379e0c67fe378942a999a89c24\nSSHFP 2 2 512e7148f98729224cbde8eaf2587bfd51081f2ae5192db1e22bfcca4cfff2f2",
+  "sshfp_ecdsa": "SSHFP 3 1 9f5c7a00195b95bf0d500f04f60d73a1a21bfafc\nSSHFP 3 2 26cf83c0bf201a3dc1cf54d9940ed016c2616a97732a4a1e494b5146c7e64de0",
+  "sshfp_ed25519": "SSHFP 4 1 634c26f1d899d60285740399f9a7767c12b4ef82\nSSHFP 4 2 be86d52c09eeecef6c7f831066bc4b3402dc06bc5f5bd2ba599c9a4f56037ba1",
+  "sshfp_rsa": "SSHFP 1 1 1f37a0ff0e197d4da1694e681939e6242fcc38a5\nSSHFP 1 2 cc48d857cd264b6d51f348ef861f3c1bb1cc3b5378841ff6e89dc2232f4d5222",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDYPpqBmRKrOIp0QqIvI7rTY+aiXJ5WwixbYCXydSL7RiyfBTFvsxeAb+o3p+kFcvKgBOCXjBwdjaz44zxo40jANWEPzDRjzVTtf0yj0Q8vySzAqjXwD9RpRF2N3RHq9GFh6hDs0TKAP71rfH2hVjFDdkPRUXLXMWuSndNkoPf6BRsb7+NToPOFrRKPiJlR7+Hpg4i4+WruxCjkZ1r/woTtguKMqfFIaRAhNsVBUdjzqpsQrO9trn1ttIk2pKNukQ4o+SXpc8Wxl/QN3Cy+Tf6SUiiHvZdi/ewCzG3uOSk8RxIM7VKp6DSzM8e8HEyDdj/2JatiCrTGsd0RtwmCl04yPFdWcdVXlG7WxPl3O/cF4ScA5GjGcTicUPUm1N8MX0mbzIn0wRsjJZ+UgomBH7sruP23P4lSfm2vfKdU2EKKdEeHRMc65vDgHPPN2gjmtJa2ANWrGylW3yBtf+2eH8BxluiLdiWbo9PsaDZ/wVUP39SUDloPbmqxGmp+s16auuk=",
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 78,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:01 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 78,
+  "uuid": "dd84381b-599e-7947-a939-12d8d8d7edfa",
+  "virtual": "virtualbox"
+}

--- a/facts/versions.txt
+++ b/facts/versions.txt
@@ -1,0 +1,16 @@
+# This is a list of all Puppet Agent versions to use to collect facts
+# Each line can have a single string which is a version number or can be a comment
+# Version information from Facter release notes: https://www.puppet.com/docs/puppet/8/release_notes_facter.htm
+# FacterDB only cares about the x.y, and drops .z - Please keep versions in order by Facter version
+
+# Facter 4.7.0 - Released April 2024 and shipped with Puppet 8.6.0.
+8.6.0
+
+# Facter 4.6.1 - Released March 2024 and shipped with Puppet 8.5.1.
+8.5.1
+
+# Facter 4.5.2 - Released January 2023 and shipped with Puppet 8.4.0.
+8.4.0
+
+# Facter 4.4.2 - Released August 2023 and shipped with Puppet 8.2.0.
+8.2.0


### PR DESCRIPTION
This will allow scripts for different operating systems to be separated and still use the same versions

This also helps keep track of what facter versions are being used with each version of Puppet Agent.

Tested on RHEL 9, openSUSE 15.4, Ubuntu 20.04, Windows 10/11, Windows Server 2019/2022

Inspired by #330