### PR TITLE
Fedora 38/39: regenerate facts & Add Missing Facter 4.6/4.7 factsets & Switch to upstream images

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ FacterDB::get_facts('osfamily=Debian')
 | Debian 12                |     |     |  2  |  2  |  2  |  1  |  1  |  1  |
 | Fedora 36                |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | Fedora 37                |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
-| Fedora 38                |     |     |  1  |  1  |  1  |  1  |     |     |
-| Fedora 39                |     |     |  1  |  1  |  1  |  1  |     |     |
+| Fedora 38                |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
+| Fedora 39                |     |     |  1  |  1  |  1  |  1  |  1  |  1  |
 | FreeBSD 11               |  1  |  1  |  1  |     |     |     |     |     |
 | FreeBSD 12               |  1  |  1  |  1  |     |     |  1  |     |     |
 | FreeBSD 13               |  1  |  1  |  1  |  1  |  1  |  1  |     |     |

--- a/facts/4.2/fedora-38-x86_64.facts
+++ b/facts/4.2/fedora-38-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VB0376f406-6c62b0a0",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "592a5d51-955e-c546-9429-146246d5e6eb"
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
   "domain": "example.com",
   "facterversion": "4.2.14",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.2.0",
+  "gem_version": "~> 4.2.14",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe01:51aa",
-  "ipaddress6_eth0": "fe80::a00:27ff:fe01:51aa",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.2.9-300.fc38.x86_64",
   "kernelversion": "6.2.9",
   "load_averages": {
-    "15m": 0.01,
-    "1m": 0.18,
-    "5m": 0.04
+    "15m": 0.16,
+    "1m": 1.16,
+    "5m": 0.44
   },
   "lsbdistrelease": "38",
   "lsbmajdistrelease": "38",
-  "macaddress": "08:00:27:01:51:aa",
-  "macaddress_eth0": "08:00:27:01:51:aa",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.56 GiB",
-      "available_bytes": 1674846208,
-      "capacity": "18.25%",
+      "available": "1.61 GiB",
+      "available_bytes": 1727635456,
+      "capacity": "15.68%",
       "total": "1.91 GiB",
-      "total_bytes": 2048643072,
-      "used": "356.48 MiB",
-      "used_bytes": 373796864
+      "total_bytes": 2048909312,
+      "used": "306.39 MiB",
+      "used_bytes": 321273856
     }
   },
-  "memoryfree": "1.56 GiB",
-  "memoryfree_mb": 1597.2578125,
+  "memoryfree": "1.61 GiB",
+  "memoryfree_mb": 1647.6015625,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
+  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
-      "available": "122.45 GiB",
-      "available_bytes": 131477950464,
-      "capacity": "1.99%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.49 GiB",
-      "used_bytes": 2668474368
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
     },
     "/boot": {
-      "available": "813.30 MiB",
-      "available_bytes": 852811776,
-      "capacity": "15.28%",
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "146.70 MiB",
-      "used_bytes": 153821184
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246652",
+        "nr_inodes=245606",
         "mode=755",
         "inode64"
       ],
@@ -234,8 +255,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024319488,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -246,15 +267,35 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024319488,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
+    },
     "/run": {
-      "available": "385.33 MiB",
-      "available_bytes": 404045824,
-      "capacity": "1.39%",
+      "available": "385.41 MiB",
+      "available_bytes": 404135936,
+      "capacity": "1.38%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -262,15 +303,15 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400128k",
+        "size=400180k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.75 MiB",
-      "size_bytes": 409731072,
-      "used": "5.42 MiB",
-      "used_bytes": 5685248
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5648384
     },
     "/run/credentials/systemd-resolved.service": {
       "available": "0 bytes",
@@ -353,8 +394,8 @@
       "used_bytes": 0
     },
     "/run/user/1000": {
-      "available": "195.37 MiB",
-      "available_bytes": 204861440,
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -364,21 +405,21 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200060k",
-        "nr_inodes=50015",
+        "size=200088k",
+        "nr_inodes=50022",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.37 MiB",
-      "size_bytes": 204861440,
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024323584,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -387,29 +428,13 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=1000316k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024323584,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "713.55 GiB",
-      "available_bytes": 766167326720,
-      "capacity": "22.09%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "202.26 GiB",
-      "used_bytes": 217177825280
     }
   },
   "mtu_eth0": 1500,
@@ -441,7 +466,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe01:51aa",
+            "address": "fe80::2d54:1b3c:73e3:6f0",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -451,8 +476,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe01:51aa",
-        "mac": "08:00:27:01:51:aa",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -490,8 +515,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe01:51aa",
-    "mac": "08:00:27:01:51:aa",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -532,68 +557,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "c24c6da0-e6d2-4176-8581-cccfe53918b7"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "83ca3e26-ea06-4f1c-9b30-84886d860515"
-    },
     "/dev/sda1": {
-      "partuuid": "8705c40a-2e78-4768-a8a1-2a6299092f34",
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "44316c3a-fc65-458a-90b3-9253f5c24971",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "fc52b7df-6d51-402f-8c8b-05399f80811b"
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "c9e11f71-394f-4ad6-8a27-c4e6c20067ee",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "eJetuf-vIJ4-9FOf-FObG-VL8t-hSY1-O2i6uC"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -607,50 +631,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68",
-        "sha256": "SSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b"
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d",
-        "sha256": "SSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524"
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193",
-        "sha256": "SSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5"
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
-  "sshfp_ecdsa": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68\nSSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b",
-  "sshfp_ed25519": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d\nSSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524",
-  "sshfp_rsa": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193\nSSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 82,
-    "uptime": "0:01 hours"
+    "seconds": 218,
+    "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 82,
-  "uuid": "592a5d51-955e-c546-9429-146246d5e6eb",
+  "uptime_seconds": 218,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.2/fedora-39-x86_64.facts
+++ b/facts/4.2/fedora-39-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VBa9780504-adf36f37",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53"
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
   "domain": "example.com",
   "facterversion": "4.2.14",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.2.0",
+  "gem_version": "~> 4.2.14",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee1:22a2",
-  "ipaddress6_eth0": "fe80::a00:27ff:fee1:22a2",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.5.6-300.fc39.x86_64",
   "kernelversion": "6.5.6",
   "load_averages": {
-    "15m": 0.05,
-    "1m": 0.19,
-    "5m": 0.12
+    "15m": 0.16,
+    "1m": 0.96,
+    "5m": 0.42
   },
   "lsbdistrelease": "39",
   "lsbmajdistrelease": "39",
-  "macaddress": "08:00:27:e1:22:a2",
-  "macaddress_eth0": "08:00:27:e1:22:a2",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.55 GiB",
-      "available_bytes": 1667596288,
-      "capacity": "18.59%",
+      "available": "1.60 GiB",
+      "available_bytes": 1714536448,
+      "capacity": "16.31%",
       "total": "1.91 GiB",
-      "total_bytes": 2048360448,
-      "used": "363.13 MiB",
-      "used_bytes": 380764160
+      "total_bytes": 2048634880,
+      "used": "318.62 MiB",
+      "used_bytes": 334098432
     }
   },
-  "memoryfree": "1.55 GiB",
-  "memoryfree_mb": 1590.34375,
+  "memoryfree": "1.60 GiB",
+  "memoryfree_mb": 1635.109375,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.46875,
+  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
-      "available": "122.49 GiB",
-      "available_bytes": 131521306624,
-      "capacity": "1.96%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.64 GiB",
+      "available_bytes": 40411168768,
+      "capacity": "2.22%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.44 GiB",
-      "used_bytes": 2625118208
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "874.31 MiB",
+      "used_bytes": 916783104
     },
     "/boot": {
-      "available": "811.04 MiB",
-      "available_bytes": 850440192,
-      "capacity": "15.52%",
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "148.96 MiB",
-      "used_bytes": 156192768
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246314",
+        "nr_inodes=244875",
         "mode=755",
         "inode64"
       ],
@@ -236,8 +257,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -248,14 +269,34 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.64 GiB",
+      "available_bytes": 40411168768,
+      "capacity": "2.22%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "874.31 MiB",
+      "used_bytes": 916783104
+    },
     "/run": {
-      "available": "385.21 MiB",
-      "available_bytes": 403922944,
+      "available": "385.29 MiB",
+      "available_bytes": 404008960,
       "capacity": "1.40%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -264,19 +305,19 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400072k",
+        "size=400124k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.70 MiB",
-      "size_bytes": 409673728,
-      "used": "5.48 MiB",
-      "used_bytes": 5750784
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.45 MiB",
+      "used_bytes": 5718016
     },
     "/run/user/1000": {
-      "available": "195.34 MiB",
-      "available_bytes": 204828672,
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
       "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -286,22 +327,22 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200032k",
-        "nr_inodes=50008",
+        "size=200060k",
+        "nr_inodes=50015",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.34 MiB",
-      "size_bytes": 204832768,
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
       "used": "4.00 KiB",
       "used_bytes": 4096
     },
     "/tmp": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
-      "capacity": "0%",
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -309,28 +350,14 @@
         "seclabel",
         "nosuid",
         "nodev",
+        "size=1000312k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "710.37 GiB",
-      "available_bytes": 762749878272,
-      "capacity": "22.43%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "205.45 GiB",
-      "used_bytes": 220595273728
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
     }
   },
   "mtu_eth0": 1500,
