### PR TITLE
Add Rocky 8 factsets, switch to bento box

### DIFF
--- a/facts/4.6/rocky-8-x86_64.facts
+++ b/facts/4.6/rocky-8-x86_64.facts
@@ -1,0 +1,469 @@
+{
+  "aio_agent_version": "8.6.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6ba94f2f-e5040cee",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "6afb4fb2-17c3-a448-bca9-3c4eb6ff5f0c",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.6.1",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.6.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "163906",
+      "version": "7.0.20"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.8.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.74,
+    "5m": 0.26
+  },
+  "memory": {
+    "swap": {
+      "available": "2.05 GiB",
+      "available_bytes": 2200956928,
+      "capacity": "0.00%",
+      "total": "2.05 GiB",
+      "total_bytes": 2200956928,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.38 GiB",
+      "available_bytes": 1485123584,
+      "capacity": "20.36%",
+      "total": "1.74 GiB",
+      "total_bytes": 1864908800,
+      "used": "362.19 MiB",
+      "used_bytes": 379785216
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "59.88 GiB",
+      "available_bytes": 64290750464,
+      "capacity": "3.30%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "61.92 GiB",
+      "size_bytes": 66484989952,
+      "used": "2.04 GiB",
+      "used_bytes": 2194239488
+    },
+    "/dev": {
+      "available": "872.19 MiB",
+      "available_bytes": 914554880,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=893120k",
+        "nr_inodes=223280",
+        "mode=755"
+      ],
+      "size": "872.19 MiB",
+      "size_bytes": 914554880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "872.83 MiB",
+      "available_bytes": 915230720,
+      "capacity": "1.85%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "16.43 MiB",
+      "used_bytes": 17223680
+    },
+    "/run/user/1000": {
+      "available": "177.85 MiB",
+      "available_bytes": 186490880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=182120k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "177.85 MiB",
+      "size_bytes": 186490880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "513.50 GiB",
+      "available_bytes": 551366533120,
+      "capacity": "43.54%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "909.41 GiB",
+      "size_bytes": 976476184576,
+      "used": "395.91 GiB",
+      "used_bytes": 425109651456
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::402f:79e9:1141:bdb",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::402f:79e9:1141:bdb",
+        "mac": "08:00:27:3a:93:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::402f:79e9:1141:bdb",
+    "mac": "08:00:27:3a:93:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "permissive",
+      "config_policy": "targeted",
+      "current_mode": "permissive",
+      "enabled": true,
+      "enforced": false,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "partuuid": "51e0bef2-01",
+      "size": "2.05 GiB",
+      "size_bytes": 2200961024,
+      "uuid": "75705064-32a7-4839-bf61-ad50e9dd4882"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partuuid": "51e0bef2-02",
+      "size": "61.95 GiB",
+      "size_bytes": 66517467136,
+      "uuid": "4107fc45-2c8e-4963-baba-d35edc1df8f1"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics",
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "3.99 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.3"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe9b2e221e9474a503fc1e6f6fb00921678c6d0d",
+        "sha256": "SSHFP 3 2 02926205e3680707a42f5531d0c2b74c973c05898fecc6238fa43d5928c561c8"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtw+GhnOKWacmm2Y4+xAidRU3qhs6kLiylfWF4EYrOMwEIBXBMVa7qNR0Cqe2MchGWDvagCTLEVbtUksggcS1s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1bd0d4a48044f3e0998285fa886e3ebb40b142d3",
+        "sha256": "SSHFP 4 2 a26de78b266687d3910e558280f9803c2fd02f6fa2f7fa4d687c2c05bbb85292"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILKGutww9qvfzB2owYX0lCupf6+AJkllq4uk7QUu+UmD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 2963827fc1bd6a1c26412bebb6e6f131d5d833c0",
+        "sha256": "SSHFP 1 2 f366c94ff526c12e38eace0d30c27688d5ab56d6154e6f4908886c1796e897a5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgO9pBNmEP44UGmygqdwNRDOr7Ed89ACNuOa+BqDKv1xBeWbXhJ0WRJS6cdIcRj3I3u5OGDbIeLcNQ8LM4TVcYTAVhn2mRarxOziRnfthFXwvkjY9pvUQGsfjDHmTrkxXMyx4X8CPiUnr/dfrtOa7byaT6fAG78srmkgyPYZ7NXXKo2HC0bDVlmQfB4NP9JHUzbn/1FOWSRmnwoinlAuFr6cb1xnSwTitkygcXHX1Eye+bWa/YVe0HlW3wO/1qwnIOvwxWMytHq5I1XthAObHsOODEY79hcwzxb4Szz5JjTIsbikwjlszWgn4bZog2crKmjwis4J3wSuPEzc9gv/3aDQ2iK2/s2tz2tCPzMw/E0iXWN+BBfQxlT4eM40+Oo8PazQizvwpFGbFvlWjHnbg9gaNH2dtn62flx2kiXaUwBNOm2nDj/LMiEjO9KWttmV/VQzz+D44+B5GvNq4z2kYwTezWo6yQVEZSg7jFLhmX0mMnPzLabzhmLra5M2VR4+U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 74,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/rocky-8-x86_64.facts
+++ b/facts/4.7/rocky-8-x86_64.facts
@@ -1,0 +1,469 @@
+{
+  "aio_agent_version": "8.6.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6ba94f2f-e5040cee",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "6afb4fb2-17c3-a448-bca9-3c4eb6ff5f0c",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.7.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "163906",
+      "version": "7.0.20"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.8.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.08,
+    "1m": 0.76,
+    "5m": 0.24
+  },
+  "memory": {
+    "swap": {
+      "available": "2.05 GiB",
+      "available_bytes": 2200956928,
+      "capacity": "0.00%",
+      "total": "2.05 GiB",
+      "total_bytes": 2200956928,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.37 GiB",
+      "available_bytes": 1475747840,
+      "capacity": "20.87%",
+      "total": "1.74 GiB",
+      "total_bytes": 1864908800,
+      "used": "371.13 MiB",
+      "used_bytes": 389160960
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "59.91 GiB",
+      "available_bytes": 64325574656,
+      "capacity": "3.25%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "61.92 GiB",
+      "size_bytes": 66484989952,
+      "used": "2.01 GiB",
+      "used_bytes": 2159415296
+    },
+    "/dev": {
+      "available": "872.19 MiB",
+      "available_bytes": 914554880,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=893120k",
+        "nr_inodes=223280",
+        "mode=755"
+      ],
+      "size": "872.19 MiB",
+      "size_bytes": 914554880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "872.84 MiB",
+      "available_bytes": 915234816,
+      "capacity": "1.85%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "16.42 MiB",
+      "used_bytes": 17219584
+    },
+    "/run/user/1000": {
+      "available": "177.85 MiB",
+      "available_bytes": 186490880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=182120k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "177.85 MiB",
+      "size_bytes": 186490880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "513.50 GiB",
+      "available_bytes": 551366737920,
+      "capacity": "43.54%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "909.41 GiB",
+      "size_bytes": 976476184576,
+      "used": "395.91 GiB",
+      "used_bytes": 425109446656
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::402f:79e9:1141:bdb",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::402f:79e9:1141:bdb",
+        "mac": "08:00:27:3a:93:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::402f:79e9:1141:bdb",
+    "mac": "08:00:27:3a:93:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "permissive",
+      "config_policy": "targeted",
+      "current_mode": "permissive",
+      "enabled": true,
+      "enforced": false,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "partuuid": "51e0bef2-01",
+      "size": "2.05 GiB",
+      "size_bytes": 2200961024,
+      "uuid": "75705064-32a7-4839-bf61-ad50e9dd4882"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partuuid": "51e0bef2-02",
+      "size": "61.95 GiB",
+      "size_bytes": 66517467136,
+      "uuid": "4107fc45-2c8e-4963-baba-d35edc1df8f1"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics",
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "3.99 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.6.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.3"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe9b2e221e9474a503fc1e6f6fb00921678c6d0d",
+        "sha256": "SSHFP 3 2 02926205e3680707a42f5531d0c2b74c973c05898fecc6238fa43d5928c561c8"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtw+GhnOKWacmm2Y4+xAidRU3qhs6kLiylfWF4EYrOMwEIBXBMVa7qNR0Cqe2MchGWDvagCTLEVbtUksggcS1s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1bd0d4a48044f3e0998285fa886e3ebb40b142d3",
+        "sha256": "SSHFP 4 2 a26de78b266687d3910e558280f9803c2fd02f6fa2f7fa4d687c2c05bbb85292"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILKGutww9qvfzB2owYX0lCupf6+AJkllq4uk7QUu+UmD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 2963827fc1bd6a1c26412bebb6e6f131d5d833c0",
+        "sha256": "SSHFP 1 2 f366c94ff526c12e38eace0d30c27688d5ab56d6154e6f4908886c1796e897a5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgO9pBNmEP44UGmygqdwNRDOr7Ed89ACNuOa+BqDKv1xBeWbXhJ0WRJS6cdIcRj3I3u5OGDbIeLcNQ8LM4TVcYTAVhn2mRarxOziRnfthFXwvkjY9pvUQGsfjDHmTrkxXMyx4X8CPiUnr/dfrtOa7byaT6fAG78srmkgyPYZ7NXXKo2HC0bDVlmQfB4NP9JHUzbn/1FOWSRmnwoinlAuFr6cb1xnSwTitkygcXHX1Eye+bWa/YVe0HlW3wO/1qwnIOvwxWMytHq5I1XthAObHsOODEY79hcwzxb4Szz5JjTIsbikwjlszWgn4bZog2crKmjwis4J3wSuPEzc9gv/3aDQ2iK2/s2tz2tCPzMw/E0iXWN+BBfQxlT4eM40+Oo8PazQizvwpFGbFvlWjHnbg9gaNH2dtn62flx2kiXaUwBNOm2nDj/LMiEjO9KWttmV/VQzz+D44+B5GvNq4z2kYwTezWo6yQVEZSg7jFLhmX0mMnPzLabzhmLra5M2VR4+U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 59,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/rocky-8-x86_64.facts
+++ b/facts/4.8/rocky-8-x86_64.facts
@@ -1,0 +1,474 @@
+{
+  "aio_agent_version": "8.8.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6ba94f2f-e5040cee",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "6afb4fb2-17c3-a448-bca9-3c4eb6ff5f0c",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.8.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "163906",
+      "version": "7.0.20"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.8.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.08,
+    "1m": 0.73,
+    "5m": 0.22
+  },
+  "memory": {
+    "swap": {
+      "available": "2.05 GiB",
+      "available_bytes": 2200956928,
+      "capacity": "0.00%",
+      "total": "2.05 GiB",
+      "total_bytes": 2200956928,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.36 GiB",
+      "available_bytes": 1462415360,
+      "capacity": "21.58%",
+      "total": "1.74 GiB",
+      "total_bytes": 1864908800,
+      "used": "383.85 MiB",
+      "used_bytes": 402493440
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "59.91 GiB",
+      "available_bytes": 64325980160,
+      "capacity": "3.25%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "61.92 GiB",
+      "size_bytes": 66484989952,
+      "used": "2.01 GiB",
+      "used_bytes": 2159009792
+    },
+    "/dev": {
+      "available": "872.19 MiB",
+      "available_bytes": 914554880,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=893120k",
+        "nr_inodes=223280",
+        "mode=755"
+      ],
+      "size": "872.19 MiB",
+      "size_bytes": 914554880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "872.84 MiB",
+      "available_bytes": 915234816,
+      "capacity": "1.85%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "16.42 MiB",
+      "used_bytes": 17219584
+    },
+    "/run/user/1000": {
+      "available": "177.85 MiB",
+      "available_bytes": 186490880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=182120k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "177.85 MiB",
+      "size_bytes": 186490880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "513.51 GiB",
+      "available_bytes": 551381864448,
+      "capacity": "43.53%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "909.41 GiB",
+      "size_bytes": 976476184576,
+      "used": "395.90 GiB",
+      "used_bytes": 425094320128
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::402f:79e9:1141:bdb",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::402f:79e9:1141:bdb",
+        "mac": "08:00:27:3a:93:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::402f:79e9:1141:bdb",
+    "mac": "08:00:27:3a:93:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "permissive",
+      "config_policy": "targeted",
+      "current_mode": "permissive",
+      "enabled": true,
+      "enforced": false,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "partuuid": "51e0bef2-01",
+      "size": "2.05 GiB",
+      "size_bytes": 2200961024,
+      "uuid": "75705064-32a7-4839-bf61-ad50e9dd4882"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partuuid": "51e0bef2-02",
+      "size": "61.95 GiB",
+      "size_bytes": 66517467136,
+      "uuid": "4107fc45-2c8e-4963-baba-d35edc1df8f1"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics",
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "3.99 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.8.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.4"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe9b2e221e9474a503fc1e6f6fb00921678c6d0d",
+        "sha256": "SSHFP 3 2 02926205e3680707a42f5531d0c2b74c973c05898fecc6238fa43d5928c561c8"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtw+GhnOKWacmm2Y4+xAidRU3qhs6kLiylfWF4EYrOMwEIBXBMVa7qNR0Cqe2MchGWDvagCTLEVbtUksggcS1s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1bd0d4a48044f3e0998285fa886e3ebb40b142d3",
+        "sha256": "SSHFP 4 2 a26de78b266687d3910e558280f9803c2fd02f6fa2f7fa4d687c2c05bbb85292"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILKGutww9qvfzB2owYX0lCupf6+AJkllq4uk7QUu+UmD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 2963827fc1bd6a1c26412bebb6e6f131d5d833c0",
+        "sha256": "SSHFP 1 2 f366c94ff526c12e38eace0d30c27688d5ab56d6154e6f4908886c1796e897a5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgO9pBNmEP44UGmygqdwNRDOr7Ed89ACNuOa+BqDKv1xBeWbXhJ0WRJS6cdIcRj3I3u5OGDbIeLcNQ8LM4TVcYTAVhn2mRarxOziRnfthFXwvkjY9pvUQGsfjDHmTrkxXMyx4X8CPiUnr/dfrtOa7byaT6fAG78srmkgyPYZ7NXXKo2HC0bDVlmQfB4NP9JHUzbn/1FOWSRmnwoinlAuFr6cb1xnSwTitkygcXHX1Eye+bWa/YVe0HlW3wO/1qwnIOvwxWMytHq5I1XthAObHsOODEY79hcwzxb4Szz5JjTIsbikwjlszWgn4bZog2crKmjwis4J3wSuPEzc9gv/3aDQ2iK2/s2tz2tCPzMw/E0iXWN+BBfQxlT4eM40+Oo8PazQizvwpFGbFvlWjHnbg9gaNH2dtn62flx2kiXaUwBNOm2nDj/LMiEjO9KWttmV/VQzz+D44+B5GvNq4z2kYwTezWo6yQVEZSg7jFLhmX0mMnPzLabzhmLra5M2VR4+U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 52,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/rocky-8-x86_64.facts
+++ b/facts/4.9/rocky-8-x86_64.facts
@@ -1,0 +1,476 @@
+{
+  "aio_agent_version": "8.9.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6ba94f2f-e5040cee",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "6afb4fb2-17c3-a448-bca9-3c4eb6ff5f0c",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.9.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "163906",
+      "version": "7.0.20"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.8.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.07,
+    "1m": 0.69,
+    "5m": 0.2
+  },
+  "memory": {
+    "swap": {
+      "available": "2.05 GiB",
+      "available_bytes": 2200956928,
+      "capacity": "0.00%",
+      "total": "2.05 GiB",
+      "total_bytes": 2200956928,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.37 GiB",
+      "available_bytes": 1476198400,
+      "capacity": "20.84%",
+      "total": "1.74 GiB",
+      "total_bytes": 1864908800,
+      "used": "370.70 MiB",
+      "used_bytes": 388710400
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "59.90 GiB",
+      "available_bytes": 64320491520,
+      "capacity": "3.26%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "61.92 GiB",
+      "size_bytes": 66484989952,
+      "used": "2.02 GiB",
+      "used_bytes": 2164498432
+    },
+    "/dev": {
+      "available": "872.19 MiB",
+      "available_bytes": 914554880,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=893120k",
+        "nr_inodes=223280",
+        "mode=755"
+      ],
+      "size": "872.19 MiB",
+      "size_bytes": 914554880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "872.84 MiB",
+      "available_bytes": 915234816,
+      "capacity": "1.85%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "16.42 MiB",
+      "used_bytes": 17219584
+    },
+    "/run/user/1000": {
+      "available": "177.85 MiB",
+      "available_bytes": 186490880,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=182120k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "177.85 MiB",
+      "size_bytes": 186490880,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "889.26 MiB",
+      "available_bytes": 932454400,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "889.26 MiB",
+      "size_bytes": 932454400,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "513.58 GiB",
+      "available_bytes": 551453630464,
+      "capacity": "43.53%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "909.41 GiB",
+      "size_bytes": 976476184576,
+      "used": "395.83 GiB",
+      "used_bytes": 425022554112
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::402f:79e9:1141:bdb",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fe80::402f:79e9:1141:bdb",
+        "mac": "08:00:27:3a:93:1d",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fe80::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "link",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fe80::402f:79e9:1141:bdb",
+    "mac": "08:00:27:3a:93:1d",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "permissive",
+      "config_policy": "targeted",
+      "current_mode": "permissive",
+      "enabled": true,
+      "enforced": false,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "parttype": "0x82",
+      "partuuid": "51e0bef2-01",
+      "size": "2.05 GiB",
+      "size_bytes": 2200961024,
+      "uuid": "75705064-32a7-4839-bf61-ad50e9dd4882"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "51e0bef2-02",
+      "size": "61.95 GiB",
+      "size_bytes": 66517467136,
+      "uuid": "4107fc45-2c8e-4963-baba-d35edc1df8f1"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics",
+      "AMD Ryzen 9 7940HS w/ Radeon 780M Graphics"
+    ],
+    "physicalcount": 1,
+    "speed": "3.99 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.9.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe9b2e221e9474a503fc1e6f6fb00921678c6d0d",
+        "sha256": "SSHFP 3 2 02926205e3680707a42f5531d0c2b74c973c05898fecc6238fa43d5928c561c8"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNtw+GhnOKWacmm2Y4+xAidRU3qhs6kLiylfWF4EYrOMwEIBXBMVa7qNR0Cqe2MchGWDvagCTLEVbtUksggcS1s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1bd0d4a48044f3e0998285fa886e3ebb40b142d3",
+        "sha256": "SSHFP 4 2 a26de78b266687d3910e558280f9803c2fd02f6fa2f7fa4d687c2c05bbb85292"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAILKGutww9qvfzB2owYX0lCupf6+AJkllq4uk7QUu+UmD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 2963827fc1bd6a1c26412bebb6e6f131d5d833c0",
+        "sha256": "SSHFP 1 2 f366c94ff526c12e38eace0d30c27688d5ab56d6154e6f4908886c1796e897a5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgO9pBNmEP44UGmygqdwNRDOr7Ed89ACNuOa+BqDKv1xBeWbXhJ0WRJS6cdIcRj3I3u5OGDbIeLcNQ8LM4TVcYTAVhn2mRarxOziRnfthFXwvkjY9pvUQGsfjDHmTrkxXMyx4X8CPiUnr/dfrtOa7byaT6fAG78srmkgyPYZ7NXXKo2HC0bDVlmQfB4NP9JHUzbn/1FOWSRmnwoinlAuFr6cb1xnSwTitkygcXHX1Eye+bWa/YVe0HlW3wO/1qwnIOvwxWMytHq5I1XthAObHsOODEY79hcwzxb4Szz5JjTIsbikwjlszWgn4bZog2crKmjwis4J3wSuPEzc9gv/3aDQ2iK2/s2tz2tCPzMw/E0iXWN+BBfQxlT4eM40+Oo8PazQizvwpFGbFvlWjHnbg9gaNH2dtn62flx2kiXaUwBNOm2nDj/LMiEjO9KWttmV/VQzz+D44+B5GvNq4z2kYwTezWo6yQVEZSg7jFLhmX0mMnPzLabzhmLra5M2VR4+U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 43,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/Vagrantfile
+++ b/facts/Vagrantfile
@@ -120,7 +120,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
   end
   config.vm.define 'rockylinux-8-x86_64', autostart: false do |host|
-    host.vm.box = 'rockylinux/8'
+    host.vm.box = 'bento/rockylinux-8'
     host.vm.synced_folder '.', '/vagrant'
     host.vm.provision 'shell', inline: 'dnf -y install wget make gcc net-tools'
     host.vm.provision 'file', source: 'Gemfile', destination: 'Gemfile'


### PR DESCRIPTION
The official Rocky 8 box is 240 days old and boots into a grub shell.