@@ -362,7 +389,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fee1:22a2",
+            "address": "fe80::85e6:627e:6634:e6b5",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -372,8 +399,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fee1:22a2",
-        "mac": "08:00:27:e1:22:a2",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -411,8 +438,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fee1:22a2",
-    "mac": "08:00:27:e1:22:a2",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -453,68 +480,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "a4bd9ad0-c708-4b6d-a771-0efde5e3edf3"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "5a5a6a35-e192-4ddd-a569-ad4f62e17304"
-    },
     "/dev/sda1": {
-      "partuuid": "7b20e462-a05a-4fd2-a9b2-2d2469443c5c",
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "ff3bad15-caad-4f45-a8d0-c988b13478b1",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "cebba907-c354-46b2-94b9-f9f2f8224d71"
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "63125510-501b-4f42-a4e2-c3c01cdbe0de",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "71HJJh-5qse-gqz2-8rFG-6KFh-nXLo-JFm3bK"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -528,50 +554,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba",
-        "sha256": "SSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38"
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454",
-        "sha256": "SSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc"
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e",
-        "sha256": "SSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502"
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
-  "sshfp_ecdsa": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba\nSSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38",
-  "sshfp_ed25519": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454\nSSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc",
-  "sshfp_rsa": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e\nSSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 309,
-    "uptime": "0:05 hours"
+    "seconds": 166,
+    "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
+  "uptime": "0:02 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 309,
-  "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53",
+  "uptime_seconds": 166,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-38-x86_64.facts
+++ b/facts/4.3/fedora-38-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VB0376f406-6c62b0a0",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,12 +46,12 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "592a5d51-955e-c546-9429-146246d5e6eb"
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
   "domain": "example.com",
   "facterversion": "4.3.1",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
@@ -57,6 +61,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe01:51aa",
-  "ipaddress6_eth0": "fe80::a00:27ff:fe01:51aa",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.2.9-300.fc38.x86_64",
   "kernelversion": "6.2.9",
   "load_averages": {
-    "15m": 0.01,
-    "1m": 0.18,
-    "5m": 0.04
+    "15m": 0.17,
+    "1m": 1.14,
+    "5m": 0.45
   },
   "lsbdistrelease": "38",
   "lsbmajdistrelease": "38",
-  "macaddress": "08:00:27:01:51:aa",
-  "macaddress_eth0": "08:00:27:01:51:aa",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.56 GiB",
-      "available_bytes": 1675812864,
-      "capacity": "18.20%",
+      "available": "1.61 GiB",
+      "available_bytes": 1726496768,
+      "capacity": "15.74%",
       "total": "1.91 GiB",
-      "total_bytes": 2048643072,
-      "used": "355.56 MiB",
-      "used_bytes": 372830208
+      "total_bytes": 2048909312,
+      "used": "307.48 MiB",
+      "used_bytes": 322412544
     }
   },
-  "memoryfree": "1.56 GiB",
-  "memoryfree_mb": 1598.1796875,
+  "memoryfree": "1.61 GiB",
+  "memoryfree_mb": 1646.515625,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
+  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
-      "available": "122.45 GiB",
-      "available_bytes": 131477950464,
-      "capacity": "1.99%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.49 GiB",
-      "used_bytes": 2668474368
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
     },
     "/boot": {
-      "available": "813.30 MiB",
-      "available_bytes": 852811776,
-      "capacity": "15.28%",
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "146.70 MiB",
-      "used_bytes": 153821184
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246652",
+        "nr_inodes=245606",
         "mode=755",
         "inode64"
       ],
@@ -234,8 +255,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024319488,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -246,15 +267,35 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024319488,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
+    },
     "/run": {
-      "available": "385.32 MiB",
-      "available_bytes": 404041728,
-      "capacity": "1.39%",
+      "available": "385.41 MiB",
+      "available_bytes": 404131840,
+      "capacity": "1.38%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -262,15 +303,15 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400128k",
+        "size=400180k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.75 MiB",
-      "size_bytes": 409731072,
-      "used": "5.43 MiB",
-      "used_bytes": 5689344
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5652480
     },
     "/run/credentials/systemd-resolved.service": {
       "available": "0 bytes",
@@ -353,8 +394,8 @@
       "used_bytes": 0
     },
     "/run/user/1000": {
-      "available": "195.37 MiB",
-      "available_bytes": 204861440,
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -364,21 +405,21 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200060k",
-        "nr_inodes=50015",
+        "size=200088k",
+        "nr_inodes=50022",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.37 MiB",
-      "size_bytes": 204861440,
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024323584,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -387,29 +428,13 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=1000316k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024323584,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "713.55 GiB",
-      "available_bytes": 766167306240,
-      "capacity": "22.09%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "202.26 GiB",
-      "used_bytes": 217177845760
     }
   },
   "mtu_eth0": 1500,
@@ -441,7 +466,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe01:51aa",
+            "address": "fe80::2d54:1b3c:73e3:6f0",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -451,8 +476,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe01:51aa",
-        "mac": "08:00:27:01:51:aa",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -490,8 +515,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe01:51aa",
-    "mac": "08:00:27:01:51:aa",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -532,68 +557,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "c24c6da0-e6d2-4176-8581-cccfe53918b7"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "83ca3e26-ea06-4f1c-9b30-84886d860515"
-    },
     "/dev/sda1": {
-      "partuuid": "8705c40a-2e78-4768-a8a1-2a6299092f34",
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "44316c3a-fc65-458a-90b3-9253f5c24971",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "fc52b7df-6d51-402f-8c8b-05399f80811b"
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "c9e11f71-394f-4ad6-8a27-c4e6c20067ee",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "eJetuf-vIJ4-9FOf-FObG-VL8t-hSY1-O2i6uC"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -607,50 +631,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68",
-        "sha256": "SSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b"
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d",
-        "sha256": "SSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524"
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193",
-        "sha256": "SSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5"
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
-  "sshfp_ecdsa": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68\nSSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b",
-  "sshfp_ed25519": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d\nSSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524",
-  "sshfp_rsa": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193\nSSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 83,
-    "uptime": "0:01 hours"
+    "seconds": 222,
+    "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 83,
-  "uuid": "592a5d51-955e-c546-9429-146246d5e6eb",
+  "uptime_seconds": 222,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.3/fedora-39-x86_64.facts
+++ b/facts/4.3/fedora-39-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VBa9780504-adf36f37",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,12 +46,12 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53"
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
   "domain": "example.com",
   "facterversion": "4.3.1",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
   "gem_version": "~> 4.3.0",
@@ -57,6 +61,8 @@
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee1:22a2",
-  "ipaddress6_eth0": "fe80::a00:27ff:fee1:22a2",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.5.6-300.fc39.x86_64",
   "kernelversion": "6.5.6",
   "load_averages": {
-    "15m": 0.06,
-    "1m": 0.25,
-    "5m": 0.14
+    "15m": 0.17,
+    "1m": 0.97,
+    "5m": 0.43
   },
   "lsbdistrelease": "39",
   "lsbmajdistrelease": "39",
-  "macaddress": "08:00:27:e1:22:a2",
-  "macaddress_eth0": "08:00:27:e1:22:a2",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.55 GiB",
-      "available_bytes": 1668513792,
-      "capacity": "18.54%",
+      "available": "1.60 GiB",
+      "available_bytes": 1713057792,
+      "capacity": "16.38%",
       "total": "1.91 GiB",
-      "total_bytes": 2048360448,
-      "used": "362.25 MiB",
-      "used_bytes": 379846656
+      "total_bytes": 2048634880,
+      "used": "320.03 MiB",
+      "used_bytes": 335577088
     }
   },
-  "memoryfree": "1.55 GiB",
-  "memoryfree_mb": 1591.21875,
+  "memoryfree": "1.60 GiB",
+  "memoryfree_mb": 1633.69921875,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.46875,
+  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
-      "available": "122.49 GiB",
-      "available_bytes": 131521306624,
-      "capacity": "1.96%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.44 GiB",
-      "used_bytes": 2625118208
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
     },
     "/boot": {
-      "available": "811.04 MiB",
-      "available_bytes": 850440192,
-      "capacity": "15.52%",
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "148.96 MiB",
-      "used_bytes": 156192768
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246314",
+        "nr_inodes=244875",
         "mode=755",
         "inode64"
       ],
@@ -236,8 +257,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -248,14 +269,34 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
     "/run": {
-      "available": "385.21 MiB",
-      "available_bytes": 403922944,
+      "available": "385.29 MiB",
+      "available_bytes": 404004864,
       "capacity": "1.40%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -264,19 +305,19 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400072k",
+        "size=400124k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.70 MiB",
-      "size_bytes": 409673728,
-      "used": "5.48 MiB",
-      "used_bytes": 5750784
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.46 MiB",
+      "used_bytes": 5722112
     },
     "/run/user/1000": {
-      "available": "195.34 MiB",
-      "available_bytes": 204828672,
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
       "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -286,22 +327,22 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200032k",
-        "nr_inodes=50008",
+        "size=200060k",
+        "nr_inodes=50015",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.34 MiB",
-      "size_bytes": 204832768,
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
       "used": "4.00 KiB",
       "used_bytes": 4096
     },
     "/tmp": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
-      "capacity": "0%",
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -309,28 +350,14 @@
         "seclabel",
         "nosuid",
         "nodev",
+        "size=1000312k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "710.37 GiB",
-      "available_bytes": 762749861888,
-      "capacity": "22.43%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "205.45 GiB",
-      "used_bytes": 220595290112
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
     }
   },
   "mtu_eth0": 1500,
@@ -362,7 +389,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fee1:22a2",
+            "address": "fe80::85e6:627e:6634:e6b5",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -372,8 +399,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fee1:22a2",
-        "mac": "08:00:27:e1:22:a2",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -411,8 +438,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fee1:22a2",
-    "mac": "08:00:27:e1:22:a2",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -453,68 +480,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "a4bd9ad0-c708-4b6d-a771-0efde5e3edf3"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "5a5a6a35-e192-4ddd-a569-ad4f62e17304"
-    },
     "/dev/sda1": {
-      "partuuid": "7b20e462-a05a-4fd2-a9b2-2d2469443c5c",
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "ff3bad15-caad-4f45-a8d0-c988b13478b1",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "cebba907-c354-46b2-94b9-f9f2f8224d71"
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "63125510-501b-4f42-a4e2-c3c01cdbe0de",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "71HJJh-5qse-gqz2-8rFG-6KFh-nXLo-JFm3bK"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -528,50 +554,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba",
-        "sha256": "SSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38"
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454",
-        "sha256": "SSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc"
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e",
-        "sha256": "SSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502"
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
-  "sshfp_ecdsa": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba\nSSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38",
-  "sshfp_ed25519": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454\nSSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc",
-  "sshfp_rsa": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e\nSSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 310,
-    "uptime": "0:05 hours"
+    "seconds": 170,
+    "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
+  "uptime": "0:02 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 310,
-  "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53",
+  "uptime_seconds": 170,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-38-x86_64.facts
+++ b/facts/4.4/fedora-38-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VB0376f406-6c62b0a0",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "592a5d51-955e-c546-9429-146246d5e6eb"
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
   "domain": "example.com",
   "facterversion": "4.4.3",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.4.0",
+  "gem_version": "~> 4.4.3",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe01:51aa",
-  "ipaddress6_eth0": "fe80::a00:27ff:fe01:51aa",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.2.9-300.fc38.x86_64",
   "kernelversion": "6.2.9",
   "load_averages": {
-    "15m": 0.01,
-    "1m": 0.18,
-    "5m": 0.04
+    "15m": 0.17,
+    "1m": 1.13,
+    "5m": 0.46
   },
   "lsbdistrelease": "38",
   "lsbmajdistrelease": "38",
-  "macaddress": "08:00:27:01:51:aa",
-  "macaddress_eth0": "08:00:27:01:51:aa",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.56 GiB",
-      "available_bytes": 1675485184,
-      "capacity": "18.21%",
+      "available": "1.61 GiB",
+      "available_bytes": 1726730240,
+      "capacity": "15.72%",
       "total": "1.91 GiB",
-      "total_bytes": 2048643072,
-      "used": "355.87 MiB",
-      "used_bytes": 373157888
+      "total_bytes": 2048909312,
+      "used": "307.25 MiB",
+      "used_bytes": 322179072
     }
   },
-  "memoryfree": "1.56 GiB",
-  "memoryfree_mb": 1597.8671875,
+  "memoryfree": "1.61 GiB",
+  "memoryfree_mb": 1646.73828125,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
+  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
-      "available": "122.45 GiB",
-      "available_bytes": 131477950464,
-      "capacity": "1.99%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.49 GiB",
-      "used_bytes": 2668474368
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
     },
     "/boot": {
-      "available": "813.30 MiB",
-      "available_bytes": 852811776,
-      "capacity": "15.28%",
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "146.70 MiB",
-      "used_bytes": 153821184
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246652",
+        "nr_inodes=245606",
         "mode=755",
         "inode64"
       ],
@@ -234,8 +255,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024319488,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -246,15 +267,35 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024319488,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
+    },
     "/run": {
-      "available": "385.32 MiB",
-      "available_bytes": 404037632,
-      "capacity": "1.39%",
+      "available": "385.41 MiB",
+      "available_bytes": 404131840,
+      "capacity": "1.38%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -262,15 +303,15 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400128k",
+        "size=400180k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.75 MiB",
-      "size_bytes": 409731072,
-      "used": "5.43 MiB",
-      "used_bytes": 5693440
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5652480
     },
     "/run/credentials/systemd-resolved.service": {
       "available": "0 bytes",
@@ -353,8 +394,8 @@
       "used_bytes": 0
     },
     "/run/user/1000": {
-      "available": "195.37 MiB",
-      "available_bytes": 204861440,
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -364,21 +405,21 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200060k",
-        "nr_inodes=50015",
+        "size=200088k",
+        "nr_inodes=50022",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.37 MiB",
-      "size_bytes": 204861440,
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024323584,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -387,29 +428,13 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=1000316k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024323584,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "713.55 GiB",
-      "available_bytes": 766167285760,
-      "capacity": "22.09%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "202.26 GiB",
-      "used_bytes": 217177866240
     }
   },
   "mtu_eth0": 1500,
@@ -441,7 +466,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe01:51aa",
+            "address": "fe80::2d54:1b3c:73e3:6f0",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -451,8 +476,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe01:51aa",
-        "mac": "08:00:27:01:51:aa",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -490,8 +515,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe01:51aa",
-    "mac": "08:00:27:01:51:aa",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -532,68 +557,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "c24c6da0-e6d2-4176-8581-cccfe53918b7"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "83ca3e26-ea06-4f1c-9b30-84886d860515"
-    },
     "/dev/sda1": {
-      "partuuid": "8705c40a-2e78-4768-a8a1-2a6299092f34",
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "44316c3a-fc65-458a-90b3-9253f5c24971",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "fc52b7df-6d51-402f-8c8b-05399f80811b"
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "c9e11f71-394f-4ad6-8a27-c4e6c20067ee",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "eJetuf-vIJ4-9FOf-FObG-VL8t-hSY1-O2i6uC"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -607,50 +631,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68",
-        "sha256": "SSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b"
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d",
-        "sha256": "SSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524"
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193",
-        "sha256": "SSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5"
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPmnvicWpurMKbzPNB529b7+3vKS3SXll6euYXd4flyJwG1xektbszWKXOKu9XL4T2HZRRJ31B8MdoZFEmjYntk=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAICgW/kKOzqXWolGAsS65N90AkvyCA9i4luilnI4qiS41",
-  "sshfp_ecdsa": "SSHFP 3 1 b9fcb7bf2ad7c70159b490238b15ab8dddf0bf68\nSSHFP 3 2 703e86133fd5d20c608b7cad0941f974590557a0bc2a15afa2f491d7c594f43b",
-  "sshfp_ed25519": "SSHFP 4 1 c996481e21d7783a53295317bc03f3c2b22d631d\nSSHFP 4 2 2dbbad350cde52da915083a8323622849f476624f6ca16fdc245188dcfb76524",
-  "sshfp_rsa": "SSHFP 1 1 c7cdadc5f7ba44de19c4ccefc154f3d2c4131193\nSSHFP 1 2 09cd764637ae63d6b155f56ac850933d70edd20cbb1b98cbdab0aff68fc8e6f5",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCuRol3Ya18wGXmVGfEHydIFdbN+B4/Q9FKkn+hG0cVdcKKw6FuHAUGLKIIFeDQmnxKTzxC1ZpI3LA3YwinJDAqL0XmkNkNLw5XDw+c8WqkVl72y6YADlBaUqiT1BA3gAf6mhfdKFvVnDuGhTkSy2JiX+7VeDEONj/6J7Z9Jr0a+He7Js0gupMJwC5jVAm20z+M+IS3JDzF5UbcYwFnU9ktafdjPKc9jjMeA7DuXwPKiOp3l2FntV74y51jP64nAUrYfR7KuB6E80X2mm9+L+vxOXQweumNx9Yf7zrfSLj4hKYas+dyobjWeGAhSMR3k3wZ20oz34vMwXU9YXRROo4zm3Fx7xJFUVcmnljhQNrlbBOKl+DQSbaoQtJAkaA1jOAAJkjMM2feZxalL39xifqvTwcG+KdCRA16D9tHRhQieS+7G+8bcEyLp93J2Yhu//0PQ7XqXuIPXTj8eHh729e59vTbdVP2AXDuJJc+Snce1L5Ru7KkS/eNJ38jVP/Pj6k=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 84,
-    "uptime": "0:01 hours"
+    "seconds": 228,
+    "uptime": "0:03 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:01 hours",
+  "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 84,
-  "uuid": "592a5d51-955e-c546-9429-146246d5e6eb",
+  "uptime_seconds": 228,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.4/fedora-39-x86_64.facts
+++ b/facts/4.4/fedora-39-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VBa9780504-adf36f37",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53"
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
   "domain": "example.com",
   "facterversion": "4.4.3",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.4.0",
+  "gem_version": "~> 4.4.3",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee1:22a2",
-  "ipaddress6_eth0": "fe80::a00:27ff:fee1:22a2",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.5.6-300.fc39.x86_64",
   "kernelversion": "6.5.6",
   "load_averages": {
-    "15m": 0.06,
-    "1m": 0.25,
-    "5m": 0.14
+    "15m": 0.17,
+    "1m": 0.97,
+    "5m": 0.43
   },
   "lsbdistrelease": "39",
   "lsbmajdistrelease": "39",
-  "macaddress": "08:00:27:e1:22:a2",
-  "macaddress_eth0": "08:00:27:e1:22:a2",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.55 GiB",
-      "available_bytes": 1667612672,
-      "capacity": "18.59%",
+      "available": "1.59 GiB",
+      "available_bytes": 1712242688,
+      "capacity": "16.42%",
       "total": "1.91 GiB",
-      "total_bytes": 2048360448,
-      "used": "363.11 MiB",
-      "used_bytes": 380747776
+      "total_bytes": 2048634880,
+      "used": "320.81 MiB",
+      "used_bytes": 336392192
     }
   },
-  "memoryfree": "1.55 GiB",
-  "memoryfree_mb": 1590.359375,
+  "memoryfree": "1.59 GiB",
+  "memoryfree_mb": 1632.921875,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.46875,
+  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
-      "available": "122.49 GiB",
-      "available_bytes": 131521306624,
-      "capacity": "1.96%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.44 GiB",
-      "used_bytes": 2625118208
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
     },
     "/boot": {
-      "available": "811.04 MiB",
-      "available_bytes": 850440192,
-      "capacity": "15.52%",
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "148.96 MiB",
-      "used_bytes": 156192768
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246314",
+        "nr_inodes=244875",
         "mode=755",
         "inode64"
       ],
@@ -236,8 +257,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -248,14 +269,34 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
     "/run": {
-      "available": "385.21 MiB",
-      "available_bytes": 403922944,
+      "available": "385.29 MiB",
+      "available_bytes": 404000768,
       "capacity": "1.40%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -264,19 +305,19 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400072k",
+        "size=400124k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.70 MiB",
-      "size_bytes": 409673728,
-      "used": "5.48 MiB",
-      "used_bytes": 5750784
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.46 MiB",
+      "used_bytes": 5726208
     },
     "/run/user/1000": {
-      "available": "195.34 MiB",
-      "available_bytes": 204828672,
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
       "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -286,22 +327,22 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200032k",
-        "nr_inodes=50008",
+        "size=200060k",
+        "nr_inodes=50015",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.34 MiB",
-      "size_bytes": 204832768,
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
       "used": "4.00 KiB",
       "used_bytes": 4096
     },
     "/tmp": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
-      "capacity": "0%",
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -309,28 +350,14 @@
         "seclabel",
         "nosuid",
         "nodev",
+        "size=1000312k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "710.37 GiB",
-      "available_bytes": 762749845504,
-      "capacity": "22.43%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "205.45 GiB",
-      "used_bytes": 220595306496
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
     }
   },
   "mtu_eth0": 1500,
@@ -362,7 +389,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fee1:22a2",
+            "address": "fe80::85e6:627e:6634:e6b5",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -372,8 +399,8 @@
           }
         ],
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fee1:22a2",
-        "mac": "08:00:27:e1:22:a2",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -411,8 +438,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fee1:22a2",
-    "mac": "08:00:27:e1:22:a2",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -453,68 +480,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "a4bd9ad0-c708-4b6d-a771-0efde5e3edf3"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "5a5a6a35-e192-4ddd-a569-ad4f62e17304"
-    },
     "/dev/sda1": {
-      "partuuid": "7b20e462-a05a-4fd2-a9b2-2d2469443c5c",
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "ff3bad15-caad-4f45-a8d0-c988b13478b1",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "cebba907-c354-46b2-94b9-f9f2f8224d71"
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "63125510-501b-4f42-a4e2-c3c01cdbe0de",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "71HJJh-5qse-gqz2-8rFG-6KFh-nXLo-JFm3bK"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -528,50 +554,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba",
-        "sha256": "SSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38"
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454",
-        "sha256": "SSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc"
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e",
-        "sha256": "SSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502"
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
-  "sshfp_ecdsa": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba\nSSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38",
-  "sshfp_ed25519": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454\nSSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc",
-  "sshfp_rsa": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e\nSSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 311,
-    "uptime": "0:05 hours"
+    "seconds": 173,
+    "uptime": "0:02 hours"
   },
   "timezone": "UTC",
-  "uptime": "0:05 hours",
+  "uptime": "0:02 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 311,
-  "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53",
+  "uptime_seconds": 173,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-38-x86_64.facts
+++ b/facts/4.5/fedora-38-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VBfc982cfc-ae310f71",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "0fdbca52-8805-2b4e-9e70-ae380934a230"
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9"
     }
   },
   "domain": "example.com",
-  "facterversion": "4.5.0",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "facterversion": "4.5.2",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.5.0",
+  "gem_version": "~> 4.5.2",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fe01:51aa",
-  "ipaddress6_eth0": "fe80::a00:27ff:fe01:51aa",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.2.9-300.fc38.x86_64",
   "kernelversion": "6.2.9",
   "load_averages": {
-    "15m": 0.09,
-    "1m": 0.64,
-    "5m": 0.25
+    "15m": 0.18,
+    "1m": 1.12,
+    "5m": 0.47
   },
   "lsbdistrelease": "38",
   "lsbmajdistrelease": "38",
-  "macaddress": "08:00:27:01:51:aa",
-  "macaddress_eth0": "08:00:27:01:51:aa",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.53 GiB",
-      "available_bytes": 1638162432,
-      "capacity": "20.04%",
+      "available": "1.61 GiB",
+      "available_bytes": 1726279680,
+      "capacity": "15.75%",
       "total": "1.91 GiB",
-      "total_bytes": 2048643072,
-      "used": "391.46 MiB",
-      "used_bytes": 410480640
+      "total_bytes": 2048909312,
+      "used": "307.68 MiB",
+      "used_bytes": 322629632
     }
   },
-  "memoryfree": "1.53 GiB",
-  "memoryfree_mb": 1562.2734375,
+  "memoryfree": "1.61 GiB",
+  "memoryfree_mb": 1646.30859375,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.73828125,
+  "memorysize_mb": 1953.9921875,
   "mountpoints": {
     "/": {
-      "available": "122.40 GiB",
-      "available_bytes": 131421495296,
-      "capacity": "2.03%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.54 GiB",
-      "used_bytes": 2724929536
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
     },
     "/boot": {
-      "available": "813.30 MiB",
-      "available_bytes": 852811776,
-      "capacity": "15.28%",
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "146.70 MiB",
-      "used_bytes": 153821184
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246652",
+        "nr_inodes=245606",
         "mode=755",
         "inode64"
       ],
@@ -234,8 +255,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024319488,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -246,15 +267,35 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024319488,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.66 GiB",
+      "available_bytes": 40438108160,
+      "capacity": "2.18%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "859.21 MiB",
+      "used_bytes": 900952064
+    },
     "/run": {
-      "available": "385.33 MiB",
-      "available_bytes": 404045824,
-      "capacity": "1.39%",
+      "available": "385.41 MiB",
+      "available_bytes": 404131840,
+      "capacity": "1.38%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -262,15 +303,15 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400128k",
+        "size=400180k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.75 MiB",
-      "size_bytes": 409731072,
-      "used": "5.42 MiB",
-      "used_bytes": 5685248
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5652480
     },
     "/run/credentials/systemd-resolved.service": {
       "available": "0 bytes",
@@ -353,8 +394,8 @@
       "used_bytes": 0
     },
     "/run/user/1000": {
-      "available": "195.37 MiB",
-      "available_bytes": 204861440,
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -364,21 +405,21 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200060k",
-        "nr_inodes=50015",
+        "size=200088k",
+        "nr_inodes=50022",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.37 MiB",
-      "size_bytes": 204861440,
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "976.87 MiB",
-      "available_bytes": 1024323584,
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -387,29 +428,13 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=1000316k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.87 MiB",
-      "size_bytes": 1024323584,
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
       "used": "0 bytes",
       "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "709.08 GiB",
-      "available_bytes": 761366233088,
-      "capacity": "22.57%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "206.73 GiB",
-      "used_bytes": 221978918912
     }
   },
   "mtu_eth0": 1500,
@@ -441,7 +466,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe01:51aa",
+            "address": "fe80::2d54:1b3c:73e3:6f0",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -452,8 +477,8 @@
         ],
         "duplex": "full",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe01:51aa",
-        "mac": "08:00:27:01:51:aa",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -496,8 +521,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe01:51aa",
-    "mac": "08:00:27:01:51:aa",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -538,68 +563,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "c24c6da0-e6d2-4176-8581-cccfe53918b7"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "83ca3e26-ea06-4f1c-9b30-84886d860515"
-    },
     "/dev/sda1": {
-      "partuuid": "8705c40a-2e78-4768-a8a1-2a6299092f34",
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "44316c3a-fc65-458a-90b3-9253f5c24971",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "fc52b7df-6d51-402f-8c8b-05399f80811b"
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "c9e11f71-394f-4ad6-8a27-c4e6c20067ee",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "eJetuf-vIJ4-9FOf-FObG-VL8t-hSY1-O2i6uC"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
     }
   },
-  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -613,50 +637,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 b06008a15313455218d6f5abc8fbf08a145f6531",
-        "sha256": "SSHFP 3 2 25fe604fbf13cecf724b8dc798b7500bac3aef21b1e587389fdfdee538e2a9b4"
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGFzc3LSrVlT6KnwzuWeGsFUmCpQWLEOdDq1/rtth9tsTTt2NCILUAHfESbBg1aenVaXqItvqKEcqQmPAv8Cv64=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 5e7f82ab680598f05ccb8af7c2bafc94e463432a",
-        "sha256": "SSHFP 4 2 1f264307cc9b28b965e05c65bf9daf662f85ed0155fc1631b165eee4a0b9fc20"
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOLzMZAUYLO2vet8UZbd0ZRGly3d64F2Vu9sYAGSpofW",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 0d9825aaf9ea34d5faea633a3b452d52af077905",
-        "sha256": "SSHFP 1 2 486d0626a1e434ff9eed9e43e32566f51dcd6dd57c0fe6e416f09db8842b845e"
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCfc7GXHQgjLuWzE9juBt6seAyjo+HrFkkaMa0JYdJ9IjuQLPJjMeevJH9gXhE2EowsUMs2iCB3nh8iXA6kAQBSVi835IHxpGqJ+hatTAfPZOIlFMhVKRb0EyJFVifxrRQ6bnPYkMHd89iq2ufoNmlyS+w88KOcDRcfnS/h/3GFgHH44EgVDczqRsZ5Df6oDdmPEwUxraESClfGI34B4ckYUVF75OGT+dDr+G08O6IK1IXIdu1dMgRX5RDvFq/cTJq29i/WO5C/ggbXUSVpa9R0g2MdamolFcT791tTIOOw1yKBZILstsmfkuL/GQ6lE8XXqVXON4KW/IBDJpWaKcV8MIixAaEIlQEGcUc/bBxvKepjSxlkUiPM1tsKHlBoAp/Nec6Eq9w47KXfeFUUPODwl1WCNzM158ScnKYWmknl05EpLHuWgP3CQ/jyKza7scrkAGbKhDVx0v3QxM1ny6mUsNz+cS7nJ71Rw6x+a5ge6PRu77viNTgntH79Rmywgl0=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGFzc3LSrVlT6KnwzuWeGsFUmCpQWLEOdDq1/rtth9tsTTt2NCILUAHfESbBg1aenVaXqItvqKEcqQmPAv8Cv64=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOLzMZAUYLO2vet8UZbd0ZRGly3d64F2Vu9sYAGSpofW",
-  "sshfp_ecdsa": "SSHFP 3 1 b06008a15313455218d6f5abc8fbf08a145f6531\nSSHFP 3 2 25fe604fbf13cecf724b8dc798b7500bac3aef21b1e587389fdfdee538e2a9b4",
-  "sshfp_ed25519": "SSHFP 4 1 5e7f82ab680598f05ccb8af7c2bafc94e463432a\nSSHFP 4 2 1f264307cc9b28b965e05c65bf9daf662f85ed0155fc1631b165eee4a0b9fc20",
-  "sshfp_rsa": "SSHFP 1 1 0d9825aaf9ea34d5faea633a3b452d52af077905\nSSHFP 1 2 486d0626a1e434ff9eed9e43e32566f51dcd6dd57c0fe6e416f09db8842b845e",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCfc7GXHQgjLuWzE9juBt6seAyjo+HrFkkaMa0JYdJ9IjuQLPJjMeevJH9gXhE2EowsUMs2iCB3nh8iXA6kAQBSVi835IHxpGqJ+hatTAfPZOIlFMhVKRb0EyJFVifxrRQ6bnPYkMHd89iq2ufoNmlyS+w88KOcDRcfnS/h/3GFgHH44EgVDczqRsZ5Df6oDdmPEwUxraESClfGI34B4ckYUVF75OGT+dDr+G08O6IK1IXIdu1dMgRX5RDvFq/cTJq29i/WO5C/ggbXUSVpa9R0g2MdamolFcT791tTIOOw1yKBZILstsmfkuL/GQ6lE8XXqVXON4KW/IBDJpWaKcV8MIixAaEIlQEGcUc/bBxvKepjSxlkUiPM1tsKHlBoAp/Nec6Eq9w47KXfeFUUPODwl1WCNzM158ScnKYWmknl05EpLHuWgP3CQ/jyKza7scrkAGbKhDVx0v3QxM1ny6mUsNz+cS7nJ71Rw6x+a5ge6PRu77viNTgntH79Rmywgl0=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 221,
+    "seconds": 232,
     "uptime": "0:03 hours"
   },
   "timezone": "UTC",
   "uptime": "0:03 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 221,
-  "uuid": "0fdbca52-8805-2b4e-9e70-ae380934a230",
+  "uptime_seconds": 232,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
   "virtual": "virtualbox"
 }

--- a/facts/4.5/fedora-39-x86_64.facts
+++ b/facts/4.5/fedora-39-x86_64.facts
@@ -1,10 +1,14 @@
 {
   "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
   "bios_release_date": "12/01/2006",
   "bios_vendor": "innotek GmbH",
   "bios_version": "VirtualBox",
   "blockdevice_sda_model": "VBOX HARDDISK",
-  "blockdevice_sda_size": 137438953472,
+  "blockdevice_sda_size": 42949672960,
   "blockdevice_sda_vendor": "ATA",
   "blockdevices": "sda",
   "boardmanufacturer": "Oracle Corporation",
@@ -17,9 +21,9 @@
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
-      "serial": "VBa9780504-adf36f37",
-      "size": "128.00 GiB",
-      "size_bytes": 137438953472,
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
       "type": "hdd",
       "vendor": "ATA"
     }
@@ -42,21 +46,23 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53"
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f"
     }
   },
   "domain": "example.com",
-  "facterversion": "4.5.1",
-  "filesystems": "btrfs,ext2,ext3,ext4,xfs",
+  "facterversion": "4.5.2",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
   "fips_enabled": false,
   "fqdn": "foo.example.com",
-  "gem_version": "~> 4.5.0",
+  "gem_version": "~> 4.5.2",
   "gid": "root",
   "hardwareisa": "unknown",
   "hardwaremodel": "x86_64",
   "hostname": "foo",
   "hypervisors": {
     "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
     }
   },
   "id": "root",
@@ -69,8 +75,8 @@
   },
   "interfaces": "eth0,lo",
   "ipaddress": "10.0.2.15",
-  "ipaddress6": "fe80::a00:27ff:fee1:22a2",
-  "ipaddress6_eth0": "fe80::a00:27ff:fee1:22a2",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
   "ipaddress6_lo": "::1",
   "ipaddress_eth0": "10.0.2.15",
   "ipaddress_lo": "127.0.0.1",
@@ -80,81 +86,96 @@
   "kernelrelease": "6.5.6-300.fc39.x86_64",
   "kernelversion": "6.5.6",
   "load_averages": {
-    "15m": 0.02,
-    "1m": 0.23,
-    "5m": 0.07
+    "15m": 0.17,
+    "1m": 0.97,
+    "5m": 0.44
   },
   "lsbdistrelease": "39",
   "lsbmajdistrelease": "39",
-  "macaddress": "08:00:27:e1:22:a2",
-  "macaddress_eth0": "08:00:27:e1:22:a2",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
   "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "3.91 GiB",
-      "available_bytes": 4195344384,
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
       "capacity": "0.00%",
-      "total": "3.91 GiB",
-      "total_bytes": 4195344384,
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "system": {
-      "available": "1.56 GiB",
-      "available_bytes": 1670643712,
-      "capacity": "18.44%",
+      "available": "1.59 GiB",
+      "available_bytes": 1710923776,
+      "capacity": "16.48%",
       "total": "1.91 GiB",
-      "total_bytes": 2048360448,
-      "used": "360.22 MiB",
-      "used_bytes": 377716736
+      "total_bytes": 2048634880,
+      "used": "322.07 MiB",
+      "used_bytes": 337711104
     }
   },
-  "memoryfree": "1.56 GiB",
-  "memoryfree_mb": 1593.25,
+  "memoryfree": "1.59 GiB",
+  "memoryfree_mb": 1631.6640625,
   "memorysize": "1.91 GiB",
-  "memorysize_mb": 1953.46875,
+  "memorysize_mb": 1953.73046875,
   "mountpoints": {
     "/": {
-      "available": "122.48 GiB",
-      "available_bytes": 131508645888,
-      "capacity": "1.97%",
-      "device": "/dev/mapper/fedora-root",
-      "filesystem": "xfs",
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
       "options": [
         "rw",
         "seclabel",
         "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
       ],
-      "size": "124.93 GiB",
-      "size_bytes": 134146424832,
-      "used": "2.46 GiB",
-      "used_bytes": 2637778944
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
     },
     "/boot": {
-      "available": "811.04 MiB",
-      "available_bytes": 850440192,
-      "capacity": "15.52%",
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
       "device": "/dev/sda2",
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "options": [
         "rw",
         "seclabel",
-        "relatime",
-        "attr2",
-        "inode64",
-        "logbufs=8",
-        "logbsize=32k",
-        "noquota"
+        "relatime"
       ],
-      "size": "960.00 MiB",
-      "size_bytes": 1006632960,
-      "used": "148.96 MiB",
-      "used_bytes": 156192768
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
     },
     "/dev": {
       "available": "4.00 MiB",
@@ -167,7 +188,7 @@
         "seclabel",
         "nosuid",
         "size=4096k",
-        "nr_inodes=246314",
+        "nr_inodes=244875",
         "mode=755",
         "inode64"
       ],
@@ -236,8 +257,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -248,14 +269,34 @@
         "nodev",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
       "used": "0 bytes",
       "used_bytes": 0
     },
+    "/home": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
     "/run": {
-      "available": "385.22 MiB",
-      "available_bytes": 403931136,
+      "available": "385.29 MiB",
+      "available_bytes": 404000768,
       "capacity": "1.40%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -264,19 +305,19 @@
         "seclabel",
         "nosuid",
         "nodev",
-        "size=400072k",
+        "size=400124k",
         "nr_inodes=819200",
         "mode=755",
         "inode64"
       ],
-      "size": "390.70 MiB",
-      "size_bytes": 409673728,
-      "used": "5.48 MiB",
-      "used_bytes": 5742592
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.46 MiB",
+      "used_bytes": 5726208
     },
     "/run/user/1000": {
-      "available": "195.34 MiB",
-      "available_bytes": 204828672,
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
       "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -286,22 +327,22 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=200032k",
-        "nr_inodes=50008",
+        "size=200060k",
+        "nr_inodes=50015",
         "mode=700",
         "uid=1000",
         "gid=1000",
         "inode64"
       ],
-      "size": "195.34 MiB",
-      "size_bytes": 204832768,
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
       "used": "4.00 KiB",
       "used_bytes": 4096
     },
     "/tmp": {
-      "available": "976.73 MiB",
-      "available_bytes": 1024180224,
-      "capacity": "0%",
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -309,28 +350,14 @@
         "seclabel",
         "nosuid",
         "nodev",
+        "size=1000312k",
         "nr_inodes=1048576",
         "inode64"
       ],
-      "size": "976.73 MiB",
-      "size_bytes": 1024180224,
-      "used": "0 bytes",
-      "used_bytes": 0
-    },
-    "/vagrant": {
-      "available": "710.36 GiB",
-      "available_bytes": 762741547008,
-      "capacity": "22.43%",
-      "device": "vagrant",
-      "filesystem": "vboxsf",
-      "options": [
-        "rw",
-        "relatime"
-      ],
-      "size": "915.81 GiB",
-      "size_bytes": 983345152000,
-      "used": "205.45 GiB",
-      "used_bytes": 220603604992
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
     }
   },
   "mtu_eth0": 1500,
@@ -362,7 +389,7 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fee1:22a2",
+            "address": "fe80::85e6:627e:6634:e6b5",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::",
             "scope6": "link",
@@ -373,8 +400,8 @@
         ],
         "duplex": "full",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fee1:22a2",
-        "mac": "08:00:27:e1:22:a2",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -417,8 +444,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fee1:22a2",
-    "mac": "08:00:27:e1:22:a2",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -459,68 +486,67 @@
   },
   "osfamily": "RedHat",
   "partitions": {
-    "/dev/mapper/fedora-root": {
-      "filesystem": "xfs",
-      "label": "root",
-      "mount": "/",
-      "size": "125.00 GiB",
-      "size_bytes": 134213533696,
-      "uuid": "a4bd9ad0-c708-4b6d-a771-0efde5e3edf3"
-    },
-    "/dev/mapper/fedora-swap": {
-      "filesystem": "swap",
-      "size": "2.00 GiB",
-      "size_bytes": 2147483648,
-      "uuid": "5a5a6a35-e192-4ddd-a569-ad4f62e17304"
-    },
     "/dev/sda1": {
-      "partuuid": "7b20e462-a05a-4fd2-a9b2-2d2469443c5c",
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
       "size": "1.00 MiB",
       "size_bytes": 1048576
     },
     "/dev/sda2": {
-      "filesystem": "xfs",
+      "filesystem": "ext4",
       "label": "boot",
       "mount": "/boot",
-      "partuuid": "ff3bad15-caad-4f45-a8d0-c988b13478b1",
-      "size": "1.00 GiB",
-      "size_bytes": 1073741824,
-      "uuid": "cebba907-c354-46b2-94b9-f9f2f8224d71"
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
     },
     "/dev/sda3": {
-      "filesystem": "LVM2_member",
-      "partuuid": "63125510-501b-4f42-a4e2-c3c01cdbe0de",
-      "size": "127.00 GiB",
-      "size_bytes": 136362065920,
-      "uuid": "71HJJh-5qse-gqz2-8rFG-6KFh-nXLo-JFm3bK"
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
     }
   },
   "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
   "physicalprocessorcount": 1,
-  "processor0": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processor1": "12th Gen Intel(R) Core(TM) i9-12900K",
-  "processorcount": 2,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
   "processors": {
-    "cores": 2,
-    "count": 2,
+    "cores": 1,
+    "count": 1,
     "isa": "unknown",
     "models": [
-      "12th Gen Intel(R) Core(TM) i9-12900K",
-      "12th Gen Intel(R) Core(TM) i9-12900K"
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
     ],
     "physicalcount": 1,
-    "speed": "3.19 GHz",
+    "speed": "1.70 GHz",
     "threads": 1
   },
   "productname": "VirtualBox",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/local/share/ruby/site_ruby",
-    "version": "3.2.2"
+    "version": "3.2.4"
   },
   "rubyplatform": "x86_64-linux",
   "rubysitedir": "/usr/local/share/ruby/site_ruby",
-  "rubyversion": "3.2.2",
+  "rubyversion": "3.2.4",
   "scope6": "link",
   "scope6_eth0": "link",
   "scope6_lo": "host",
@@ -534,50 +560,50 @@
   "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba",
-        "sha256": "SSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38"
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454",
-        "sha256": "SSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc"
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e",
-        "sha256": "SSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502"
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
       "type": "ssh-rsa"
     }
   },
-  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLX2AI728HUnLW7UyGXXWk5GiW70MiNL3iQbc5ZIwS1euyt+hSdIlmR0PnUokWyFCxQ5VGIDkr4V0awQqt8gxg0=",
-  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIJ2wZLd7otHTxUiJJlS05mJapLvtOSLNKltDZ8NLJuyl",
-  "sshfp_ecdsa": "SSHFP 3 1 88c6d9c5ad05640de9c609556684cce0734e7bba\nSSHFP 3 2 6e756b59d8200be22ba1cc12551adb142facc69022f868cd85dfa2696bdd6e38",
-  "sshfp_ed25519": "SSHFP 4 1 dbe373bb15933dda0f97ac53c3d89a5559678454\nSSHFP 4 2 207bbf5800179fd5ee727743e61c9bb15d392a74e510c7bd85ce768a7e61a7dc",
-  "sshfp_rsa": "SSHFP 1 1 d06c5192ec16ab5d4e1734b2851fffd9ed17549e\nSSHFP 1 2 940ce6e20f30da7a3af01fdf11e18ff1e8dfa23b6b5a95c083da09cfffb55502",
-  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCYr8j2Ao2rK/kU5Z4WZosGq+s8OnMfG+paOgvXhz65S4WZD3Z0ZOUV6tPn3jcvDTBoMteW+0MWD9d2U9z1BskajHCSDD9BQ2A7sfyqMdi4c/+76hp6z1CnA50WMnM3WCFx2zImv3jpg+C5XVwI6H8+Ir/cHW0vgTVcQ+0eQUORfVBBSI63ajtMFUnlQjeA7ic8odynec+E5QxVKf8HZ+JYUJmEcBCGMSF3LNbWaUh/3h3AoK2gX2uZYQxBhEVe3ttwPJINWNayf1t/uiorjiDqgaKdR0bfldo012UkmdGulGUjxOFc8rnNVqT4U1QREUpmZY3wdP8E2Eg0ta95QkNcCg4tzeC4dAaLz/dn8BitjHI9XnQkCR8MbKZTej/AMw5A4EWyS+H/i6UcKDmZoDviE44OyBKY7+5Yv9J6qLox1zjF3weeGqxnoTTQcpIlUGwF/WHqsUVinvn1eTZriFKpL8l5hRcyOWpOk93Jx4R0XXm2nyWNcuhRInFdI7zb4O8=",
-  "swapfree": "3.91 GiB",
-  "swapfree_mb": 4000.9921875,
-  "swapsize": "3.91 GiB",
-  "swapsize_mb": 4000.9921875,
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 129,
+    "seconds": 177,
     "uptime": "0:02 hours"
   },
   "timezone": "UTC",
   "uptime": "0:02 hours",
   "uptime_days": 0,
   "uptime_hours": 0,
-  "uptime_seconds": 129,
-  "uuid": "5dea01e8-d9eb-484c-a16c-a76c5b25fd53",
+  "uptime_seconds": 177,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
   "virtual": "virtualbox"
 }

--- a/facts/4.6/fedora-38-x86_64.facts
+++ b/facts/4.6/fedora-38-x86_64.facts
@@ -1,0 +1,688 @@
+{
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.6.1",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gem_version": "~> 4.6.0",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "6.2",
+  "kernelrelease": "6.2.9-300.fc38.x86_64",
+  "kernelversion": "6.2.9",
+  "load_averages": {
+    "15m": 0.18,
+    "1m": 1.11,
+    "5m": 0.48
+  },
+  "lsbdistrelease": "38",
+  "lsbmajdistrelease": "38",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "swap": {
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
+      "capacity": "0.00%",
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.61 GiB",
+      "available_bytes": 1725267968,
+      "capacity": "15.80%",
+      "total": "1.91 GiB",
+      "total_bytes": 2048909312,
+      "used": "308.65 MiB",
+      "used_bytes": 323641344
+    }
+  },
+  "memoryfree": "1.61 GiB",
+  "memoryfree_mb": 1645.34375,
+  "memorysize": "1.91 GiB",
+  "memorysize_mb": 1953.9921875,
+  "mountpoints": {
+    "/": {
+      "available": "37.66 GiB",
+      "available_bytes": 40436576256,
+      "capacity": "2.20%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "865.86 MiB",
+      "used_bytes": 907923456
+    },
+    "/boot": {
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
+      "device": "/dev/sda2",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=245606",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/home": {
+      "available": "37.66 GiB",
+      "available_bytes": 40436576256,
+      "capacity": "2.20%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "865.86 MiB",
+      "used_bytes": 907923456
+    },
+    "/run": {
+      "available": "385.41 MiB",
+      "available_bytes": 404131840,
+      "capacity": "1.38%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=400180k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5652480
+    },
+    "/run/credentials/systemd-resolved.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200088k",
+        "nr_inodes=50022",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/tmp": {
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "nr_inodes=1048576",
+        "inode64"
+      ],
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::2d54:1b3c:73e3:6f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "Fedora",
+  "operatingsystemmajrelease": "38",
+  "operatingsystemrelease": "38",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Thirty Eight",
+      "description": "Fedora release 38 (Thirty Eight)",
+      "id": "Fedora",
+      "release": {
+        "full": "38",
+        "major": "38"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Fedora",
+    "release": {
+      "full": "38",
+      "major": "38"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/sda1": {
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "ext4",
+      "label": "boot",
+      "mount": "/boot",
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
+    },
+    "/dev/sda3": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
+    }
+  },
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "unknown",
+    "models": [
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "1.70 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
+    "version": "3.2.4"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "3.2.4",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "serialnumber": "0",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 237,
+    "uptime": "0:03 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:03 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 237,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
+  "virtual": "virtualbox"
+}

--- a/facts/4.6/fedora-39-x86_64.facts
+++ b/facts/4.6/fedora-39-x86_64.facts
@@ -1,0 +1,611 @@
+{
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.6.1",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gem_version": "~> 4.6.0",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "6.5",
+  "kernelrelease": "6.5.6-300.fc39.x86_64",
+  "kernelversion": "6.5.6",
+  "load_averages": {
+    "15m": 0.18,
+    "1m": 0.97,
+    "5m": 0.45
+  },
+  "lsbdistrelease": "39",
+  "lsbmajdistrelease": "39",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "swap": {
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
+      "capacity": "0.00%",
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.59 GiB",
+      "available_bytes": 1709350912,
+      "capacity": "16.56%",
+      "total": "1.91 GiB",
+      "total_bytes": 2048634880,
+      "used": "323.57 MiB",
+      "used_bytes": 339283968
+    }
+  },
+  "memoryfree": "1.59 GiB",
+  "memoryfree_mb": 1630.1640625,
+  "memorysize": "1.91 GiB",
+  "memorysize_mb": 1953.73046875,
+  "mountpoints": {
+    "/": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
+    "/boot": {
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
+      "device": "/dev/sda2",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=244875",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/home": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
+    "/run": {
+      "available": "385.29 MiB",
+      "available_bytes": 404000768,
+      "capacity": "1.40%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=400124k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.46 MiB",
+      "used_bytes": 5726208
+    },
+    "/run/user/1000": {
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200060k",
+        "nr_inodes=50015",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/tmp": {
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=1000312k",
+        "nr_inodes=1048576",
+        "inode64"
+      ],
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::85e6:627e:6634:e6b5",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "Fedora",
+  "operatingsystemmajrelease": "39",
+  "operatingsystemrelease": "39",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Thirty Nine",
+      "description": "Fedora release 39 (Thirty Nine)",
+      "id": "Fedora",
+      "release": {
+        "full": "39",
+        "major": "39"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Fedora",
+    "release": {
+      "full": "39",
+      "major": "39"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/sda1": {
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "ext4",
+      "label": "boot",
+      "mount": "/boot",
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
+    },
+    "/dev/sda3": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "unknown",
+    "models": [
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "1.70 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
+    "version": "3.2.4"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "3.2.4",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "serialnumber": "0",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 180,
+    "uptime": "0:03 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:03 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 180,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/fedora-38-x86_64.facts
+++ b/facts/4.7/fedora-38-x86_64.facts
@@ -1,0 +1,688 @@
+{
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb7ba6662-f508695f",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.7.0",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gem_version": "~> 4.7.0",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_eth0": "fe80::2d54:1b3c:73e3:6f0",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "6.2",
+  "kernelrelease": "6.2.9-300.fc38.x86_64",
+  "kernelversion": "6.2.9",
+  "load_averages": {
+    "15m": 0.18,
+    "1m": 0.37,
+    "5m": 0.28
+  },
+  "lsbdistrelease": "38",
+  "lsbmajdistrelease": "38",
+  "macaddress": "52:54:00:d6:6b:09",
+  "macaddress_eth0": "52:54:00:d6:6b:09",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "swap": {
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
+      "capacity": "0.00%",
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.60 GiB",
+      "available_bytes": 1715728384,
+      "capacity": "16.26%",
+      "total": "1.91 GiB",
+      "total_bytes": 2048909312,
+      "used": "317.75 MiB",
+      "used_bytes": 333180928
+    }
+  },
+  "memoryfree": "1.60 GiB",
+  "memoryfree_mb": 1636.24609375,
+  "memorysize": "1.91 GiB",
+  "memorysize_mb": 1953.9921875,
+  "mountpoints": {
+    "/": {
+      "available": "37.64 GiB",
+      "available_bytes": 40418242560,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "883.35 MiB",
+      "used_bytes": 926257152
+    },
+    "/boot": {
+      "available": "843.72 MiB",
+      "available_bytes": 884703232,
+      "capacity": "6.24%",
+      "device": "/dev/sda2",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "56.13 MiB",
+      "used_bytes": 58859520
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=245606",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/home": {
+      "available": "37.64 GiB",
+      "available_bytes": 40418242560,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "883.35 MiB",
+      "used_bytes": 926257152
+    },
+    "/run": {
+      "available": "385.41 MiB",
+      "available_bytes": 404131840,
+      "capacity": "1.38%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=400180k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "390.80 MiB",
+      "size_bytes": 409784320,
+      "used": "5.39 MiB",
+      "used_bytes": 5652480
+    },
+    "/run/credentials/systemd-resolved.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "ramfs",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "195.40 MiB",
+      "available_bytes": 204890112,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200088k",
+        "nr_inodes=50022",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.40 MiB",
+      "size_bytes": 204890112,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/tmp": {
+      "available": "977.00 MiB",
+      "available_bytes": 1024454656,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "nr_inodes=1048576",
+        "inode64"
+      ],
+      "size": "977.00 MiB",
+      "size_bytes": 1024454656,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::2d54:1b3c:73e3:6f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::2d54:1b3c:73e3:6f0",
+        "mac": "52:54:00:d6:6b:09",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::2d54:1b3c:73e3:6f0",
+    "mac": "52:54:00:d6:6b:09",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "Fedora",
+  "operatingsystemmajrelease": "38",
+  "operatingsystemrelease": "38",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Thirty Eight",
+      "description": "Fedora release 38 (Thirty Eight)",
+      "id": "Fedora",
+      "release": {
+        "full": "38",
+        "major": "38"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Fedora",
+    "release": {
+      "full": "38",
+      "major": "38"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/sda1": {
+      "partuuid": "d42d1067-415a-4e51-9694-d591cd0aa187",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "ext4",
+      "label": "boot",
+      "mount": "/boot",
+      "partuuid": "f31677f8-f2bc-4827-b4ea-956b5e8dc494",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "a7fc7609-e044-4b52-ab39-a3107784d0a6"
+    },
+    "/dev/sda3": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "22cbcfd2-aa89-4818-a9d5-c3dbed6c3d2a",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "6C57-ADB4"
+    },
+    "/dev/sda4": {
+      "partuuid": "28982ccb-e06f-4dce-8fd1-0b64f903c9c6",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "a3340207-1256-4af9-a3db-c42ab8300bee",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "94fc4136-6c15-43b0-8d86-094c126ee7d4"
+    }
+  },
+  "path": "/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "unknown",
+    "models": [
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "1.70 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
+    "version": "3.2.4"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "3.2.4",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "serialnumber": "0",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707",
+        "sha256": "SSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c",
+        "sha256": "SSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d",
+        "sha256": "SSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAnyV8+rp6dmYnr7R0mBfArIzMadc0vsREjc+VOCnWVs0IaEtnlzw0n9B8j9vY/3gs/BBTbtynjmov+Oaqx7YEg=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAILnBGLwHllzB2415hNq3iiGB4+29jbrtr4v+Q5kf4Y48",
+  "sshfp_ecdsa": "SSHFP 3 1 8c2bca85e212db7c5802abb9dc0f0d3dc2213707\nSSHFP 3 2 43670d63948aa477a34f20d7be1d2534dfd686c56fcea5c2cb7ede0b4e8f7333",
+  "sshfp_ed25519": "SSHFP 4 1 14db6e254987f3a513666b39cfb875963a7b0d5c\nSSHFP 4 2 1aa4b8a956ce93c58cd2f5280742d548a09b42a8ce8d2cd4524683650cdb2c93",
+  "sshfp_rsa": "SSHFP 1 1 8dd8594e87495963b011e8356556406a72482d4d\nSSHFP 1 2 9c1d4ce171e37429024d36a923aad076515e1f241b4ea1e7e937ea25af799581",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCoPdyJXS66rmHTLtNTxy0DMcUp1KxIh20TjzNSClAwbSPyfnnfZRcmMENu05Ea9yYIULlCFjmjkNshDacgwyZVQajv9Pf7wqzVNUlWdcXDRcJv5r2Z4nbR+pVDtoyNZcEy8+GKmIKbTPX9fza8svyxTdKO1yi3qGR/WYj85w8KUwHhMziJZl4EETJGpVKThDBcRgqzMZOaY8573Ct8pu8abi84kVgYinzLMh+9LoVvSmy7jRic/h/4KskFhNqmOEAhMQqM21JPfOmpAMg6o8hPQJ6L84h5sVMoaNTVv/wcUd9lRE0p0ibyhjI+kKgYsUElXZxOqxgCayLyO1CB79ffKVDryEhdbldEPImId14pAhymziUHorOoqwOF81JHcQTvZsyBbwrC9KCL2EZfJ9ZmHDAGe2n33amnNAaloxjqTDJB6L7f4YsvkthkDkRMPN6WErOdXBovCR2GbMoIj8okfuyrIxdEh2cEG2sNRmsHI3d3yMHPMKUES4iBFLGyZVk=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 583,
+    "uptime": "0:09 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:09 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 583,
+  "uuid": "7aa40baa-bcb3-7b42-86c5-f98e39bf11c9",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/fedora-39-x86_64.facts
+++ b/facts/4.7/fedora-39-x86_64.facts
@@ -1,0 +1,611 @@
+{
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.13.0"
+  },
+  "augeasversion": "1.13.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 42949672960,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "system": null
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB0c858941-78651535",
+      "size": "40.00 GiB",
+      "size_bytes": 42949672960,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
+      "version": "1.2"
+    }
+  },
+  "domain": "example.com",
+  "facterversion": "4.7.0",
+  "filesystems": "btrfs,ext2,ext3,ext4,vfat",
+  "fips_enabled": false,
+  "fqdn": "foo.example.com",
+  "gem_version": "~> 4.7.0",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "162988",
+      "version": "7.0.18"
+    }
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_eth0": "fe80::85e6:627e:6634:e6b5",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "6.5",
+  "kernelrelease": "6.5.6-300.fc39.x86_64",
+  "kernelversion": "6.5.6",
+  "load_averages": {
+    "15m": 0.18,
+    "1m": 0.97,
+    "5m": 0.45
+  },
+  "lsbdistrelease": "39",
+  "lsbmajdistrelease": "39",
+  "macaddress": "52:54:00:52:8d:1d",
+  "macaddress_eth0": "52:54:00:52:8d:1d",
+  "manufacturer": "innotek GmbH",
+  "memory": {
+    "swap": {
+      "available": "1.91 GiB",
+      "available_bytes": 2047864832,
+      "capacity": "0.00%",
+      "total": "1.91 GiB",
+      "total_bytes": 2047864832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.59 GiB",
+      "available_bytes": 1709379584,
+      "capacity": "16.56%",
+      "total": "1.91 GiB",
+      "total_bytes": 2048634880,
+      "used": "323.54 MiB",
+      "used_bytes": 339255296
+    }
+  },
+  "memoryfree": "1.59 GiB",
+  "memoryfree_mb": 1630.19140625,
+  "memorysize": "1.91 GiB",
+  "memorysize_mb": 1953.73046875,
+  "mountpoints": {
+    "/": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=256",
+        "subvol=/root"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
+    "/boot": {
+      "available": "839.20 MiB",
+      "available_bytes": 879960064,
+      "capacity": "6.74%",
+      "device": "/dev/sda2",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "965.85 MiB",
+      "size_bytes": 1012768768,
+      "used": "60.66 MiB",
+      "used_bytes": 63602688
+    },
+    "/boot/efi": {
+      "available": "88.21 MiB",
+      "available_bytes": 92499968,
+      "capacity": "11.57%",
+      "device": "/dev/sda3",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "99.76 MiB",
+      "size_bytes": 104607744,
+      "used": "11.55 MiB",
+      "used_bytes": 12107776
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=244875",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "976.86 MiB",
+      "available_bytes": 1024315392,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "976.86 MiB",
+      "size_bytes": 1024315392,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/home": {
+      "available": "37.63 GiB",
+      "available_bytes": 40407924736,
+      "capacity": "2.24%",
+      "device": "/dev/sda5",
+      "filesystem": "btrfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "compress=zstd:1",
+        "space_cache=v2",
+        "subvolid=257",
+        "subvol=/home"
+      ],
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "used": "881.84 MiB",
+      "used_bytes": 924680192
+    },
+    "/run": {
+      "available": "385.29 MiB",
+      "available_bytes": 404000768,
+      "capacity": "1.40%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=400124k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "390.75 MiB",
+      "size_bytes": 409726976,
+      "used": "5.46 MiB",
+      "used_bytes": 5726208
+    },
+    "/run/user/1000": {
+      "available": "195.37 MiB",
+      "available_bytes": 204857344,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200060k",
+        "nr_inodes=50015",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.37 MiB",
+      "size_bytes": 204861440,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/tmp": {
+      "available": "976.86 MiB",
+      "available_bytes": 1024307200,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=1000312k",
+        "nr_inodes=1048576",
+        "inode64"
+      ],
+      "size": "976.87 MiB",
+      "size_bytes": 1024319488,
+      "used": "12.00 KiB",
+      "used_bytes": 12288
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::85e6:627e:6634:e6b5",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::85e6:627e:6634:e6b5",
+        "mac": "52:54:00:52:8d:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::85e6:627e:6634:e6b5",
+    "mac": "52:54:00:52:8d:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "Fedora",
+  "operatingsystemmajrelease": "39",
+  "operatingsystemrelease": "39",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Thirty Nine",
+      "description": "Fedora release 39 (Thirty Nine)",
+      "id": "Fedora",
+      "release": {
+        "full": "39",
+        "major": "39"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Fedora",
+    "release": {
+      "full": "39",
+      "major": "39"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/sda1": {
+      "partuuid": "6ba0d95b-f84e-457e-9bb6-a8b8d14a16cb",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "ext4",
+      "label": "boot",
+      "mount": "/boot",
+      "partuuid": "7ecb078b-d577-4877-814a-0543b5df03cc",
+      "size": "1000.00 MiB",
+      "size_bytes": 1048576000,
+      "uuid": "812bf8d3-3f7d-40c4-bbe2-0c0641381b94"
+    },
+    "/dev/sda3": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partuuid": "20779d33-74fb-4c91-b78c-f019961c6b86",
+      "size": "100.00 MiB",
+      "size_bytes": 104857600,
+      "uuid": "3BFB-1432"
+    },
+    "/dev/sda4": {
+      "partuuid": "2f9952af-6f85-4755-bf41-029a29fe469a",
+      "size": "4.00 MiB",
+      "size_bytes": 4194304
+    },
+    "/dev/sda5": {
+      "filesystem": "btrfs",
+      "label": "fedora",
+      "mount": "/",
+      "partuuid": "0862fc4d-9b2f-4814-a1fb-5920b0a722df",
+      "size": "38.92 GiB",
+      "size_bytes": 41788899328,
+      "uuid": "0ad62522-932a-40a8-bd4b-efd69746a117"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/lib/snapd/snap/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "AMD Ryzen 7 PRO 4750U with Radeon Graphics",
+  "processorcount": 1,
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "unknown",
+    "models": [
+      "AMD Ryzen 7 PRO 4750U with Radeon Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "1.70 GHz",
+    "threads": 1
+  },
+  "productname": "VirtualBox",
+  "productversion": "1.2",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
+    "version": "3.2.4"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "3.2.4",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "33",
+  "serialnumber": "0",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab",
+        "sha256": "SSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d",
+        "sha256": "SSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e",
+        "sha256": "SSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBM4UqdGxHncetifzxrT5xVi959jI2z5ihoTWL8npLlc/PwAeqtuNp+fIABV9MXbW1ynyatwF5QMI4BA2l+ZUTfI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAII1nOyfLJegOsuJ7yOIVe1DjbyKGIPnZLduSo/FSr0HP",
+  "sshfp_ecdsa": "SSHFP 3 1 1daaa8484ad8b1ebe710a4e16d3e12087eedacab\nSSHFP 3 2 87382d042ce55d0f137e92abd81b921948aa331bc030f307de8f3ece955cd960",
+  "sshfp_ed25519": "SSHFP 4 1 8a74e0931af9292e174caa80752c6642f5dfcd4d\nSSHFP 4 2 f5f3774a6a5d36042aa0e336c425d68778d360eb81d4555f8af97eeec1d7052b",
+  "sshfp_rsa": "SSHFP 1 1 1814231799c5a0db39fecc8a379f1e41e1a2b13e\nSSHFP 1 2 cfec9c3320f75df19e22d988e9b7c65ac121f7b4cc067dbe335512e55e382a53",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCxLlK1bgy3Suq3FvEKlrrmPdG71unILfxTCyN5NC2K5z6oeFzkMXWVsP/qWnj4QRlt606BGWnvYPtyJE4wY2CrZdlnGHf2aOJV0R59ezTamRGc49LfjUxMcOwssYp95hn6f+grioiZSqioGCbDWupIxRovMa+89UHNaMr0BULOGZOXNojc8uCG9V5IDSd5X4qv2vZKtmvTaTur9MOi8/Ke8rtsNeq0cRPvvG5EADHBi9ImhhEigvcNwVBiyro54PYGGM5fFa31GvxXI2SjxxjYhIboPBcgWZzQlfz6d4zhbLrUKevUdYStwA6WP2e4yddU8QPC4LrXWU+QAXE+Q4pNnmyMrWvn3oa6HHCoVA/LkNjtLHQ8oPN1JCST+25hCO1CeEH7IviZv2McqVELZW46bTDfxqrV+X4OsIHDP4z16cDpGepS1qwwYfFZpbBFXJ6GlgVvLy5TyRdJFmi99byoQgbjwwpLHv6gQLQbwmpyL7SZAEyqbxDSkVmauudsXGE=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1952.99609375,
+  "swapsize": "1.91 GiB",
+  "swapsize_mb": 1952.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 184,
+    "uptime": "0:03 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "0:03 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 184,
+  "uuid": "c0c5350e-c03f-d248-a0c0-6fec0d7cf81f",
+  "virtual": "virtualbox"
+}

--- a/facts/Vagrantfile
+++ b/facts/Vagrantfile
@@ -367,17 +367,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
   end
   config.vm.define 'fedora-38-x86_64', autostart: false do |host|
-    host.vm.box = 'generic/fedora38'
+    # default memory limit kills dnf as soon as we install packages
+    host.vm.provider 'virtualbox' do |v|
+      v.memory = 2048
+    end
+    host.vm.box = 'fedora/38-cloud-base'
     host.vm.synced_folder '.', '/vagrant'
     host.vm.provision 'file', source: 'Gemfile', destination: 'Gemfile'
     host.vm.provision 'shell', path: 'get_facts.sh'
-    host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
+    # rsync is used to get the vagrant dir into the VM.
+    # We need to copy the factsets out of the VM by hand
+    # host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
   end
   config.vm.define 'fedora-39-x86_64', autostart: false do |host|
-    host.vm.box = 'generic/fedora39'
+    # default memory limit kills dnf as soon as we install packages
+    host.vm.provider 'virtualbox' do |v|
+      v.memory = 2048
+    end
+    host.vm.box = 'fedora/39-cloud-base'
     host.vm.synced_folder '.', '/vagrant'
     host.vm.provision 'file', source: 'Gemfile', destination: 'Gemfile'
     host.vm.provision 'shell', path: 'get_facts.sh'
-    host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
+    # rsync is used to get the vagrant dir into the VM.
+    # We need to copy the factsets out of the VM by hand
+    # host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
   end
 end


### PR DESCRIPTION
the existing factsets  were rebuild with augeas installed so we've the augeas facts.

I don't know what strange memory defaults those images have, but the VM
goes OOM when we run the get_facts.sh script, so I adjusted the memory
to 2G. also rsync is used and no shared folder. So I disabled the
automatic shutdown so we can copy the files out of the VM.