### PR TITLE
add in more facts for various OS releases

### DIFF
--- a/facts/4.10/almalinux-8-x86_64.facts
+++ b/facts/4.10/almalinux-8-x86_64.facts
@@ -1,0 +1,536 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6573693e-8f45705c",
+      "size": "19.53 GiB",
+      "size_bytes": 20971520000,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-b4c9883b-68b2-498c-9786-12f54d5c9c38",
+      "uuid": "3b88c9b4-b268-8c49-9786-12f54d5c9c38",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "vfat,xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.40.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.07,
+    "1m": 0.57,
+    "5m": 0.19
+  },
+  "memory": {
+    "system": {
+      "available": "538.25 MiB",
+      "available_bytes": 564400128,
+      "capacity": "43.03%",
+      "total": "944.76 MiB",
+      "total_bytes": 990654464,
+      "used": "406.51 MiB",
+      "used_bytes": 426254336
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "15.64 GiB",
+      "available_bytes": 16797777920,
+      "capacity": "14.62%",
+      "device": "/dev/sda4",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "18.32 GiB",
+      "size_bytes": 19674431488,
+      "used": "2.68 GiB",
+      "used_bytes": 2876653568
+    },
+    "/boot": {
+      "available": "848.00 MiB",
+      "available_bytes": 889188352,
+      "capacity": "16.37%",
+      "device": "/dev/sda3",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "166.00 MiB",
+      "used_bytes": 174067712
+    },
+    "/boot/efi": {
+      "available": "193.96 MiB",
+      "available_bytes": 203382784,
+      "capacity": "2.92%",
+      "device": "/dev/sda2",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "199.79 MiB",
+      "size_bytes": 209489920,
+      "used": "5.82 MiB",
+      "used_bytes": 6107136
+    },
+    "/dev": {
+      "available": "454.88 MiB",
+      "available_bytes": 476979200,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=465800k",
+        "nr_inodes=116450",
+        "mode=755"
+      ],
+      "size": "454.88 MiB",
+      "size_bytes": 476979200,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "472.38 MiB",
+      "available_bytes": 495325184,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "460.17 MiB",
+      "available_bytes": 482521088,
+      "capacity": "2.58%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "12.21 MiB",
+      "used_bytes": 12804096
+    },
+    "/run/user/1000": {
+      "available": "94.47 MiB",
+      "available_bytes": 99061760,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=96740k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "94.47 MiB",
+      "size_bytes": 99061760,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "472.38 MiB",
+      "available_bytes": 495325184,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "444.30 GiB",
+      "available_bytes": 477066043392,
+      "capacity": "51.49%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "471.51 GiB",
+      "used_bytes": 506279108608
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe4c:bd69",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe4c:bd69",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe4c:bd69",
+        "mac": "08:00:27:4c:bd:69",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe4c:bd69",
+    "mac": "08:00:27:4c:bd:69",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Cerulean Leopard",
+      "description": "AlmaLinux release 8.10 (Cerulean Leopard)",
+      "id": "AlmaLinux",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "AlmaLinux",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "d447a01d-fd27-4060-b558-903180bc94df",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partlabel": "EFI System Partition",
+      "parttype": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+      "partuuid": "cb398502-99ea-48ee-9b97-0ef7cc955981",
+      "size": "200.00 MiB",
+      "size_bytes": 209715200,
+      "uuid": "42D7-2C8F"
+    },
+    "/dev/sda3": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "68b329d8-8cdc-4059-b142-78354bf6fb45",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "93a3ebfa-5b5c-4fc1-887c-cec86f8de495"
+    },
+    "/dev/sda4": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partlabel": "root",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "6e0c34de-799c-4f0a-bb64-002dcc251a89",
+      "size": "18.33 GiB",
+      "size_bytes": 19684917248,
+      "uuid": "cd821234-5064-4367-8918-c7737d2bfce6"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 aa1b7cb8bcd545d623f0a8751ccdc4ba1837305b",
+        "sha256": "SSHFP 3 2 979416c45abe65423b14bb9c414be1784d5edb330c7ebff9302eae92af4bb86d"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAiVAy15gyXZU4ojJsgd0+q6sFpHFPyHLhp0t2kOPcJIJt+vKG3S1p0dQ3gHSMXn7AlbFNVAi9Trge9Wbo8kkL0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1d0a392c4941f6174e78b9d0344dc9be1ad5db33",
+        "sha256": "SSHFP 4 2 6a2f938d9b4e2f0a62b92ccd6528af91539cf6dd99545d937cf5de2ee2678192"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIH6xJcQuuHq7wQeqUhVlh1G5V9g6bSe43rhvSHV7X9/N",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 e165ebeb97c2478fd4df75ee02c5b6de148662af",
+        "sha256": "SSHFP 1 2 3770276e6014cf52c9d5af68b938ee3311d77a8fa2fc272c6605956d9346a34e"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC3qpLNCJUckHQen/jgc7JjN8RHFmeRXXTJ/Y85+FtsIxSSrxDoFOvdes5ZrfaSVZV3vBmmTJmlLybpNLAJhp49ttvK25uhnemFQ1sFU/Y4xCDBLTp+YjUpCOK8pKRay5WdUg/WNoJqM9zm0KJcNISSKrTexab0mEjijKXoRVTysN7wjIh92Uz8Y6oZAmECGeBgqP/9LacdHrceZ2WYnOpQTZ+g45Yvn7Xl6luwUQ6vzsDAaqJXRLla9pbPjwzV3zTmQUibJ2eCqLjjApINFiHidYnpQmEGcNkG0vdxP21Yf8tMV9RiOELH0+VkgDlYew0LM7sCC6ziA2nwq0IUg8dAcwfKAqY2S7O9cSQnVx39bA6pcnAtvbTzgPeOUsDflhqRyGDjCCG6P0/mPrZW/R6xzcr0b1Ad4yH6wXuzvkuhTpxAQ//8QfXvHgPQ0ExRnuGZ0HyInl28DlfqlLyRRgftnCEWDUTNdhKC5nrPVKEwT+wM3ohxdOzA+Uk7D0MRKvk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 79,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/almalinux-9-x86_64.facts
+++ b/facts/4.10/almalinux-9-x86_64.facts
@@ -1,0 +1,587 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB8c723371-d3d312b7",
+      "size": "19.53 GiB",
+      "size_bytes": 20971520000,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-4436fef1-90e5-45d4-87ee-11f028bac655",
+      "uuid": "f1fe3644-e590-d445-87ee-11f028bac655",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "vfat,xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.0-503.15.1.el9_5.x86_64",
+  "kernelversion": "5.14.0",
+  "load_averages": {
+    "15m": 0.09,
+    "1m": 0.74,
+    "5m": 0.25
+  },
+  "memory": {
+    "system": {
+      "available": "487.23 MiB",
+      "available_bytes": 510894080,
+      "capacity": "48.29%",
+      "total": "942.20 MiB",
+      "total_bytes": 987963392,
+      "used": "454.97 MiB",
+      "used_bytes": 477069312
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "16.70 GiB",
+      "available_bytes": 17927528448,
+      "capacity": "8.62%",
+      "device": "/dev/sda4",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "18.27 GiB",
+      "size_bytes": 19617808384,
+      "used": "1.57 GiB",
+      "used_bytes": 1690279936
+    },
+    "/boot": {
+      "available": "828.63 MiB",
+      "available_bytes": 868884480,
+      "capacity": "13.68%",
+      "device": "/dev/sda3",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "960.00 MiB",
+      "size_bytes": 1006632960,
+      "used": "131.37 MiB",
+      "used_bytes": 137748480
+    },
+    "/boot/efi": {
+      "available": "192.72 MiB",
+      "available_bytes": 202080256,
+      "capacity": "3.53%",
+      "device": "/dev/sda2",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "199.77 MiB",
+      "size_bytes": 209469440,
+      "used": "7.05 MiB",
+      "used_bytes": 7389184
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=111472",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "471.10 MiB",
+      "available_bytes": 493981696,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "471.10 MiB",
+      "size_bytes": 493981696,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "183.25 MiB",
+      "available_bytes": 192151552,
+      "capacity": "2.75%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=192964k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "188.44 MiB",
+      "size_bytes": 197595136,
+      "used": "5.19 MiB",
+      "used_bytes": 5443584
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "94.22 MiB",
+      "available_bytes": 98795520,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=96480k",
+        "nr_inodes=24120",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "94.22 MiB",
+      "size_bytes": 98795520,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "442.76 GiB",
+      "available_bytes": 475405709312,
+      "capacity": "51.65%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "473.06 GiB",
+      "used_bytes": 507939442688
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "rpc_pipefs",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe0d:f5f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe0d:f5f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe0d:f5f0",
+        "mac": "08:00:27:0d:f5:f0",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe0d:f5f0",
+    "mac": "08:00:27:0d:f5:f0",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Teal Serval",
+      "description": "AlmaLinux release 9.5 (Teal Serval)",
+      "id": "AlmaLinux",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "AlmaLinux",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "f090b7d8-33ad-470f-99f5-66bab2c7aa3c",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partlabel": "EFI System Partition",
+      "parttype": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+      "partuuid": "10aad5af-650e-4f3b-b67f-1d68588a7f3d",
+      "size": "200.00 MiB",
+      "size_bytes": 209715200,
+      "uuid": "DB29-5C75"
+    },
+    "/dev/sda3": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "25f59295-3706-48f7-a20a-20e427e06042",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "484a1e16-48e4-4829-a591-5d142d579d40"
+    },
+    "/dev/sda4": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partlabel": "root",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "57ef363f-97ff-4af6-a6e0-2d289ff6e201",
+      "size": "18.33 GiB",
+      "size_bytes": 19684917248,
+      "uuid": "5ac5d360-5d04-423c-9e98-5ee8f11d2066"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 a6295720bb1612d8ba76b934c0b6aad33543550b",
+        "sha256": "SSHFP 3 2 c424e31194af8397864a9857224b67d387dec60c00d73f782a3c1377a1cef5aa"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKVY6h3Z9ZDmiXcuGeu9OqoFaOWRmh7riO9CSJtgUsSjGOjDlwL+Af0xFt0ms7sz0bJjN7BLuilHkyrrzx8qO2s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 96a6ea33a34a01a75685e6291490cb3f51fa0e24",
+        "sha256": "SSHFP 4 2 04a8a42220396546bb7ae74c2fc50667bc5b3352ecbfd764e17e75f357f5f2c9"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIGic1d2OxpSE0YvLhuDkqjw/IsO3vxlL/O7KZu56zjdv",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 d34e4f88ee3bf7f3bd9bc4fc67880788bc47ff13",
+        "sha256": "SSHFP 1 2 95134a9ba53b706a447ed4632e6c1ec17ef6f37c76c25503c1ba05529e7e9092"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCh41NXSvYhqI24pAc/cxwUCRsuoxJVUNiUI2zELaO98a7CV5bZjLljhBb3KMXXyKF12NT55CtnfkLk6Ue3HO1aXxG50T6axWdP4ripJmuKzxnAuESEE3bebtHK8sd7usZL4mcO6VtzBIU8Nn+z1fiH53KTwXvhwuWhGT/4SxJl5OuMO40fuBKbb7ma+mgezOlYsAmKtquH5BAZW4SwRa3A4MDVfj0+isziRtEGBoXOjO4WaH6yrok42kE8XoHBCtKLq0xNsNBk2CkKa9IHx4cdtGe9OROgQjRE+sgY6VyNRsWboY06010w7CHq8mgr9vLGf9HAwtsiabdBTnq9RMV4GDs/fzehnbqkWacADqUp52/suzpbGBk6mzFqJoSjZosT3oOOT2ozpWomF/QhgvD0FCYB5EXcuoj2rT8IFStonqAKmTWhep1jAd20YbJ5umcAVTx0uF15BqB9YHpyvW8yjfxG6FTx5JS60uhx4NA1wF3RK4vYxFxfxu6m60up8OU=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 67,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/amazon-2-x86_64.facts
+++ b/facts/4.10/amazon-2-x86_64.facts
@@ -1,0 +1,265 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.34,
+    "5m": 0.64
+  },
+  "memory": {
+    "system": {
+      "available": "1.63 GiB",
+      "available_bytes": 1750728704,
+      "capacity": "15.68%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "310.55 MiB",
+      "used_bytes": 325636096
+    }
+  },
+  "mountpoints": {},
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 94,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/opensuse-15-x86_64.facts
+++ b/facts/4.10/opensuse-15-x86_64.facts
@@ -1,0 +1,482 @@
+{
+  "aio_agent_version": "8.10.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f82cad1-18aa0ba4",
+      "size": "42.00 GiB",
+      "size_bytes": 45097156608,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-e4d260f7-2d9d-44ab-a42b-5c083e9fcbc1",
+      "uuid": "f760d2e4-9d2d-ab44-a42b-5c083e9fcbc1",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "ext2,ext3,ext4",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.21-150400.24.60-default",
+  "kernelversion": "5.14.21",
+  "load_averages": {
+    "15m": 0.08,
+    "1m": 0.69,
+    "5m": 0.22
+  },
+  "memory": {
+    "system": {
+      "available": "688.60 MiB",
+      "available_bytes": 722051072,
+      "capacity": "28.47%",
+      "total": "962.70 MiB",
+      "total_bytes": 1009463296,
+      "used": "274.10 MiB",
+      "used_bytes": 287412224
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "37.49 GiB",
+      "available_bytes": 40256274432,
+      "capacity": "3.69%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "41.04 GiB",
+      "size_bytes": 44069601280,
+      "used": "1.44 GiB",
+      "used_bytes": 1541746688
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=1048576",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "481.34 MiB",
+      "available_bytes": 504725504,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "481.35 MiB",
+      "size_bytes": 504729600,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/run": {
+      "available": "187.14 MiB",
+      "available_bytes": 196227072,
+      "capacity": "2.81%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "size=197164k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "192.54 MiB",
+      "size_bytes": 201895936,
+      "used": "5.41 MiB",
+      "used_bytes": 5668864
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.27 MiB",
+      "available_bytes": 100941824,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98580k",
+        "nr_inodes=24645",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "96.27 MiB",
+      "size_bytes": 100945920,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/sys/fs/cgroup": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "size=4096k",
+        "nr_inodes=1024",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "431.95 GiB",
+      "available_bytes": 463798005760,
+      "capacity": "52.83%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "483.87 GiB",
+      "used_bytes": 519547146240
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::bf30:22dc:342a:4dc9",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+              "temporary"
+            ]
+          },
+          {
+            "address": "fd00::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::bf30:22dc:342a:4dc9",
+        "mac": "08:00:27:7a:a2:d7",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::bf30:22dc:342a:4dc9",
+    "mac": "08:00:27:7a:a2:d7",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "openSUSE Leap 15.4",
+      "id": "SUSE",
+      "release": {
+        "full": "15.4",
+        "major": "15",
+        "minor": "4"
+      }
+    },
+    "family": "Suse",
+    "hardware": "x86_64",
+    "name": "openSUSE",
+    "release": {
+      "full": "15.4",
+      "major": "15",
+      "minor": "4"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "ROOT",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "f42329f8-01",
+      "size": "42.00 GiB",
+      "size_bytes": 45096108032,
+      "uuid": "30832e7a-e906-43bc-b445-247b91cb9e0e"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.10.0",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 fa6a59446c44186ae52f2c6434cdadc13cc4d87b",
+        "sha256": "SSHFP 2 2 3581fde41bb78a886f78215ff2612c4fa630edc2b8247294ec84bfd3badd08af"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAOHqZjSkv/ufdFSSvgGFrycROq8oII65NjjTPI9v6e3sTCL34bugS6zUmlELg3HHgTVb826UdXOg6VuoId+cPCtYBbKw7Dqecfd6+AQRQVAXbPSx13+lwBdiY9/lxZQbQVFJzs7N+shor+Vkmz3T7gEOYvVlSqV8ZOw+qK0sk5LBAAAAFQDvWtZVlWOanpnpmRAsxLHLcTVxhwAAAIA6uJGdcsgrTq42MQi4DH1mAtdYxTQwI1OM30+TG77EqkL3uqVAJufIIgYT3Q2PuV3qNgGatjIP7kVpnhZm6hRHCqPNucIy6tULaSa4nufeIxFW95OIwDZEzKJVNLFr/7KeeBPuw9DLKPxjSIteVtgpUqDYivQKwhs1Xl6SQ9xYvwAAAIEArZ58uV8Cj4CbRi/Fe5JiZxEU7GWZRui9n7k8pCBVoV4gJ1OLDEGXYusbEu9QWYjRi7F9N91Sjzw09k8cDtpXrZ/F623NWVxnxIZ9k59kMhZD3BlBrbXv/5YUlnPH/+7EwcmP2h06FxEK4Zg48GATzsXuURDZ/1OpN/MLHSKtyJ8=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 3fdc4c6af3cf9605bc8399011fe6783ceac3d8ab",
+        "sha256": "SSHFP 3 2 b63d5f583bf1cabbb281b3a696771b2516f22e633356557de566e5d7e05d00a0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCoB6SFbcfcROGXvuhUrCfJnr0Zr1aU92M7tXzXdhqXmAT/UjGPww1m/g2aoqoAMJANa18+pTIq/gW2Q80YDhG0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 5d7825e0feca470bbebc2677b6f911ca0dcbcb29",
+        "sha256": "SSHFP 4 2 1546726e2154cbe24fd9fa23e1cb7fca585769dc788be8c8bd502af9b6a504fa"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFyXCK7NNLRKf5eGIVtiyDpXx7DHpLJ0/XoUk0WFzF59",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a5fb27b70d27f80bc556297d0537e724bbf56063",
+        "sha256": "SSHFP 1 2 e090c7f5e1850844186c6b6903fa9095a3821d9085456ec2e14a4fc37247b4aa"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBpOtNRerOup8tDFot/DPmMQ51h7SK/Py5y1Z2KwZNVrF0cEX+D/T0Kg65w3PxfGITxsaU2ohfXiFOZSwOeZ5iEXOawRm5ndR+6fDjsrqsj8HKmq6nExP2Prun1ea4ujyhsQgrVL0mf8G9e6KfySuMehsjhTO4xrZYjBxdmhegfVGNyQ+/87w0pPlf943/khkygLEErdRpju31dZkZNoSTKIdYh+3SvxMkDEd93BTWUuWbBymCP8OpInqwomeJgAhOqzn/KrUwthbspLZs/Uzd2v2hHM/xFSyhSHvgpIdY2dQZBDkGUbzmK5dk1k0SCfJ+/GrooeJyPhjP25sl0wJFvtKT6R29ZxPRDO85Gs9r5sbOz+LOzX95QqNJvtzEDchgiVZ+ihoJ8ikrHdZemoJ0PgNjYFKKp+5AosZ2vtbH4MrEoGt9bpBw+iTjMiytpWFfuxMn81SsqVJ+mCdgWfMyQC1OWUuygxCYomtXlQEWq/uXRM+k6UzU+a7kDcJm0M8=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 126,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/oraclelinux-8-x86_64.facts
+++ b/facts/4.10/oraclelinux-8-x86_64.facts
@@ -1,0 +1,518 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBa19b630e-9f5ed789",
+      "size": "37.00 GiB",
+      "size_bytes": 39728447488,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "2935e453-ceb1-8046-b60c-d499559b887b",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "xfs,zonefs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.15",
+  "kernelrelease": "5.15.0-306.177.4.el8uek.x86_64",
+  "kernelversion": "5.15.0",
+  "load_averages": {
+    "15m": 0.12,
+    "1m": 0.82,
+    "5m": 0.32
+  },
+  "memory": {
+    "swap": {
+      "available": "4.00 GiB",
+      "available_bytes": 4294688768,
+      "capacity": "0.01%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
+      "used": "268.00 KiB",
+      "used_bytes": 274432
+    },
+    "system": {
+      "available": "1.48 GiB",
+      "available_bytes": 1585610752,
+      "capacity": "22.83%",
+      "total": "1.91 GiB",
+      "total_bytes": 2054807552,
+      "used": "447.46 MiB",
+      "used_bytes": 469196800
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "28.96 GiB",
+      "available_bytes": 31099224064,
+      "capacity": "9.43%",
+      "device": "/dev/mapper/vg_main-lv_root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "31.98 GiB",
+      "size_bytes": 34338770944,
+      "used": "3.02 GiB",
+      "used_bytes": 3239546880
+    },
+    "/boot": {
+      "available": "905.06 MiB",
+      "available_bytes": 949022720,
+      "capacity": "10.74%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "108.94 MiB",
+      "used_bytes": 114233344
+    },
+    "/dev": {
+      "available": "953.50 MiB",
+      "available_bytes": 999817216,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=976384k",
+        "nr_inodes=244096",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "953.50 MiB",
+      "size_bytes": 999817216,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "979.81 MiB",
+      "available_bytes": 1027403776,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "963.43 MiB",
+      "available_bytes": 1010225152,
+      "capacity": "1.67%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "16.38 MiB",
+      "used_bytes": 17178624
+    },
+    "/run/user/1000": {
+      "available": "195.96 MiB",
+      "available_bytes": 205479936,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200664k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.96 MiB",
+      "size_bytes": 205479936,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "979.81 MiB",
+      "available_bytes": 1027403776,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "436.47 GiB",
+      "available_bytes": 468651667456,
+      "capacity": "52.34%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "479.35 GiB",
+      "used_bytes": 514693484544
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe1a:91c3",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe1a:91c3",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "unknown",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe1a:91c3",
+        "mac": "08:00:27:1a:91:c3",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": -1
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe1a:91c3",
+    "mac": "08:00:27:1a:91:c3",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Ootpa",
+      "description": "Oracle Linux Server 8.10",
+      "id": "Ol",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "OracleLinux",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/mapper/vg_main-lv_root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "32.00 GiB",
+      "size_bytes": 34355544064,
+      "uuid": "743cd91f-42be-4736-90b0-8fdbc787e29a"
+    },
+    "/dev/mapper/vg_main-lv_swap": {
+      "filesystem": "swap",
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "b13e269a-0864-4ee3-a81a-57267fb3d4b8"
+    },
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "b24fbe38-5545-4de6-a9a3-5b2c45bb8307",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "label": "boot",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "6c0bad4c-381a-4e5d-bc17-cd79753b4932",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "e3843ecc-d8e5-43b1-b8c6-68563e013be1"
+    },
+    "/dev/sda3": {
+      "filesystem": "LVM2_member",
+      "partlabel": "pv_vol",
+      "parttype": "e6d6d379-f507-44c2-a23c-238f2a3df928",
+      "partuuid": "6e313cbf-21ac-4940-9880-7bc478ddc96a",
+      "size": "36.00 GiB",
+      "size_bytes": 38651559936,
+      "uuid": "lAIrDO-gXKH-hMIH-lboJ-wwG0-74bF-45NhOs"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/share/Modules/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 f88076c2c9793d716752f07fc416e3c3f1f498eb",
+        "sha256": "SSHFP 3 2 544f49dc10e04418c7cd02527fb2974124dccf02af7ad81969492f0069580691"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCKfLK+TIoFwmM9P3ZyX7BwfQUqwbave2PT0qQjnmP/RwlgTgGhR2o1XwilSkVaDar9bQZdgZ9eHPNEG2ovOQUQ=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 7976c0b587dc5d2d3ec08f1a524338b9db630fa6",
+        "sha256": "SSHFP 4 2 12cfe4a3f4af09f9aeee5b07c9c0ba37ec7c724a6668649db3cba4ba0b9b8a05"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIMpMLkpHaltPuEJkoaZjg0QPbfaQuQwY/yQzswTCm0ZE",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 c3345971a21053ab61c04fc9b5ac543ea97ad564",
+        "sha256": "SSHFP 1 2 1a6b0b163bba1c263997407591dbdbb10fef6ccefabf0f5cd1a538b221f5fe36"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCtxarbsM0it7peRap9cWagiuOT+vtCNNxd8yff4p4t7YRo3Lj2n2XLvzNndHEL6wZD4hUVK8a13tDg+TJL9fLNCwZMJb8ZFe1WoqAkJkGDgL6OgbYnuX6iEk4fYJqKDTQtDFwKtorR1w2cLcPvbQrG4INJqtAdOFBji2sSf1/NYR8hSXkl33imp6F/6GaKmbUJwCgnXh4T4xq3XxL6PU56tr9+jGP9Y3Cj+dvWZi/ap4yht5iq23m7BcV+KivsFsmkfdh8qiwPizo9RXQC1eRO5KZ96lvXgy+x8cf5XJvNmbrD9J0EBe8SGLo7T3L29F4rTxvsEvSXmZyBB2s6v3XKLkGx+09jvvrgyeVcl07a5DH/r/Xz7LX2aQSrgX6/XfqZnXH51jUB5TCcIP+06JMQOdH1fkqLS5t1YRvrzfuvVQa9gQ3c3Qsn9Dkh+6i4rdCFBS7MGVA8WROG6gdaOgGV0cBD4eUFsYgSLQicJy+v8G3RSGLq/YWSuozJat+PhTM=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 138,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/oraclelinux-9-x86_64.facts
+++ b/facts/4.10/oraclelinux-9-x86_64.facts
@@ -1,0 +1,584 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB9a95c0bd-62acdbd7",
+      "size": "37.00 GiB",
+      "size_bytes": 39728447488,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "3e6a95c2-c3da-4a4d-9c54-1fd89c81760a",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "btrfs,xfs,zonefs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.15",
+  "kernelrelease": "5.15.0-306.177.4.el9uek.x86_64",
+  "kernelversion": "5.15.0",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.83,
+    "5m": 0.29
+  },
+  "memory": {
+    "swap": {
+      "available": "4.00 GiB",
+      "available_bytes": 4294688768,
+      "capacity": "0.01%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
+      "used": "268.00 KiB",
+      "used_bytes": 274432
+    },
+    "system": {
+      "available": "1.45 GiB",
+      "available_bytes": 1559838720,
+      "capacity": "24.09%",
+      "total": "1.91 GiB",
+      "total_bytes": 2054746112,
+      "used": "471.98 MiB",
+      "used_bytes": 494907392
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "29.06 GiB",
+      "available_bytes": 31207796736,
+      "capacity": "8.98%",
+      "device": "/dev/mapper/vg_main-lv_root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "31.93 GiB",
+      "size_bytes": 34288435200,
+      "used": "2.87 GiB",
+      "used_bytes": 3080638464
+    },
+    "/boot": {
+      "available": "846.03 MiB",
+      "available_bytes": 887123968,
+      "capacity": "11.87%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "960.00 MiB",
+      "size_bytes": 1006632960,
+      "used": "113.97 MiB",
+      "used_bytes": 119508992
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=243989",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "979.78 MiB",
+      "available_bytes": 1027371008,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "979.78 MiB",
+      "size_bytes": 1027371008,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "381.67 MiB",
+      "available_bytes": 400211968,
+      "capacity": "2.61%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=401320k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "391.91 MiB",
+      "size_bytes": 410951680,
+      "used": "10.24 MiB",
+      "used_bytes": 10739712
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "195.95 MiB",
+      "available_bytes": 205471744,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200656k",
+        "nr_inodes=50164",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.95 MiB",
+      "size_bytes": 205471744,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "433.55 GiB",
+      "available_bytes": 465516875776,
+      "capacity": "52.66%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "482.27 GiB",
+      "used_bytes": 517828276224
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe5b:5722",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe5b:5722",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "unknown",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe5b:5722",
+        "mac": "08:00:27:5b:57:22",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": -1
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe5b:5722",
+    "mac": "08:00:27:5b:57:22",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Plow",
+      "description": "Oracle Linux Server 9.5",
+      "id": "Ol",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "OracleLinux",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/mapper/vg_main-lv_root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "32.00 GiB",
+      "size_bytes": 34355544064,
+      "uuid": "aa59a49a-2c06-4537-8b43-7f0dbed70f2c"
+    },
+    "/dev/mapper/vg_main-lv_swap": {
+      "filesystem": "swap",
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "7aa4b888-9f17-4fa5-8f2b-a30534dbe656"
+    },
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "9be28db9-8c4f-4834-b761-0e7228c0797d",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "label": "boot",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "02cc627a-03d6-4883-a7a7-fad2e5cbf070",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "924af72d-980c-4e99-8745-6cf81e074b40"
+    },
+    "/dev/sda3": {
+      "filesystem": "LVM2_member",
+      "partlabel": "pv_vol",
+      "parttype": "e6d6d379-f507-44c2-a23c-238f2a3df928",
+      "partuuid": "7f949a84-9c33-453b-89d8-8f9438e01cde",
+      "size": "36.00 GiB",
+      "size_bytes": 38651559936,
+      "uuid": "f7PMoa-ewjJ-G3b4-Js0S-hvMw-AIrp-qbX9zg"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe6b06fbe99df0c5492ef8a161ea4efd3c564c3e",
+        "sha256": "SSHFP 3 2 8262b08e300039f58efa379bfef889f6c0a5b41ec7b1467ad5a4b02047eed8d9"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHB2UFx6aOpe5BNsXpvPxX6eFWDTMyFiwt9Tl7fb54T9ySuaWZuJjdX3Ns3Gtl8/F9onyLM7WUdXhIm4t6CC/vg=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 7bab3b1d773863e32b2d1821881aef1f0e5df741",
+        "sha256": "SSHFP 4 2 e55a5186473dc680340281d4d5f10ba528807c66a95476fb77f0cc8728696dca"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIBBVQcOaMH2ZouwzUiVeuFZK1NY7niOa2Ez1UzJtJHB+",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a77c50ec565850aa51cc4de7bd070eff7dad2366",
+        "sha256": "SSHFP 1 2 8dbbe1d5b715a986fd0c9e2ff0c89058069d6ea64aa7053c90e1444cafe27603"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCT9DGrr7nJWzRkHn4JKenmKHslNC9QtCKrp4zvjt/sLqe10hA+zPnKZ3KfX7YUvO/yZkKaHLgjM18IGxGbUlRB9x1E1gsQeNZXXj2vkkR21n3w3R6WC7lS+7x3FMHIUvQhe6HfBxYFLDLWQZLV1g6lNbGTmrWC/06QNAZQ7xgi1PklBYF+zdLD+2p7g+7KO6sxgTk6AixeRqj8ZMipJLa+c8m9T4p4Ppi7PB6dBkClu4WfvNykZlhuLIOXxAR0SYM72AxtYYIT58KpQMNiJub1ZHzfv0s5WtjsWQK8D4LQRDgOW77SNU+QhWjfsN8waCTz/IlosGQF29AbGSTsHJ8ck9yhiv7piW4aUSx+xBWvL2NY9YJJhHJNWDE6B5UjcU6l8j5nbXORpODLgckrDqwoyGsPCavZp6/uPFY4XaP42nlTYHKMklcL9o1bcuIRszzLEjuhtqqzdV0yErIdBZwoMHyTaf2rRtdAxR7j/4Hxtaq6afHAxp8U432HjVxxUzM=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 114,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/rocky-8-x86_64.facts
+++ b/facts/4.10/rocky-8-x86_64.facts
@@ -1,0 +1,486 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB85e912fb-08fe30ec",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-bcbba733-498f-464e-ab3e-022c51f57386",
+      "uuid": "33a7bbbc-8f49-4e46-ab3e-022c51f57386",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    },
+    "vmware": {}
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.40.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.88,
+    "5m": 0.28
+  },
+  "memory": {
+    "swap": {
+      "available": "3.03 GiB",
+      "available_bytes": 3257921536,
+      "capacity": "0.00%",
+      "total": "3.03 GiB",
+      "total_bytes": 3257921536,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "2.29 GiB",
+      "available_bytes": 2453766144,
+      "capacity": "16.02%",
+      "total": "2.72 GiB",
+      "total_bytes": 2921865216,
+      "used": "446.41 MiB",
+      "used_bytes": 468099072
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "58.48 GiB",
+      "available_bytes": 62789517312,
+      "capacity": "4.03%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "60.94 GiB",
+      "size_bytes": 65428541440,
+      "used": "2.46 GiB",
+      "used_bytes": 2639024128
+    },
+    "/dev": {
+      "available": "1.34 GiB",
+      "available_bytes": 1442488320,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=1408680k",
+        "nr_inodes=352170",
+        "mode=755"
+      ],
+      "size": "1.34 GiB",
+      "size_bytes": 1442488320,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.36 GiB",
+      "available_bytes": 1460932608,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "1.34 GiB",
+      "available_bytes": 1443676160,
+      "capacity": "1.18%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "16.46 MiB",
+      "used_bytes": 17256448
+    },
+    "/run/user/1000": {
+      "available": "278.65 MiB",
+      "available_bytes": 292184064,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=285336k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "278.65 MiB",
+      "size_bytes": 292184064,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "1.36 GiB",
+      "available_bytes": 1460932608,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "440.69 GiB",
+      "available_bytes": 473187713024,
+      "capacity": "51.88%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "475.12 GiB",
+      "used_bytes": 510157438976
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::41b9:8323:28ee:f121",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::d092:a218:931:ae47",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::41b9:8323:28ee:f121",
+        "mac": "08:00:27:e1:cc:39",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::41b9:8323:28ee:f121",
+    "mac": "08:00:27:e1:cc:39",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      },
+      "specification": ":core-4.1-amd64:core-4.1-noarch"
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "parttype": "0x82",
+      "partuuid": "c3e94172-01",
+      "size": "3.03 GiB",
+      "size_bytes": 3257925632,
+      "uuid": "a36b3fd2-b4df-487f-936c-2aff084aa835"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "c3e94172-02",
+      "size": "60.96 GiB",
+      "size_bytes": 65460502528,
+      "uuid": "70b09872-e9e2-476e-88e7-8401f91cdd76"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 b6a599d170cc4b5fa7e17ef1273354f56f835aaf",
+        "sha256": "SSHFP 3 2 b63783e3f0a6607cfda4718f5175ed72e84bfc00bce1e769d49d06fd348eb000"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGz05DfkxUiynBY2YzUNx5BZD10OI7nyDG6qdbx0ReMy3M3FOpbY2t2kDvEtOeuwCiaFfGCbu+2YEJ6kNjvBqO4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1b9dd60073706d9cbd17bf4ec5f38d80e3c814b8",
+        "sha256": "SSHFP 4 2 cfd87a6db56f03b28873aeb2c1f689972f45f40a5e99df234afd2b695c5a1bcd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAID0DTSb3cZGZTibqz+m7NvkDtm/0rQrgiw3hu7GuY6Mi",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 44a2c8d780a6796e86007a775779c1ad603f93a1",
+        "sha256": "SSHFP 1 2 e045246458de5004326f3f06c83246df0e7557a03791d65bd59812e1d7929652"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC3rfBr6m33AbRzjexFfZ/WLWTfdF3oHi0VkO0uDGDPvtW9Yr5ind0RW5XfiZYOajha+TAIoXMR1M3D0Rj5iAh6Z50ntw/ORvJfNZIrRg3ik2Xr0t2H8Tm890Ji62EcC7JhcNxNtBlPl7P/QnVVMJUIjtMm5MxhNCEa/AnjZOmUlutL+YCaBuKj24xdv+e/WO1X+z3T2VVGyCXiupMKxMG6iepHHLCHsIOoC5MeCtklj5MefQuGWap53ib2fhnIev/TipwOS5g+vc10PHaSW9JX8VtkPH4p4LWeCe/z0CmDA0ZQAYPVNXr8hQNnPeGm5MTh+mhR2yx1vTZ+wGhORNJJdvFgKMRHfzZPHZe3RefTv8nwkX3MRpmI2kiBmIrDu7bP3GhYrcwuVTQuvVj1pdXqlzLKvuisZxhtgCHb863Xa2vUuHwwIz+8KEdaD0Z+vJsSTeSAe1wq+idqKeGJe5LJUbkJ/uqjPpJdk1+cJh232zhshiOK/iAK1Klyy/V5FI0=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 70,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/rocky-9-x86_64.facts
+++ b/facts/4.10/rocky-9-x86_64.facts
@@ -1,0 +1,536 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f316a1f-a7d7495d",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-6cb0b832-92cd-4c94-9535-b2d99b8ccf8b",
+      "uuid": "32b8b06c-cd92-944c-9535-b2d99b8ccf8b",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.10.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.10.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    },
+    "vmware": {}
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.0-503.23.2.el9_5.x86_64",
+  "kernelversion": "5.14.0",
+  "load_averages": {
+    "15m": 0.08,
+    "1m": 0.71,
+    "5m": 0.23
+  },
+  "memory": {
+    "swap": {
+      "available": "3.03 GiB",
+      "available_bytes": 3250581504,
+      "capacity": "0.00%",
+      "total": "3.03 GiB",
+      "total_bytes": 3250581504,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "2.39 GiB",
+      "available_bytes": 2562920448,
+      "capacity": "17.74%",
+      "total": "2.90 GiB",
+      "total_bytes": 3115765760,
+      "used": "527.23 MiB",
+      "used_bytes": 552845312
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "58.71 GiB",
+      "available_bytes": 63043977216,
+      "capacity": "3.60%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "60.91 GiB",
+      "size_bytes": 65400733696,
+      "used": "2.19 GiB",
+      "used_bytes": 2356756480
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=375370",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.45 GiB",
+      "available_bytes": 1557880832,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "1.45 GiB",
+      "size_bytes": 1557880832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "578.91 MiB",
+      "available_bytes": 607031296,
+      "capacity": "2.59%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=608548k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "594.29 MiB",
+      "size_bytes": 623153152,
+      "used": "15.38 MiB",
+      "used_bytes": 16121856
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "297.14 MiB",
+      "available_bytes": 311574528,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=304272k",
+        "nr_inodes=76068",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "297.14 MiB",
+      "size_bytes": 311574528,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "491.32 GiB",
+      "available_bytes": 527546855424,
+      "capacity": "46.35%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "424.50 GiB",
+      "used_bytes": 455798296576
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::f96c:63fe:9157:c223",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::3b85:4077:3446:7f6c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::f96c:63fe:9157:c223",
+        "mac": "08:00:27:4c:24:90",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::f96c:63fe:9157:c223",
+    "mac": "08:00:27:4c:24:90",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Blue Onyx",
+      "description": "Rocky Linux release 9.5 (Blue Onyx)",
+      "id": "Rocky",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "parttype": "0x82",
+      "partuuid": "47579c88-01",
+      "size": "3.03 GiB",
+      "size_bytes": 3250585600,
+      "uuid": "1e67ec0a-b68a-40b7-85c7-191269487594"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "47579c88-02",
+      "size": "60.97 GiB",
+      "size_bytes": 65467842560,
+      "uuid": "691f2ba0-0c77-4cb6-b23e-befc58d6c122"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 f2a5cc138a59f25b73279acf484ddd7550c94208",
+        "sha256": "SSHFP 3 2 7c8692ee714c8d72f62d7a94f56a3fe141a9a7ef24bd1499660d2a35d9a6b00e"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJBS9lxu/IKxomxOsRi8t+WSFRCyGUTdTdExNlzjhsZtUgXLA11uRE5K6SVlX0aO4GClxCOEO2cdMDapUsVtokE=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 d4ce3dc7eb8058f79a47f681b4f39c1089abc699",
+        "sha256": "SSHFP 4 2 adc877c56b50930f2b2eecfadc0c4a0a11ef683f706bc55e9147ccdaf8ef45f0"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIN2WV2mlRuD01kw5t2oJgKgYQuoVhA1DDDoi7G3aVfnD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 0e730825efb37f98713f42bed86b90b6b755906f",
+        "sha256": "SSHFP 1 2 2f754f21adb5d7f22d1151e93581aca138336d27abcfbc463466b380bbdba2a7"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDhaQLdfr7HTyoxICuw0kkeQbZjJJuZVY0oYS/epFD5+E+0y86e63GzEDwFuTzI5YZuIyHPqZdceOzSWDZrQYhX0nGR9lJMh+6eKzWSHvFSnZOQUpMF33NVPnx2ZFxRnUD66mF3qz7kTQJTsACJhGe516ox6WPKyIe+k57J3lYomFHy23v61wx9DPeLKRKK+qvbeEnYwQFFx+viNTe8YRFYSOwFuspW5Clt0Pq1/4nDwtBHig/XQGsWZ7qkPy+7dzijAPe/8o6r/yD2gYew0rcYVY1uHZCApJbYWC1qh2KLoxT1T4DIYNh4w1LadugtyfZuj3twIDrtib8ztXNpSSUZze8AVNWkHv5W8zp62aSesMxYpCor3zDYzYBvITQ3gmW4oH2yvLcWCM4BdgxZ378VdKhOpUMREFzbSChLHflotv7Ng4J4Z91xWW+CplJVowxO+9A9/65o9y1TJHlZ+EzvxZU97wutG//Z/ySD/f9AMAgIalL5IUpWk08jvIYVqhc=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 63,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/windows-10-x86_64.facts
+++ b/facts/4.10/windows-10-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.10.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-0699f12e-1a6b-4a14-8f99-e6fabf380f80",
+      "uuid": "0699F12E-1A6B-4A14-8F99-E6FABF380F80"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.10.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.19045",
+  "kernelversion": "10.0.19045",
+  "memory": {
+    "system": {
+      "available": "1.53 GiB",
+      "available_bytes": 1644163072,
+      "capacity": "61.55%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "2.45 GiB",
+      "used_bytes": 2631610368
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::5ce8:7c62:3daf:521c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::c957:e844:529:1260",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::c957:e844:529:1260",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::fca9:4ad5:2331:5a96",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::5ce8:7c62:3daf:521c",
+        "mac": "08:00:27:41:A5:BB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::5ce8:7c62:3daf:521c",
+    "mac": "08:00:27:41:A5:BB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "10",
+      "major": "10"
+    },
+    "windows": {
+      "display_version": "22H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "22H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.10.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 1e6d6f5051ddb2bed3ba836c8beecb9e44dd3859",
+        "sha256": "SSHFP 2 2 8a32b8908fa1fd8d210f7715dd84e0a6a10145650b2a0ff6fc505d11ddb2beea"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBANxCGgsHCLb1HKFsQoDznyfMNvNM3uhXZ7DzyX4DkMFMEzvjb8hp0tg3V+Y3kQCzQbVTfJNFhp8Pa0yxOJ87iHO8f1xrhsT+3sk3kn4i3f+ombYm7oBFAg3A06hWpv/1P1pvvME1oZYXzzParVhmLjnliSu5pXqXE1AH8ix02tBNAAAAFQC0LBvWWRtvyFiMl8MqClt7bufrjQAAAIEAhcJVFBF3+rBwo3enZ3F38K+UB/Y4PkzbtaZGfIchWEcaTMpM6iewVXwQKxyI/+HnRPUuBMocjdlCSdsDXdidUdJOpe77HrbFMsRqbStZUG+iI+CfcxFbFiJk5DdP5zJiMikfSrfDwZz8WqSzxejloJB+kyKCf4tyVBAxrhj6QUAAAACAUfczVEEjzLNrXXb/LrxqNh1i1BV25pFztvrtLELLeNkSX47weU1jkyorbbRH4/zsfCyCslexcEVESr1BM++CGQ/h3BJQyNhUqNdPjT4zJXQliGCTIG299i6XiEBsnXuHhPoLYZkMI/4a1pxf43B/a1/N6CxLLscSwnal/JvkJFM=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 727d2ac3fa8fd4c1d9ad11bfb69e046887e6f002",
+        "sha256": "SSHFP 3 2 112f7cadb360eec726c95e5261e22ca85d4e6f323583f72bc2698c8d41f0aed0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHqrpTPvjMm3yNx5DQN4nGy9q3y0y3OvmySffb1fo35zhGNCHqBlq5VBF88N76+c2zXKsGkrKzfCkIoIZnFQhag=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 c29a0d2f14ec94061ce5a9837674f492e99db5b3",
+        "sha256": "SSHFP 4 2 c0b0ff427cf1a621871539b49a7ea04f7d0fa9adff8b0aa8c882957071e797ca"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIIBZtECISp2veFqOfSB0ovYrsKRu545I0RCbn+yEGa0h",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 cd9568a2b3a50416c6554c3538f2311157be7c5e",
+        "sha256": "SSHFP 1 2 01d88fff37df8f7dabb7427314f81179a67c0b68248b22647e53a359b47729b5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgJRy9zs5MmqA4FACZesRAOdvBE9u1+aWjL5QMC3ZHj9O2BG9FshrqIVKgMlmRQj4prnsiR3aSc/wKic3/sKr4Vh06QMkDLaxaaBtmt3gBxft+exeAxS15z0KtWOjvFC0v+Z2+qQ/UDMlSIJMS/3GtykX/5agAJGZ3Ftf9MQEvuIpAn1Yp4WbPwxOEWIu5PGNH+z5JANVDsSrg1vK8vmpoBBanxSwj7fcrnC6u/obzhb2hzX13Te/D6JkFcg2sB5u2zESzFasVlmJClDwRqEHlHVRcyexOuorL/5oNp1FzBvazZQZAyegptiQRwPJnWE3pjqAdruR485KxdAo3Bv1tjUpWUmIfSrYMpc2p4Ud7AaEz7j6B5nf9TRS05A6DH/Iqeg3IdxTFufle6Oqw7juKzVY8J4P24irgvPrgaYLoiIri282zy6v+5DQDhKp09ZVI4sqKvsFZHtYVwXFHGoUw/6gZELCcWeZ3L25kFZ2YI/L6HKGqtYjk0Wq5Km3iN/U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 1818,
+    "uptime": "0:30 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/windows-11-x86_64.facts
+++ b/facts/4.10/windows-11-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.10.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-02f503cd-4af5-4d3e-9f62-ed36f67b4e7c",
+      "uuid": "02F503CD-4AF5-4D3E-9F62-ED36F67B4E7C"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.10.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.26100",
+  "kernelversion": "10.0.26100",
+  "memory": {
+    "system": {
+      "available": "858.69 MiB",
+      "available_bytes": 900403200,
+      "capacity": "78.94%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "3.14 GiB",
+      "used_bytes": 3375370240
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::b0fc:25f4:9c4:2410",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::7c4c:7ba5:25b4:fa86",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::7c4c:7ba5:25b4:fa86",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::8721:b67c:9c3d:b2ad",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::b0fc:25f4:9c4:2410",
+        "mac": "08:00:27:CA:30:DB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::b0fc:25f4:9c4:2410",
+    "mac": "08:00:27:CA:30:DB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "11",
+      "major": "11"
+    },
+    "windows": {
+      "display_version": "24H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "24H2",
+      "system32": "C:\\WINDOWS\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.10.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a267414bf6e283e1889f38fdd77561f36f914d39",
+        "sha256": "SSHFP 2 2 ada979fc12f1ecc17477b90cbd8c18e4b8efdff22bf9b2d1cab55f9ca98614c2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAPPqAjpZAWwdE5mu8clESdJ0hj+ryOMR8Qrp+hr+r4iNi96wWD9zQSwfQEuBtXC5XcHIUwTQkkOot7AYRUOjb+PQUL1qd2WH0lVSDbW1KzsBoEYRSLNCpZ4xHWk1s7kXq1q7/7DH3D+scUfyUL1GEbViWhbvRdMbepI5rKZsXddvAAAAFQDeThx3/D95fBnr/t7OaUd+yrDofQAAAIArIYUbKbe+iMS2PxSZsyTMUu3GgBKPKRVQXbXkrDHcnXd6h+omLi28oKG2ZsGqsTeEQZAiBSTXegPux4/TUijqrFj0pt+1mVi3yt4Na12MO6o6Ih7C6eWyEMIhJxVUggo+wHUao5T9gBZI9Ctb2BbxUEF93bwPezE/0SqLvDE7fgAAAIBNUb5Yn7AqSWpDQIe4DY9MhwX4o/yJKDih/hYzwf6A8IxMLAE6Bpooj5lJaeGZpp58YRc4peKZbMpI+13EHQFZ9g+2XPGTuHErm84kWUWZcTMUnKoguHevpd6QDRYOLfmconAnPqj2pgqPDEIIcn4yg2e169N8p25F+e291EMuMQ==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 89e1df9d9f782bbe165493fda627a8e20249c0c5",
+        "sha256": "SSHFP 3 2 d62c0863c095aef1fbcb3a5d8003ded2b913f6b553fe40600697226d9dd3c18a"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBEBFXijienEhKxpYzOl1gy8RKSNwgoXlvYhaKRdjO6XZTkJB/xrR/VbF5c67Ip5uvL4oBlM9B6Tay5rmRsFTDk=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 bac125c932a8bb9599740b06648ac4dfd4324399",
+        "sha256": "SSHFP 4 2 6c8a4ed535c1441501516c138b7bb06993fce4efed44046694aa21ff31ae401a"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHiGHFfFuX3y+Be8CKlgAV6SkaHTfcNg5V/UtjDBkHsh",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 af2300ce3b8646c9b3a499e76b5d47342fc85129",
+        "sha256": "SSHFP 1 2 d818a35474be56648bb48ae362a63fdbef244f24ce468d4b216bf001e06bea5d"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDHIijLrDgiEzrAakvAcOUS8ZWb4KOmOJGcSaUPTAAwpYQAmqh1Et1mO0Yr1sXNnPGnI38QFLHeDKNmdvQu7zxhQV3zD7ehJEgRAbetMim/2S8JVUmVpxCiHDD60Vcw5ip/NUTWddTeLrwhAK8z0RKOPi/HZmtNsKHxvmWBM8kIUz5DRnFPWkUWFbmB5tDqIIiGUx4khe1tJKGElZQuuTFGZZGDpX593uNQN9u8TBqf3TJCaSs+LNjQd0A8Z+LgSKerGlMF/UlQccreHkFgN8RRTOp161jLpjdTBqUVWXlF2ih57lQyRCi/iU/JfE33yh68wTlhCww7PR1XLmMRHr1cxoqpSY8a+undPnBCiXgzfw2QrHG0Yq+qyKvjGdSL7rN/3M3Jz4B6SDnAVbJSj6Z4mncMlt9/VIC+jPliV7JLZixGIxKf73SSkihIifHxjYHySK/g6ZFlpbK2EdmX0tRaYjYolvopVmHaKooZrkC/UwUv2h4LLxDrCfyvTZdDo1s=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 91,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.10/windows-2022-x86_64.facts
+++ b/facts/4.10/windows-2022-x86_64.facts
@@ -1,0 +1,168 @@
+{
+  "aio_agent_version": "8.10.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-8afd7ad4-bfe9-4f5a-8d30-93c42b25907d",
+      "uuid": "8AFD7AD4-BFE9-4F5A-8D30-93C42B25907D"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.10.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.20348",
+  "kernelversion": "10.0.20348",
+  "memory": {
+    "system": {
+      "available": "671.45 MiB",
+      "available_bytes": 704065536,
+      "capacity": "66.92%",
+      "total": "1.98 GiB",
+      "total_bytes": 2128289792,
+      "used": "1.33 GiB",
+      "used_bytes": 1424224256
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::46ab:507:687:5b80",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::aff:b25e:a03e:f84f",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::46ab:507:687:5b80",
+        "mac": "08:00:27:07:2A:6E",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::46ab:507:687:5b80",
+    "mac": "08:00:27:07:2A:6E",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2022",
+      "major": "2022"
+    },
+    "windows": {
+      "display_version": "21H2",
+      "edition_id": "ServerStandardEval",
+      "installation_type": "Server Core",
+      "product_name": "Windows Server 2022 Standard Evaluation",
+      "release_id": "21H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.10.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a8d082d65ba073f4b588ca1532b2afff564655a5",
+        "sha256": "SSHFP 2 2 d58da160af2402446a90fefa3406636720cd41086332826939d95c9e3093b052"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAKKFEAtK0bNFrprCzPCwDTRR9kTrsuVgGhfWHH/z6cDb2MW3MiZR7FwPAMjyF8uDkOmujzx4v+T6OzqgjEm3d/AIbaBY7Ngk19RMGd6DcP6jj6356p1yQmZP/YRinSfYM6I6sYmjPopjREh7oCSw+mAtbpa6o0GZcwf8xyGU2CGvAAAAFQDSzyN8rO7yngMTJnsc5judSNv6nQAAAIAH7xfPEkE7jMV/BuVdmCsMfmHpI+KiKnyp+JjRBgz13FxfvWUu+tbCP6xJ2yeECKjk1oFfT/bsrKm0ChkZ7HssYRKcQW9CvcH6Z5ttRx9Oqm8PCM0kJpSxWm5a5dFPiHMdBCRIvJNksW7BPLCkuj/D+XzHCaDCDECzXELksPpspQAAAIBsV6OxseQ22u+48sDJJj1Jwl72cFtcxoZ7dFs/q78/xxeKHIRjNzTiaMqhBPY4V+2Sm6Zzgu2wJOQXYkEkq5F8X3BeTB0+xFkGPUXa/VexXJD71/Mc2uq0b24Z4ZqyqJfigp3PM6GzWuOUC14aS56t++ddGG690sPW1PhebPdgrw==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 92c1a6d77ee3c13a54441b60a59a646f505f1309",
+        "sha256": "SSHFP 3 2 6630092ecc8589ad778944e3d203de842348b151e0dd3a0457533701a7fbb383"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJuKojHoqRInzDL4edrdYI7gbbBrhj/oSptoChw4Y62/9id2Li73+6MEPc5RjnY+d5bBu0zUBUN5bSIEa0EaRI4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 baaf376fcd4d0e07122280476eb61443fd17ab7f",
+        "sha256": "SSHFP 4 2 435cfd5fe8021a37548cc0e595c56c72de2c705f84992413f686c97de282d844"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKRQrcC/RFnVsJO8EI0Y0okEa6cfasfwaDYNXsRKlmb6",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 959d4674df454c8659a7da15a806b1892c784ce5",
+        "sha256": "SSHFP 1 2 95c4ce016dae223545270157b40fdb6e1d3b854464460637ba3e707316ec3c33"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gpkm190gP0gU8pD15mzIRdZl22QzkOUMnODF53qcYOgprQG4xni+1IGXZUrt2JoTbFG5yj0IVz6lZ+BOuk55vZ+WStIHMvVgAwxahelwaEHbbC0F7hAqfuPtUaqGSrjvGjRlGUEMZD/TTI/3jcvhb6ps31YsWHdhqRwo7nUPAWLVwpmX9EI1XENnwj38BD9jdLbhiXqJZMNyGmbivLwoQYUPZrtNGmO44Hfxx0rZqoXk5uexp/XR7r3qM3M4aa62zQKsDLDnfjwidkIbkUNTZgc1zC4tDQfd0zfa2LDiiawKCXBs18MhzcZJ581VCgs/D8Oa+PPOs3f4Ecl93HKd8bHiJ16ZBdBvcDFa9nZTQgQqyGZa72TyxXjwsyHHIOQ8wsAScjAufnBNoVFUugjgIhF9cuo/AfcMPGhUAgw2tlD6jT5QJyYOg7YG87qGKzU4XYeVQMnLgE1esoDkSA+IWmIX0rbDFoOi7ex8qComb7Z+HCldm7uIu5lgWE3zxwE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 60,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/almalinux-8-x86_64.facts
+++ b/facts/4.11/almalinux-8-x86_64.facts
@@ -1,0 +1,538 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB6573693e-8f45705c",
+      "size": "19.53 GiB",
+      "size_bytes": 20971520000,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-b4c9883b-68b2-498c-9786-12f54d5c9c38",
+      "uuid": "3b88c9b4-b268-8c49-9786-12f54d5c9c38",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "vfat,xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.40.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.05,
+    "1m": 0.52,
+    "5m": 0.15
+  },
+  "memory": {
+    "system": {
+      "available": "554.32 MiB",
+      "available_bytes": 581246976,
+      "capacity": "41.33%",
+      "total": "944.76 MiB",
+      "total_bytes": 990654464,
+      "used": "390.44 MiB",
+      "used_bytes": 409407488
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "15.68 GiB",
+      "available_bytes": 16840900608,
+      "capacity": "14.40%",
+      "device": "/dev/sda4",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "18.32 GiB",
+      "size_bytes": 19674431488,
+      "used": "2.64 GiB",
+      "used_bytes": 2833530880
+    },
+    "/boot": {
+      "available": "848.00 MiB",
+      "available_bytes": 889188352,
+      "capacity": "16.37%",
+      "device": "/dev/sda3",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "166.00 MiB",
+      "used_bytes": 174067712
+    },
+    "/boot/efi": {
+      "available": "193.96 MiB",
+      "available_bytes": 203382784,
+      "capacity": "2.92%",
+      "device": "/dev/sda2",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "199.79 MiB",
+      "size_bytes": 209489920,
+      "used": "5.82 MiB",
+      "used_bytes": 6107136
+    },
+    "/dev": {
+      "available": "454.88 MiB",
+      "available_bytes": 476979200,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=465800k",
+        "nr_inodes=116450",
+        "mode=755"
+      ],
+      "size": "454.88 MiB",
+      "size_bytes": 476979200,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "472.38 MiB",
+      "available_bytes": 495325184,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "460.17 MiB",
+      "available_bytes": 482521088,
+      "capacity": "2.58%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "12.21 MiB",
+      "used_bytes": 12804096
+    },
+    "/run/user/1000": {
+      "available": "94.47 MiB",
+      "available_bytes": 99061760,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=96740k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "94.47 MiB",
+      "size_bytes": 99061760,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "472.38 MiB",
+      "available_bytes": 495325184,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "472.38 MiB",
+      "size_bytes": 495325184,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "444.35 GiB",
+      "available_bytes": 477112725504,
+      "capacity": "51.48%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "471.47 GiB",
+      "used_bytes": 506232426496
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe4c:bd69",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fe4c:bd69",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe4c:bd69",
+        "mac": "08:00:27:4c:bd:69",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe4c:bd69",
+    "mac": "08:00:27:4c:bd:69",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Cerulean Leopard",
+      "description": "AlmaLinux release 8.10 (Cerulean Leopard)",
+      "id": "AlmaLinux",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "AlmaLinux",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "d447a01d-fd27-4060-b558-903180bc94df",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partlabel": "EFI System Partition",
+      "parttype": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+      "partuuid": "cb398502-99ea-48ee-9b97-0ef7cc955981",
+      "size": "200.00 MiB",
+      "size_bytes": 209715200,
+      "uuid": "42D7-2C8F"
+    },
+    "/dev/sda3": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "68b329d8-8cdc-4059-b142-78354bf6fb45",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "93a3ebfa-5b5c-4fc1-887c-cec86f8de495"
+    },
+    "/dev/sda4": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partlabel": "root",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "6e0c34de-799c-4f0a-bb64-002dcc251a89",
+      "size": "18.33 GiB",
+      "size_bytes": 19684917248,
+      "uuid": "cd821234-5064-4367-8918-c7737d2bfce6"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 aa1b7cb8bcd545d623f0a8751ccdc4ba1837305b",
+        "sha256": "SSHFP 3 2 979416c45abe65423b14bb9c414be1784d5edb330c7ebff9302eae92af4bb86d"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAiVAy15gyXZU4ojJsgd0+q6sFpHFPyHLhp0t2kOPcJIJt+vKG3S1p0dQ3gHSMXn7AlbFNVAi9Trge9Wbo8kkL0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1d0a392c4941f6174e78b9d0344dc9be1ad5db33",
+        "sha256": "SSHFP 4 2 6a2f938d9b4e2f0a62b92ccd6528af91539cf6dd99545d937cf5de2ee2678192"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIH6xJcQuuHq7wQeqUhVlh1G5V9g6bSe43rhvSHV7X9/N",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 e165ebeb97c2478fd4df75ee02c5b6de148662af",
+        "sha256": "SSHFP 1 2 3770276e6014cf52c9d5af68b938ee3311d77a8fa2fc272c6605956d9346a34e"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC3qpLNCJUckHQen/jgc7JjN8RHFmeRXXTJ/Y85+FtsIxSSrxDoFOvdes5ZrfaSVZV3vBmmTJmlLybpNLAJhp49ttvK25uhnemFQ1sFU/Y4xCDBLTp+YjUpCOK8pKRay5WdUg/WNoJqM9zm0KJcNISSKrTexab0mEjijKXoRVTysN7wjIh92Uz8Y6oZAmECGeBgqP/9LacdHrceZ2WYnOpQTZ+g45Yvn7Xl6luwUQ6vzsDAaqJXRLla9pbPjwzV3zTmQUibJ2eCqLjjApINFiHidYnpQmEGcNkG0vdxP21Yf8tMV9RiOELH0+VkgDlYew0LM7sCC6ziA2nwq0IUg8dAcwfKAqY2S7O9cSQnVx39bA6pcnAtvbTzgPeOUsDflhqRyGDjCCG6P0/mPrZW/R6xzcr0b1Ad4yH6wXuzvkuhTpxAQ//8QfXvHgPQ0ExRnuGZ0HyInl28DlfqlLyRRgftnCEWDUTNdhKC5nrPVKEwT+wM3ohxdOzA+Uk7D0MRKvk=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 59,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/almalinux-9-x86_64.facts
+++ b/facts/4.11/almalinux-9-x86_64.facts
@@ -1,0 +1,589 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB8c723371-d3d312b7",
+      "size": "19.53 GiB",
+      "size_bytes": 20971520000,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-4436fef1-90e5-45d4-87ee-11f028bac655",
+      "uuid": "f1fe3644-e590-d445-87ee-11f028bac655",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "vfat,xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.0-503.15.1.el9_5.x86_64",
+  "kernelversion": "5.14.0",
+  "load_averages": {
+    "15m": 0.07,
+    "1m": 0.65,
+    "5m": 0.2
+  },
+  "memory": {
+    "system": {
+      "available": "537.50 MiB",
+      "available_bytes": 563609600,
+      "capacity": "42.95%",
+      "total": "942.20 MiB",
+      "total_bytes": 987963392,
+      "used": "404.70 MiB",
+      "used_bytes": 424353792
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "16.91 GiB",
+      "available_bytes": 18151739392,
+      "capacity": "7.47%",
+      "device": "/dev/sda4",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "18.27 GiB",
+      "size_bytes": 19617808384,
+      "used": "1.37 GiB",
+      "used_bytes": 1466068992
+    },
+    "/boot": {
+      "available": "828.63 MiB",
+      "available_bytes": 868884480,
+      "capacity": "13.68%",
+      "device": "/dev/sda3",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "960.00 MiB",
+      "size_bytes": 1006632960,
+      "used": "131.37 MiB",
+      "used_bytes": 137748480
+    },
+    "/boot/efi": {
+      "available": "192.72 MiB",
+      "available_bytes": 202080256,
+      "capacity": "3.53%",
+      "device": "/dev/sda2",
+      "filesystem": "vfat",
+      "options": [
+        "rw",
+        "relatime",
+        "fmask=0077",
+        "dmask=0077",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=winnt",
+        "errors=remount-ro"
+      ],
+      "size": "199.77 MiB",
+      "size_bytes": 209469440,
+      "used": "7.05 MiB",
+      "used_bytes": 7389184
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=111472",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "471.10 MiB",
+      "available_bytes": 493981696,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "471.10 MiB",
+      "size_bytes": 493981696,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "183.25 MiB",
+      "available_bytes": 192147456,
+      "capacity": "2.76%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=192964k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "188.44 MiB",
+      "size_bytes": 197595136,
+      "used": "5.20 MiB",
+      "used_bytes": 5447680
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "94.22 MiB",
+      "available_bytes": 98795520,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=96480k",
+        "nr_inodes=24120",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "94.22 MiB",
+      "size_bytes": 98795520,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "442.76 GiB",
+      "available_bytes": 475410903040,
+      "capacity": "51.65%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "473.05 GiB",
+      "used_bytes": 507934248960
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "rpc_pipefs",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe0d:f5f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fe0d:f5f0",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe0d:f5f0",
+        "mac": "08:00:27:0d:f5:f0",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe0d:f5f0",
+    "mac": "08:00:27:0d:f5:f0",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Teal Serval",
+      "description": "AlmaLinux release 9.5 (Teal Serval)",
+      "id": "AlmaLinux",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "AlmaLinux",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "f090b7d8-33ad-470f-99f5-66bab2c7aa3c",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "vfat",
+      "mount": "/boot/efi",
+      "partlabel": "EFI System Partition",
+      "parttype": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+      "partuuid": "10aad5af-650e-4f3b-b67f-1d68588a7f3d",
+      "size": "200.00 MiB",
+      "size_bytes": 209715200,
+      "uuid": "DB29-5C75"
+    },
+    "/dev/sda3": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "25f59295-3706-48f7-a20a-20e427e06042",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "484a1e16-48e4-4829-a591-5d142d579d40"
+    },
+    "/dev/sda4": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "partlabel": "root",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "57ef363f-97ff-4af6-a6e0-2d289ff6e201",
+      "size": "18.33 GiB",
+      "size_bytes": 19684917248,
+      "uuid": "5ac5d360-5d04-423c-9e98-5ee8f11d2066"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 a6295720bb1612d8ba76b934c0b6aad33543550b",
+        "sha256": "SSHFP 3 2 c424e31194af8397864a9857224b67d387dec60c00d73f782a3c1377a1cef5aa"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKVY6h3Z9ZDmiXcuGeu9OqoFaOWRmh7riO9CSJtgUsSjGOjDlwL+Af0xFt0ms7sz0bJjN7BLuilHkyrrzx8qO2s=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 96a6ea33a34a01a75685e6291490cb3f51fa0e24",
+        "sha256": "SSHFP 4 2 04a8a42220396546bb7ae74c2fc50667bc5b3352ecbfd764e17e75f357f5f2c9"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIGic1d2OxpSE0YvLhuDkqjw/IsO3vxlL/O7KZu56zjdv",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 d34e4f88ee3bf7f3bd9bc4fc67880788bc47ff13",
+        "sha256": "SSHFP 1 2 95134a9ba53b706a447ed4632e6c1ec17ef6f37c76c25503c1ba05529e7e9092"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCh41NXSvYhqI24pAc/cxwUCRsuoxJVUNiUI2zELaO98a7CV5bZjLljhBb3KMXXyKF12NT55CtnfkLk6Ue3HO1aXxG50T6axWdP4ripJmuKzxnAuESEE3bebtHK8sd7usZL4mcO6VtzBIU8Nn+z1fiH53KTwXvhwuWhGT/4SxJl5OuMO40fuBKbb7ma+mgezOlYsAmKtquH5BAZW4SwRa3A4MDVfj0+isziRtEGBoXOjO4WaH6yrok42kE8XoHBCtKLq0xNsNBk2CkKa9IHx4cdtGe9OROgQjRE+sgY6VyNRsWboY06010w7CHq8mgr9vLGf9HAwtsiabdBTnq9RMV4GDs/fzehnbqkWacADqUp52/suzpbGBk6mzFqJoSjZosT3oOOT2ozpWomF/QhgvD0FCYB5EXcuoj2rT8IFStonqAKmTWhep1jAd20YbJ5umcAVTx0uF15BqB9YHpyvW8yjfxG6FTx5JS60uhx4NA1wF3RK4vYxFxfxu6m60up8OU=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 49,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/amazon-2-x86_64.facts
+++ b/facts/4.11/amazon-2-x86_64.facts
@@ -1,0 +1,462 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.27,
+    "1m": 2.64,
+    "5m": 0.78
+  },
+  "memory": {
+    "system": {
+      "available": "1.67 GiB",
+      "available_bytes": 1793785856,
+      "capacity": "13.61%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "269.49 MiB",
+      "used_bytes": 282578944
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "23.12 GiB",
+      "available_bytes": 24824717312,
+      "capacity": "7.47%",
+      "device": "/dev/sda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "noatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "24.99 GiB",
+      "size_bytes": 26828324864,
+      "used": "1.87 GiB",
+      "used_bytes": 2003607552
+    },
+    "/dev": {
+      "available": "973.07 MiB",
+      "available_bytes": 1020338176,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=996424k",
+        "nr_inodes=249106",
+        "mode=755"
+      ],
+      "size": "973.07 MiB",
+      "size_bytes": 1020338176,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "990.09 MiB",
+      "available_bytes": 1038180352,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "990.09 MiB",
+      "size_bytes": 1038180352,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "989.68 MiB",
+      "available_bytes": 1037758464,
+      "capacity": "0.04%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "990.09 MiB",
+      "size_bytes": 1038180352,
+      "used": "412.00 KiB",
+      "used_bytes": 421888
+    },
+    "/run/user/1000": {
+      "available": "198.02 MiB",
+      "available_bytes": 207638528,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=202772k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "198.02 MiB",
+      "size_bytes": 207638528,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "990.09 MiB",
+      "available_bytes": 1038180352,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "990.09 MiB",
+      "size_bytes": 1038180352,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "419.66 GiB",
+      "available_bytes": 450601390080,
+      "capacity": "54.18%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "496.16 GiB",
+      "used_bytes": 532743761920
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "mount": "/",
+      "partlabel": "Linux",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 36,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/oraclelinux-8-x86_64.facts
+++ b/facts/4.11/oraclelinux-8-x86_64.facts
@@ -1,0 +1,520 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBa19b630e-9f5ed789",
+      "size": "37.00 GiB",
+      "size_bytes": 39728447488,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "2935e453-ceb1-8046-b60c-d499559b887b",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "xfs,zonefs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.15",
+  "kernelrelease": "5.15.0-306.177.4.el8uek.x86_64",
+  "kernelversion": "5.15.0",
+  "load_averages": {
+    "15m": 0.09,
+    "1m": 0.82,
+    "5m": 0.26
+  },
+  "memory": {
+    "swap": {
+      "available": "4.00 GiB",
+      "available_bytes": 4294688768,
+      "capacity": "0.01%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
+      "used": "268.00 KiB",
+      "used_bytes": 274432
+    },
+    "system": {
+      "available": "1.49 GiB",
+      "available_bytes": 1599307776,
+      "capacity": "22.17%",
+      "total": "1.91 GiB",
+      "total_bytes": 2054807552,
+      "used": "434.40 MiB",
+      "used_bytes": 455499776
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "29.05 GiB",
+      "available_bytes": 31191252992,
+      "capacity": "9.17%",
+      "device": "/dev/mapper/vg_main-lv_root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "31.98 GiB",
+      "size_bytes": 34338770944,
+      "used": "2.93 GiB",
+      "used_bytes": 3147517952
+    },
+    "/boot": {
+      "available": "905.06 MiB",
+      "available_bytes": 949022720,
+      "capacity": "10.74%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "108.94 MiB",
+      "used_bytes": 114233344
+    },
+    "/dev": {
+      "available": "953.50 MiB",
+      "available_bytes": 999817216,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=976384k",
+        "nr_inodes=244096",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "953.50 MiB",
+      "size_bytes": 999817216,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "979.81 MiB",
+      "available_bytes": 1027403776,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "963.43 MiB",
+      "available_bytes": 1010225152,
+      "capacity": "1.67%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "16.38 MiB",
+      "used_bytes": 17178624
+    },
+    "/run/user/1000": {
+      "available": "195.96 MiB",
+      "available_bytes": 205479936,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200664k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.96 MiB",
+      "size_bytes": 205479936,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "979.81 MiB",
+      "available_bytes": 1027403776,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "979.81 MiB",
+      "size_bytes": 1027403776,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "436.52 GiB",
+      "available_bytes": 468704776192,
+      "capacity": "52.34%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "479.30 GiB",
+      "used_bytes": 514640375808
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe1a:91c3",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fe1a:91c3",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "unknown",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe1a:91c3",
+        "mac": "08:00:27:1a:91:c3",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": -1
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe1a:91c3",
+    "mac": "08:00:27:1a:91:c3",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Ootpa",
+      "description": "Oracle Linux Server 8.10",
+      "id": "Ol",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "OracleLinux",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/mapper/vg_main-lv_root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "32.00 GiB",
+      "size_bytes": 34355544064,
+      "uuid": "743cd91f-42be-4736-90b0-8fdbc787e29a"
+    },
+    "/dev/mapper/vg_main-lv_swap": {
+      "filesystem": "swap",
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "b13e269a-0864-4ee3-a81a-57267fb3d4b8"
+    },
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "b24fbe38-5545-4de6-a9a3-5b2c45bb8307",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "label": "boot",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "6c0bad4c-381a-4e5d-bc17-cd79753b4932",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "e3843ecc-d8e5-43b1-b8c6-68563e013be1"
+    },
+    "/dev/sda3": {
+      "filesystem": "LVM2_member",
+      "partlabel": "pv_vol",
+      "parttype": "e6d6d379-f507-44c2-a23c-238f2a3df928",
+      "partuuid": "6e313cbf-21ac-4940-9880-7bc478ddc96a",
+      "size": "36.00 GiB",
+      "size_bytes": 38651559936,
+      "uuid": "lAIrDO-gXKH-hMIH-lboJ-wwG0-74bF-45NhOs"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/share/Modules/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 f88076c2c9793d716752f07fc416e3c3f1f498eb",
+        "sha256": "SSHFP 3 2 544f49dc10e04418c7cd02527fb2974124dccf02af7ad81969492f0069580691"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCKfLK+TIoFwmM9P3ZyX7BwfQUqwbave2PT0qQjnmP/RwlgTgGhR2o1XwilSkVaDar9bQZdgZ9eHPNEG2ovOQUQ=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 7976c0b587dc5d2d3ec08f1a524338b9db630fa6",
+        "sha256": "SSHFP 4 2 12cfe4a3f4af09f9aeee5b07c9c0ba37ec7c724a6668649db3cba4ba0b9b8a05"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIMpMLkpHaltPuEJkoaZjg0QPbfaQuQwY/yQzswTCm0ZE",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 c3345971a21053ab61c04fc9b5ac543ea97ad564",
+        "sha256": "SSHFP 1 2 1a6b0b163bba1c263997407591dbdbb10fef6ccefabf0f5cd1a538b221f5fe36"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCtxarbsM0it7peRap9cWagiuOT+vtCNNxd8yff4p4t7YRo3Lj2n2XLvzNndHEL6wZD4hUVK8a13tDg+TJL9fLNCwZMJb8ZFe1WoqAkJkGDgL6OgbYnuX6iEk4fYJqKDTQtDFwKtorR1w2cLcPvbQrG4INJqtAdOFBji2sSf1/NYR8hSXkl33imp6F/6GaKmbUJwCgnXh4T4xq3XxL6PU56tr9+jGP9Y3Cj+dvWZi/ap4yht5iq23m7BcV+KivsFsmkfdh8qiwPizo9RXQC1eRO5KZ96lvXgy+x8cf5XJvNmbrD9J0EBe8SGLo7T3L29F4rTxvsEvSXmZyBB2s6v3XKLkGx+09jvvrgyeVcl07a5DH/r/Xz7LX2aQSrgX6/XfqZnXH51jUB5TCcIP+06JMQOdH1fkqLS5t1YRvrzfuvVQa9gQ3c3Qsn9Dkh+6i4rdCFBS7MGVA8WROG6gdaOgGV0cBD4eUFsYgSLQicJy+v8G3RSGLq/YWSuozJat+PhTM=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 108,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/oraclelinux-9-x86_64.facts
+++ b/facts/4.11/oraclelinux-9-x86_64.facts
@@ -1,0 +1,586 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB9a95c0bd-62acdbd7",
+      "size": "37.00 GiB",
+      "size_bytes": 39728447488,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "3e6a95c2-c3da-4a4d-9c54-1fd89c81760a",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "btrfs,xfs,zonefs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.15",
+  "kernelrelease": "5.15.0-306.177.4.el9uek.x86_64",
+  "kernelversion": "5.15.0",
+  "load_averages": {
+    "15m": 0.09,
+    "1m": 0.87,
+    "5m": 0.25
+  },
+  "memory": {
+    "swap": {
+      "available": "4.00 GiB",
+      "available_bytes": 4294688768,
+      "capacity": "0.01%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294963200,
+      "used": "268.00 KiB",
+      "used_bytes": 274432
+    },
+    "system": {
+      "available": "1.46 GiB",
+      "available_bytes": 1567944704,
+      "capacity": "23.69%",
+      "total": "1.91 GiB",
+      "total_bytes": 2054746112,
+      "used": "464.25 MiB",
+      "used_bytes": 486801408
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "29.31 GiB",
+      "available_bytes": 31466983424,
+      "capacity": "8.23%",
+      "device": "/dev/mapper/vg_main-lv_root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "31.93 GiB",
+      "size_bytes": 34288435200,
+      "used": "2.63 GiB",
+      "used_bytes": 2821451776
+    },
+    "/boot": {
+      "available": "846.03 MiB",
+      "available_bytes": 887123968,
+      "capacity": "11.87%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "960.00 MiB",
+      "size_bytes": 1006632960,
+      "used": "113.97 MiB",
+      "used_bytes": 119508992
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=243989",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "979.78 MiB",
+      "available_bytes": 1027371008,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "979.78 MiB",
+      "size_bytes": 1027371008,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "381.67 MiB",
+      "available_bytes": 400211968,
+      "capacity": "2.61%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=401320k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "391.91 MiB",
+      "size_bytes": 410951680,
+      "used": "10.24 MiB",
+      "used_bytes": 10739712
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "195.95 MiB",
+      "available_bytes": 205471744,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=200656k",
+        "nr_inodes=50164",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "195.95 MiB",
+      "size_bytes": 205471744,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "433.55 GiB",
+      "available_bytes": 465518792704,
+      "capacity": "52.66%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "482.26 GiB",
+      "used_bytes": 517826359296
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fe5b:5722",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::a00:27ff:fe5b:5722",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "unknown",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fe5b:5722",
+        "mac": "08:00:27:5b:57:22",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": -1
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fe5b:5722",
+    "mac": "08:00:27:5b:57:22",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Plow",
+      "description": "Oracle Linux Server 9.5",
+      "id": "Ol",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "OracleLinux",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/mapper/vg_main-lv_root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "32.00 GiB",
+      "size_bytes": 34355544064,
+      "uuid": "aa59a49a-2c06-4537-8b43-7f0dbed70f2c"
+    },
+    "/dev/mapper/vg_main-lv_swap": {
+      "filesystem": "swap",
+      "size": "4.00 GiB",
+      "size_bytes": 4294967296,
+      "uuid": "7aa4b888-9f17-4fa5-8f2b-a30534dbe656"
+    },
+    "/dev/sda1": {
+      "partlabel": "biosboot",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "9be28db9-8c4f-4834-b761-0e7228c0797d",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "label": "boot",
+      "mount": "/boot",
+      "partlabel": "boot",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "02cc627a-03d6-4883-a7a7-fad2e5cbf070",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "924af72d-980c-4e99-8745-6cf81e074b40"
+    },
+    "/dev/sda3": {
+      "filesystem": "LVM2_member",
+      "partlabel": "pv_vol",
+      "parttype": "e6d6d379-f507-44c2-a23c-238f2a3df928",
+      "partuuid": "7f949a84-9c33-453b-89d8-8f9438e01cde",
+      "size": "36.00 GiB",
+      "size_bytes": 38651559936,
+      "uuid": "f7PMoa-ewjJ-G3b4-Js0S-hvMw-AIrp-qbX9zg"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 fe6b06fbe99df0c5492ef8a161ea4efd3c564c3e",
+        "sha256": "SSHFP 3 2 8262b08e300039f58efa379bfef889f6c0a5b41ec7b1467ad5a4b02047eed8d9"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHB2UFx6aOpe5BNsXpvPxX6eFWDTMyFiwt9Tl7fb54T9ySuaWZuJjdX3Ns3Gtl8/F9onyLM7WUdXhIm4t6CC/vg=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 7bab3b1d773863e32b2d1821881aef1f0e5df741",
+        "sha256": "SSHFP 4 2 e55a5186473dc680340281d4d5f10ba528807c66a95476fb77f0cc8728696dca"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIBBVQcOaMH2ZouwzUiVeuFZK1NY7niOa2Ez1UzJtJHB+",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a77c50ec565850aa51cc4de7bd070eff7dad2366",
+        "sha256": "SSHFP 1 2 8dbbe1d5b715a986fd0c9e2ff0c89058069d6ea64aa7053c90e1444cafe27603"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCT9DGrr7nJWzRkHn4JKenmKHslNC9QtCKrp4zvjt/sLqe10hA+zPnKZ3KfX7YUvO/yZkKaHLgjM18IGxGbUlRB9x1E1gsQeNZXXj2vkkR21n3w3R6WC7lS+7x3FMHIUvQhe6HfBxYFLDLWQZLV1g6lNbGTmrWC/06QNAZQ7xgi1PklBYF+zdLD+2p7g+7KO6sxgTk6AixeRqj8ZMipJLa+c8m9T4p4Ppi7PB6dBkClu4WfvNykZlhuLIOXxAR0SYM72AxtYYIT58KpQMNiJub1ZHzfv0s5WtjsWQK8D4LQRDgOW77SNU+QhWjfsN8waCTz/IlosGQF29AbGSTsHJ8ck9yhiv7piW4aUSx+xBWvL2NY9YJJhHJNWDE6B5UjcU6l8j5nbXORpODLgckrDqwoyGsPCavZp6/uPFY4XaP42nlTYHKMklcL9o1bcuIRszzLEjuhtqqzdV0yErIdBZwoMHyTaf2rRtdAxR7j/4Hxtaq6afHAxp8U432HjVxxUzM=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 93,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/rocky-8-x86_64.facts
+++ b/facts/4.11/rocky-8-x86_64.facts
@@ -1,0 +1,489 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB85e912fb-08fe30ec",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-bcbba733-498f-464e-ab3e-022c51f57386",
+      "uuid": "33a7bbbc-8f49-4e46-ab3e-022c51f57386",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    },
+    "vmware": {
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-553.40.1.el8_10.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.06,
+    "1m": 0.54,
+    "5m": 0.16
+  },
+  "memory": {
+    "swap": {
+      "available": "3.03 GiB",
+      "available_bytes": 3257921536,
+      "capacity": "0.00%",
+      "total": "3.03 GiB",
+      "total_bytes": 3257921536,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "2.28 GiB",
+      "available_bytes": 2449956864,
+      "capacity": "16.15%",
+      "total": "2.72 GiB",
+      "total_bytes": 2921865216,
+      "used": "450.05 MiB",
+      "used_bytes": 471908352
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "58.68 GiB",
+      "available_bytes": 63006359552,
+      "capacity": "3.70%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "60.94 GiB",
+      "size_bytes": 65428541440,
+      "used": "2.26 GiB",
+      "used_bytes": 2422181888
+    },
+    "/dev": {
+      "available": "1.34 GiB",
+      "available_bytes": 1442488320,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=1408680k",
+        "nr_inodes=352170",
+        "mode=755"
+      ],
+      "size": "1.34 GiB",
+      "size_bytes": 1442488320,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.36 GiB",
+      "available_bytes": 1460932608,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "1.34 GiB",
+      "available_bytes": 1443672064,
+      "capacity": "1.18%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "16.46 MiB",
+      "used_bytes": 17260544
+    },
+    "/run/user/1000": {
+      "available": "278.65 MiB",
+      "available_bytes": 292184064,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=285336k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "278.65 MiB",
+      "size_bytes": 292184064,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "1.36 GiB",
+      "available_bytes": 1460932608,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "1.36 GiB",
+      "size_bytes": 1460932608,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "440.79 GiB",
+      "available_bytes": 473296859136,
+      "capacity": "51.87%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "475.02 GiB",
+      "used_bytes": 510048292864
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::41b9:8323:28ee:f121",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::d092:a218:931:ae47",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::41b9:8323:28ee:f121",
+        "mac": "08:00:27:e1:cc:39",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::41b9:8323:28ee:f121",
+    "mac": "08:00:27:e1:cc:39",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Green Obsidian",
+      "description": "Rocky Linux release 8.10 (Green Obsidian)",
+      "id": "Rocky",
+      "release": {
+        "full": "8.10",
+        "major": "8",
+        "minor": "10"
+      },
+      "specification": ":core-4.1-amd64:core-4.1-noarch"
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "8.10",
+      "major": "8",
+      "minor": "10"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "parttype": "0x82",
+      "partuuid": "c3e94172-01",
+      "size": "3.03 GiB",
+      "size_bytes": 3257925632,
+      "uuid": "a36b3fd2-b4df-487f-936c-2aff084aa835"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "c3e94172-02",
+      "size": "60.96 GiB",
+      "size_bytes": 65460502528,
+      "uuid": "70b09872-e9e2-476e-88e7-8401f91cdd76"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 b6a599d170cc4b5fa7e17ef1273354f56f835aaf",
+        "sha256": "SSHFP 3 2 b63783e3f0a6607cfda4718f5175ed72e84bfc00bce1e769d49d06fd348eb000"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGz05DfkxUiynBY2YzUNx5BZD10OI7nyDG6qdbx0ReMy3M3FOpbY2t2kDvEtOeuwCiaFfGCbu+2YEJ6kNjvBqO4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 1b9dd60073706d9cbd17bf4ec5f38d80e3c814b8",
+        "sha256": "SSHFP 4 2 cfd87a6db56f03b28873aeb2c1f689972f45f40a5e99df234afd2b695c5a1bcd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAID0DTSb3cZGZTibqz+m7NvkDtm/0rQrgiw3hu7GuY6Mi",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 44a2c8d780a6796e86007a775779c1ad603f93a1",
+        "sha256": "SSHFP 1 2 e045246458de5004326f3f06c83246df0e7557a03791d65bd59812e1d7929652"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC3rfBr6m33AbRzjexFfZ/WLWTfdF3oHi0VkO0uDGDPvtW9Yr5ind0RW5XfiZYOajha+TAIoXMR1M3D0Rj5iAh6Z50ntw/ORvJfNZIrRg3ik2Xr0t2H8Tm890Ji62EcC7JhcNxNtBlPl7P/QnVVMJUIjtMm5MxhNCEa/AnjZOmUlutL+YCaBuKj24xdv+e/WO1X+z3T2VVGyCXiupMKxMG6iepHHLCHsIOoC5MeCtklj5MefQuGWap53ib2fhnIev/TipwOS5g+vc10PHaSW9JX8VtkPH4p4LWeCe/z0CmDA0ZQAYPVNXr8hQNnPeGm5MTh+mhR2yx1vTZ+wGhORNJJdvFgKMRHfzZPHZe3RefTv8nwkX3MRpmI2kiBmIrDu7bP3GhYrcwuVTQuvVj1pdXqlzLKvuisZxhtgCHb863Xa2vUuHwwIz+8KEdaD0Z+vJsSTeSAe1wq+idqKeGJe5LJUbkJ/uqjPpJdk1+cJh232zhshiOK/iAK1Klyy/V5FI0=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 49,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.11/rocky-9-x86_64.facts
+++ b/facts/4.11/rocky-9-x86_64.facts
@@ -1,0 +1,539 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f316a1f-a7d7495d",
+      "size": "64.00 GiB",
+      "size_bytes": 68719476736,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-6cb0b832-92cd-4c94-9535-b2d99b8ccf8b",
+      "uuid": "32b8b06c-cd92-944c-9535-b2d99b8ccf8b",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.11.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    },
+    "vmware": {
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.0-503.23.2.el9_5.x86_64",
+  "kernelversion": "5.14.0",
+  "load_averages": {
+    "15m": 0.06,
+    "1m": 0.59,
+    "5m": 0.18
+  },
+  "memory": {
+    "swap": {
+      "available": "3.03 GiB",
+      "available_bytes": 3250581504,
+      "capacity": "0.00%",
+      "total": "3.03 GiB",
+      "total_bytes": 3250581504,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "2.40 GiB",
+      "available_bytes": 2575294464,
+      "capacity": "17.35%",
+      "total": "2.90 GiB",
+      "total_bytes": 3115765760,
+      "used": "515.43 MiB",
+      "used_bytes": 540471296
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "58.96 GiB",
+      "available_bytes": 63303147520,
+      "capacity": "3.21%",
+      "device": "/dev/sda2",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "logbufs=8",
+        "logbsize=32k",
+        "noquota"
+      ],
+      "size": "60.91 GiB",
+      "size_bytes": 65400733696,
+      "used": "1.95 GiB",
+      "used_bytes": 2097586176
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=375370",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "1.45 GiB",
+      "available_bytes": 1557880832,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "1.45 GiB",
+      "size_bytes": 1557880832,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "578.91 MiB",
+      "available_bytes": 607027200,
+      "capacity": "2.59%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "size=608548k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "594.29 MiB",
+      "size_bytes": 623153152,
+      "used": "15.38 MiB",
+      "used_bytes": 16125952
+    },
+    "/run/credentials/systemd-sysctl.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup-dev.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/credentials/systemd-tmpfiles-setup.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "297.14 MiB",
+      "available_bytes": 311574528,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=304272k",
+        "nr_inodes=76068",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "297.14 MiB",
+      "size_bytes": 311574528,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "491.32 GiB",
+      "available_bytes": 527546880000,
+      "capacity": "46.35%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "424.50 GiB",
+      "used_bytes": 455798272000
+    },
+    "/var/lib/nfs/rpc_pipefs": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "sunrpc",
+      "filesystem": "rpc_pipefs",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::f96c:63fe:9157:c223",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+
+            ]
+          },
+          {
+            "address": "fe80::3b85:4077:3446:7f6c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::f96c:63fe:9157:c223",
+        "mac": "08:00:27:4c:24:90",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::f96c:63fe:9157:c223",
+    "mac": "08:00:27:4c:24:90",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Blue Onyx",
+      "description": "Rocky Linux release 9.5 (Blue Onyx)",
+      "id": "Rocky",
+      "release": {
+        "full": "9.5",
+        "major": "9",
+        "minor": "5"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Rocky",
+    "release": {
+      "full": "9.5",
+      "major": "9",
+      "minor": "5"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "swap",
+      "parttype": "0x82",
+      "partuuid": "47579c88-01",
+      "size": "3.03 GiB",
+      "size_bytes": 3250585600,
+      "uuid": "1e67ec0a-b68a-40b7-85c7-191269487594"
+    },
+    "/dev/sda2": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "47579c88-02",
+      "size": "60.97 GiB",
+      "size_bytes": 65467842560,
+      "uuid": "691f2ba0-0c77-4cb6-b23e-befc58d6c122"
+    }
+  },
+  "path": "/opt/puppetlabs/bin:/root/.local/bin:/root/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "puppetversion": "8.12.1",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 f2a5cc138a59f25b73279acf484ddd7550c94208",
+        "sha256": "SSHFP 3 2 7c8692ee714c8d72f62d7a94f56a3fe141a9a7ef24bd1499660d2a35d9a6b00e"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJBS9lxu/IKxomxOsRi8t+WSFRCyGUTdTdExNlzjhsZtUgXLA11uRE5K6SVlX0aO4GClxCOEO2cdMDapUsVtokE=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 d4ce3dc7eb8058f79a47f681b4f39c1089abc699",
+        "sha256": "SSHFP 4 2 adc877c56b50930f2b2eecfadc0c4a0a11ef683f706bc55e9147ccdaf8ef45f0"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIN2WV2mlRuD01kw5t2oJgKgYQuoVhA1DDDoi7G3aVfnD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 0e730825efb37f98713f42bed86b90b6b755906f",
+        "sha256": "SSHFP 1 2 2f754f21adb5d7f22d1151e93581aca138336d27abcfbc463466b380bbdba2a7"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDhaQLdfr7HTyoxICuw0kkeQbZjJJuZVY0oYS/epFD5+E+0y86e63GzEDwFuTzI5YZuIyHPqZdceOzSWDZrQYhX0nGR9lJMh+6eKzWSHvFSnZOQUpMF33NVPnx2ZFxRnUD66mF3qz7kTQJTsACJhGe516ox6WPKyIe+k57J3lYomFHy23v61wx9DPeLKRKK+qvbeEnYwQFFx+viNTe8YRFYSOwFuspW5Clt0Pq1/4nDwtBHig/XQGsWZ7qkPy+7dzijAPe/8o6r/yD2gYew0rcYVY1uHZCApJbYWC1qh2KLoxT1T4DIYNh4w1LadugtyfZuj3twIDrtib8ztXNpSSUZze8AVNWkHv5W8zp62aSesMxYpCor3zDYzYBvITQ3gmW4oH2yvLcWCM4BdgxZ378VdKhOpUMREFzbSChLHflotv7Ng4J4Z91xWW+CplJVowxO+9A9/65o9y1TJHlZ+EzvxZU97wutG//Z/ySD/f9AMAgIalL5IUpWk08jvIYVqhc=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 44,
+    "uptime": "0:00 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.2/amazon-2-x86_64.facts
+++ b/facts/4.2/amazon-2-x86_64.facts
@@ -1,0 +1,249 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51"
+    }
+  },
+  "facterversion": "4.2.14",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.2.14",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.23,
+    "1m": 1.41,
+    "5m": 0.62
+  },
+  "memory": {
+    "system": {
+      "available": "1.65 GiB",
+      "available_bytes": 1771077632,
+      "capacity": "14.70%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "291.14 MiB",
+      "used_bytes": 305287168
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 83,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.3/amazon-2-x86_64.facts
+++ b/facts/4.3/amazon-2-x86_64.facts
@@ -1,0 +1,249 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51"
+    }
+  },
+  "facterversion": "4.3.1",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.3.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.37,
+    "5m": 0.63
+  },
+  "memory": {
+    "system": {
+      "available": "1.65 GiB",
+      "available_bytes": 1769259008,
+      "capacity": "14.79%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "292.88 MiB",
+      "used_bytes": 307105792
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 85,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.4/amazon-2-x86_64.facts
+++ b/facts/4.4/amazon-2-x86_64.facts
@@ -1,0 +1,249 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51"
+    }
+  },
+  "facterversion": "4.4.3",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.4.3",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.37,
+    "5m": 0.63
+  },
+  "memory": {
+    "system": {
+      "available": "1.64 GiB",
+      "available_bytes": 1766092800,
+      "capacity": "14.94%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "295.90 MiB",
+      "used_bytes": 310272000
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 86,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.6/amazon-2-x86_64.facts
+++ b/facts/4.6/amazon-2-x86_64.facts
@@ -1,0 +1,257 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.6.1",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.6.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.37,
+    "5m": 0.63
+  },
+  "memory": {
+    "system": {
+      "available": "1.64 GiB",
+      "available_bytes": 1761710080,
+      "capacity": "15.15%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "300.08 MiB",
+      "used_bytes": 314654720
+    }
+  },
+  "mountpoints": {},
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 89,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.6/opensuse-15-x86_64.facts
+++ b/facts/4.6/opensuse-15-x86_64.facts
@@ -1,0 +1,475 @@
+{
+  "aio_agent_version": "8.10.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f82cad1-18aa0ba4",
+      "size": "42.00 GiB",
+      "size_bytes": 45097156608,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-e4d260f7-2d9d-44ab-a42b-5c083e9fcbc1",
+      "uuid": "f760d2e4-9d2d-ab44-a42b-5c083e9fcbc1",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.6.1",
+  "filesystems": "ext2,ext3,ext4",
+  "fips_enabled": false,
+  "gem_version": "~> 4.6.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.21-150400.24.60-default",
+  "kernelversion": "5.14.21",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.82,
+    "5m": 0.26
+  },
+  "memory": {
+    "system": {
+      "available": "702.49 MiB",
+      "available_bytes": 736616448,
+      "capacity": "27.03%",
+      "total": "962.70 MiB",
+      "total_bytes": 1009463296,
+      "used": "260.21 MiB",
+      "used_bytes": 272846848
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "37.44 GiB",
+      "available_bytes": 40196214784,
+      "capacity": "3.83%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "41.04 GiB",
+      "size_bytes": 44069601280,
+      "used": "1.49 GiB",
+      "used_bytes": 1601806336
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=1048576",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "481.34 MiB",
+      "available_bytes": 504725504,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "481.35 MiB",
+      "size_bytes": 504729600,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/run": {
+      "available": "187.14 MiB",
+      "available_bytes": 196227072,
+      "capacity": "2.81%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "size=197164k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "192.54 MiB",
+      "size_bytes": 201895936,
+      "used": "5.41 MiB",
+      "used_bytes": 5668864
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.27 MiB",
+      "available_bytes": 100941824,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98580k",
+        "nr_inodes=24645",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "96.27 MiB",
+      "size_bytes": 100945920,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/sys/fs/cgroup": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "size=4096k",
+        "nr_inodes=1024",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "431.92 GiB",
+      "available_bytes": 463769415680,
+      "capacity": "52.84%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "483.89 GiB",
+      "used_bytes": 519575736320
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::bf30:22dc:342a:4dc9",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+              "temporary"
+            ]
+          },
+          {
+            "address": "fd00::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::bf30:22dc:342a:4dc9",
+        "mac": "08:00:27:7a:a2:d7",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::bf30:22dc:342a:4dc9",
+    "mac": "08:00:27:7a:a2:d7",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "openSUSE Leap 15.4",
+      "id": "SUSE",
+      "release": {
+        "full": "15.4",
+        "major": "15",
+        "minor": "4"
+      }
+    },
+    "family": "Suse",
+    "hardware": "x86_64",
+    "name": "openSUSE",
+    "release": {
+      "full": "15.4",
+      "major": "15",
+      "minor": "4"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "ROOT",
+      "mount": "/",
+      "partuuid": "f42329f8-01",
+      "size": "42.00 GiB",
+      "size_bytes": 45096108032,
+      "uuid": "30832e7a-e906-43bc-b445-247b91cb9e0e"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 fa6a59446c44186ae52f2c6434cdadc13cc4d87b",
+        "sha256": "SSHFP 2 2 3581fde41bb78a886f78215ff2612c4fa630edc2b8247294ec84bfd3badd08af"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAOHqZjSkv/ufdFSSvgGFrycROq8oII65NjjTPI9v6e3sTCL34bugS6zUmlELg3HHgTVb826UdXOg6VuoId+cPCtYBbKw7Dqecfd6+AQRQVAXbPSx13+lwBdiY9/lxZQbQVFJzs7N+shor+Vkmz3T7gEOYvVlSqV8ZOw+qK0sk5LBAAAAFQDvWtZVlWOanpnpmRAsxLHLcTVxhwAAAIA6uJGdcsgrTq42MQi4DH1mAtdYxTQwI1OM30+TG77EqkL3uqVAJufIIgYT3Q2PuV3qNgGatjIP7kVpnhZm6hRHCqPNucIy6tULaSa4nufeIxFW95OIwDZEzKJVNLFr/7KeeBPuw9DLKPxjSIteVtgpUqDYivQKwhs1Xl6SQ9xYvwAAAIEArZ58uV8Cj4CbRi/Fe5JiZxEU7GWZRui9n7k8pCBVoV4gJ1OLDEGXYusbEu9QWYjRi7F9N91Sjzw09k8cDtpXrZ/F623NWVxnxIZ9k59kMhZD3BlBrbXv/5YUlnPH/+7EwcmP2h06FxEK4Zg48GATzsXuURDZ/1OpN/MLHSKtyJ8=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 3fdc4c6af3cf9605bc8399011fe6783ceac3d8ab",
+        "sha256": "SSHFP 3 2 b63d5f583bf1cabbb281b3a696771b2516f22e633356557de566e5d7e05d00a0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCoB6SFbcfcROGXvuhUrCfJnr0Zr1aU92M7tXzXdhqXmAT/UjGPww1m/g2aoqoAMJANa18+pTIq/gW2Q80YDhG0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 5d7825e0feca470bbebc2677b6f911ca0dcbcb29",
+        "sha256": "SSHFP 4 2 1546726e2154cbe24fd9fa23e1cb7fca585769dc788be8c8bd502af9b6a504fa"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFyXCK7NNLRKf5eGIVtiyDpXx7DHpLJ0/XoUk0WFzF59",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a5fb27b70d27f80bc556297d0537e724bbf56063",
+        "sha256": "SSHFP 1 2 e090c7f5e1850844186c6b6903fa9095a3821d9085456ec2e14a4fc37247b4aa"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBpOtNRerOup8tDFot/DPmMQ51h7SK/Py5y1Z2KwZNVrF0cEX+D/T0Kg65w3PxfGITxsaU2ohfXiFOZSwOeZ5iEXOawRm5ndR+6fDjsrqsj8HKmq6nExP2Prun1ea4ujyhsQgrVL0mf8G9e6KfySuMehsjhTO4xrZYjBxdmhegfVGNyQ+/87w0pPlf943/khkygLEErdRpju31dZkZNoSTKIdYh+3SvxMkDEd93BTWUuWbBymCP8OpInqwomeJgAhOqzn/KrUwthbspLZs/Uzd2v2hHM/xFSyhSHvgpIdY2dQZBDkGUbzmK5dk1k0SCfJ+/GrooeJyPhjP25sl0wJFvtKT6R29ZxPRDO85Gs9r5sbOz+LOzX95QqNJvtzEDchgiVZ+ihoJ8ikrHdZemoJ0PgNjYFKKp+5AosZ2vtbH4MrEoGt9bpBw+iTjMiytpWFfuxMn81SsqVJ+mCdgWfMyQC1OWUuygxCYomtXlQEWq/uXRM+k6UzU+a7kDcJm0M8=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 136,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.7/amazon-2-x86_64.facts
+++ b/facts/4.7/amazon-2-x86_64.facts
@@ -1,0 +1,257 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.7.1",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.7.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.34,
+    "5m": 0.64
+  },
+  "memory": {
+    "system": {
+      "available": "1.64 GiB",
+      "available_bytes": 1760538624,
+      "capacity": "15.21%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "301.20 MiB",
+      "used_bytes": 315826176
+    }
+  },
+  "mountpoints": {},
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 90,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/amazon-2-x86_64.facts
+++ b/facts/4.8/amazon-2-x86_64.facts
@@ -1,0 +1,263 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.8.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.8.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.34,
+    "5m": 0.64
+  },
+  "memory": {
+    "system": {
+      "available": "1.63 GiB",
+      "available_bytes": 1754779648,
+      "capacity": "15.49%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "306.69 MiB",
+      "used_bytes": 321585152
+    }
+  },
+  "mountpoints": {},
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 91,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/opensuse-15-x86_64.facts
+++ b/facts/4.8/opensuse-15-x86_64.facts
@@ -1,0 +1,481 @@
+{
+  "aio_agent_version": "8.10.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f82cad1-18aa0ba4",
+      "size": "42.00 GiB",
+      "size_bytes": 45097156608,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-e4d260f7-2d9d-44ab-a42b-5c083e9fcbc1",
+      "uuid": "f760d2e4-9d2d-ab44-a42b-5c083e9fcbc1",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.8.0",
+  "filesystems": "ext2,ext3,ext4",
+  "fips_enabled": false,
+  "gem_version": "~> 4.8.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.21-150400.24.60-default",
+  "kernelversion": "5.14.21",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.82,
+    "5m": 0.26
+  },
+  "memory": {
+    "system": {
+      "available": "702.16 MiB",
+      "available_bytes": 736264192,
+      "capacity": "27.06%",
+      "total": "962.70 MiB",
+      "total_bytes": 1009463296,
+      "used": "260.54 MiB",
+      "used_bytes": 273199104
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "37.43 GiB",
+      "available_bytes": 40186097664,
+      "capacity": "3.86%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "41.04 GiB",
+      "size_bytes": 44069601280,
+      "used": "1.50 GiB",
+      "used_bytes": 1611923456
+    },
+    "/dev": {
+      "available": "4.00 MiB",
+      "available_bytes": 4190208,
+      "capacity": "0.10%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=1048576",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "481.34 MiB",
+      "available_bytes": 504725504,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "481.35 MiB",
+      "size_bytes": 504729600,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/run": {
+      "available": "187.14 MiB",
+      "available_bytes": 196227072,
+      "capacity": "2.81%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "size=197164k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "192.54 MiB",
+      "size_bytes": 201895936,
+      "used": "5.41 MiB",
+      "used_bytes": 5668864
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.27 MiB",
+      "available_bytes": 100941824,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98580k",
+        "nr_inodes=24645",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "96.27 MiB",
+      "size_bytes": 100945920,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/sys/fs/cgroup": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "size=4096k",
+        "nr_inodes=1024",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "431.92 GiB",
+      "available_bytes": 463768154112,
+      "capacity": "52.84%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "483.89 GiB",
+      "used_bytes": 519576997888
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::bf30:22dc:342a:4dc9",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+              "temporary"
+            ]
+          },
+          {
+            "address": "fd00::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::bf30:22dc:342a:4dc9",
+        "mac": "08:00:27:7a:a2:d7",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::bf30:22dc:342a:4dc9",
+    "mac": "08:00:27:7a:a2:d7",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "openSUSE Leap 15.4",
+      "id": "SUSE",
+      "release": {
+        "full": "15.4",
+        "major": "15",
+        "minor": "4"
+      }
+    },
+    "family": "Suse",
+    "hardware": "x86_64",
+    "name": "openSUSE",
+    "release": {
+      "full": "15.4",
+      "major": "15",
+      "minor": "4"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "ROOT",
+      "mount": "/",
+      "partuuid": "f42329f8-01",
+      "size": "42.00 GiB",
+      "size_bytes": 45096108032,
+      "uuid": "30832e7a-e906-43bc-b445-247b91cb9e0e"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 fa6a59446c44186ae52f2c6434cdadc13cc4d87b",
+        "sha256": "SSHFP 2 2 3581fde41bb78a886f78215ff2612c4fa630edc2b8247294ec84bfd3badd08af"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAOHqZjSkv/ufdFSSvgGFrycROq8oII65NjjTPI9v6e3sTCL34bugS6zUmlELg3HHgTVb826UdXOg6VuoId+cPCtYBbKw7Dqecfd6+AQRQVAXbPSx13+lwBdiY9/lxZQbQVFJzs7N+shor+Vkmz3T7gEOYvVlSqV8ZOw+qK0sk5LBAAAAFQDvWtZVlWOanpnpmRAsxLHLcTVxhwAAAIA6uJGdcsgrTq42MQi4DH1mAtdYxTQwI1OM30+TG77EqkL3uqVAJufIIgYT3Q2PuV3qNgGatjIP7kVpnhZm6hRHCqPNucIy6tULaSa4nufeIxFW95OIwDZEzKJVNLFr/7KeeBPuw9DLKPxjSIteVtgpUqDYivQKwhs1Xl6SQ9xYvwAAAIEArZ58uV8Cj4CbRi/Fe5JiZxEU7GWZRui9n7k8pCBVoV4gJ1OLDEGXYusbEu9QWYjRi7F9N91Sjzw09k8cDtpXrZ/F623NWVxnxIZ9k59kMhZD3BlBrbXv/5YUlnPH/+7EwcmP2h06FxEK4Zg48GATzsXuURDZ/1OpN/MLHSKtyJ8=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 3fdc4c6af3cf9605bc8399011fe6783ceac3d8ab",
+        "sha256": "SSHFP 3 2 b63d5f583bf1cabbb281b3a696771b2516f22e633356557de566e5d7e05d00a0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCoB6SFbcfcROGXvuhUrCfJnr0Zr1aU92M7tXzXdhqXmAT/UjGPww1m/g2aoqoAMJANa18+pTIq/gW2Q80YDhG0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 5d7825e0feca470bbebc2677b6f911ca0dcbcb29",
+        "sha256": "SSHFP 4 2 1546726e2154cbe24fd9fa23e1cb7fca585769dc788be8c8bd502af9b6a504fa"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFyXCK7NNLRKf5eGIVtiyDpXx7DHpLJ0/XoUk0WFzF59",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a5fb27b70d27f80bc556297d0537e724bbf56063",
+        "sha256": "SSHFP 1 2 e090c7f5e1850844186c6b6903fa9095a3821d9085456ec2e14a4fc37247b4aa"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBpOtNRerOup8tDFot/DPmMQ51h7SK/Py5y1Z2KwZNVrF0cEX+D/T0Kg65w3PxfGITxsaU2ohfXiFOZSwOeZ5iEXOawRm5ndR+6fDjsrqsj8HKmq6nExP2Prun1ea4ujyhsQgrVL0mf8G9e6KfySuMehsjhTO4xrZYjBxdmhegfVGNyQ+/87w0pPlf943/khkygLEErdRpju31dZkZNoSTKIdYh+3SvxMkDEd93BTWUuWbBymCP8OpInqwomeJgAhOqzn/KrUwthbspLZs/Uzd2v2hHM/xFSyhSHvgpIdY2dQZBDkGUbzmK5dk1k0SCfJ+/GrooeJyPhjP25sl0wJFvtKT6R29ZxPRDO85Gs9r5sbOz+LOzX95QqNJvtzEDchgiVZ+ihoJ8ikrHdZemoJ0PgNjYFKKp+5AosZ2vtbH4MrEoGt9bpBw+iTjMiytpWFfuxMn81SsqVJ+mCdgWfMyQC1OWUuygxCYomtXlQEWq/uXRM+k6UzU+a7kDcJm0M8=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 138,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/windows-10-x86_64.facts
+++ b/facts/4.8/windows-10-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.8.1",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-0699f12e-1a6b-4a14-8f99-e6fabf380f80",
+      "uuid": "0699F12E-1A6B-4A14-8F99-E6FABF380F80"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.8.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.19045",
+  "kernelversion": "10.0.19045",
+  "memory": {
+    "system": {
+      "available": "1.66 GiB",
+      "available_bytes": 1779056640,
+      "capacity": "58.39%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "2.33 GiB",
+      "used_bytes": 2496716800
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::5ce8:7c62:3daf:521c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::c957:e844:529:1260",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::c957:e844:529:1260",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::fca9:4ad5:2331:5a96",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::5ce8:7c62:3daf:521c",
+        "mac": "08:00:27:41:A5:BB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::5ce8:7c62:3daf:521c",
+    "mac": "08:00:27:41:A5:BB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "10",
+      "major": "10"
+    },
+    "windows": {
+      "display_version": "22H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "22H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.8.1",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.4"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 1e6d6f5051ddb2bed3ba836c8beecb9e44dd3859",
+        "sha256": "SSHFP 2 2 8a32b8908fa1fd8d210f7715dd84e0a6a10145650b2a0ff6fc505d11ddb2beea"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBANxCGgsHCLb1HKFsQoDznyfMNvNM3uhXZ7DzyX4DkMFMEzvjb8hp0tg3V+Y3kQCzQbVTfJNFhp8Pa0yxOJ87iHO8f1xrhsT+3sk3kn4i3f+ombYm7oBFAg3A06hWpv/1P1pvvME1oZYXzzParVhmLjnliSu5pXqXE1AH8ix02tBNAAAAFQC0LBvWWRtvyFiMl8MqClt7bufrjQAAAIEAhcJVFBF3+rBwo3enZ3F38K+UB/Y4PkzbtaZGfIchWEcaTMpM6iewVXwQKxyI/+HnRPUuBMocjdlCSdsDXdidUdJOpe77HrbFMsRqbStZUG+iI+CfcxFbFiJk5DdP5zJiMikfSrfDwZz8WqSzxejloJB+kyKCf4tyVBAxrhj6QUAAAACAUfczVEEjzLNrXXb/LrxqNh1i1BV25pFztvrtLELLeNkSX47weU1jkyorbbRH4/zsfCyCslexcEVESr1BM++CGQ/h3BJQyNhUqNdPjT4zJXQliGCTIG299i6XiEBsnXuHhPoLYZkMI/4a1pxf43B/a1/N6CxLLscSwnal/JvkJFM=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 727d2ac3fa8fd4c1d9ad11bfb69e046887e6f002",
+        "sha256": "SSHFP 3 2 112f7cadb360eec726c95e5261e22ca85d4e6f323583f72bc2698c8d41f0aed0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHqrpTPvjMm3yNx5DQN4nGy9q3y0y3OvmySffb1fo35zhGNCHqBlq5VBF88N76+c2zXKsGkrKzfCkIoIZnFQhag=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 c29a0d2f14ec94061ce5a9837674f492e99db5b3",
+        "sha256": "SSHFP 4 2 c0b0ff427cf1a621871539b49a7ea04f7d0fa9adff8b0aa8c882957071e797ca"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIIBZtECISp2veFqOfSB0ovYrsKRu545I0RCbn+yEGa0h",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 cd9568a2b3a50416c6554c3538f2311157be7c5e",
+        "sha256": "SSHFP 1 2 01d88fff37df8f7dabb7427314f81179a67c0b68248b22647e53a359b47729b5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgJRy9zs5MmqA4FACZesRAOdvBE9u1+aWjL5QMC3ZHj9O2BG9FshrqIVKgMlmRQj4prnsiR3aSc/wKic3/sKr4Vh06QMkDLaxaaBtmt3gBxft+exeAxS15z0KtWOjvFC0v+Z2+qQ/UDMlSIJMS/3GtykX/5agAJGZ3Ftf9MQEvuIpAn1Yp4WbPwxOEWIu5PGNH+z5JANVDsSrg1vK8vmpoBBanxSwj7fcrnC6u/obzhb2hzX13Te/D6JkFcg2sB5u2zESzFasVlmJClDwRqEHlHVRcyexOuorL/5oNp1FzBvazZQZAyegptiQRwPJnWE3pjqAdruR485KxdAo3Bv1tjUpWUmIfSrYMpc2p4Ud7AaEz7j6B5nf9TRS05A6DH/Iqeg3IdxTFufle6Oqw7juKzVY8J4P24irgvPrgaYLoiIri282zy6v+5DQDhKp09ZVI4sqKvsFZHtYVwXFHGoUw/6gZELCcWeZ3L25kFZ2YI/L6HKGqtYjk0Wq5Km3iN/U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 1921,
+    "uptime": "0:32 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/windows-11-x86_64.facts
+++ b/facts/4.8/windows-11-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.8.1",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-02f503cd-4af5-4d3e-9f62-ed36f67b4e7c",
+      "uuid": "02F503CD-4AF5-4D3E-9F62-ED36F67B4E7C"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.8.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.26100",
+  "kernelversion": "10.0.26100",
+  "memory": {
+    "system": {
+      "available": "1.69 GiB",
+      "available_bytes": 1819742208,
+      "capacity": "57.44%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "2.29 GiB",
+      "used_bytes": 2456031232
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::b0fc:25f4:9c4:2410",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::7c4c:7ba5:25b4:fa86",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::7c4c:7ba5:25b4:fa86",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::8721:b67c:9c3d:b2ad",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::b0fc:25f4:9c4:2410",
+        "mac": "08:00:27:CA:30:DB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::b0fc:25f4:9c4:2410",
+    "mac": "08:00:27:CA:30:DB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "11",
+      "major": "11"
+    },
+    "windows": {
+      "display_version": "24H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "24H2",
+      "system32": "C:\\WINDOWS\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.8.1",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.4"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a267414bf6e283e1889f38fdd77561f36f914d39",
+        "sha256": "SSHFP 2 2 ada979fc12f1ecc17477b90cbd8c18e4b8efdff22bf9b2d1cab55f9ca98614c2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAPPqAjpZAWwdE5mu8clESdJ0hj+ryOMR8Qrp+hr+r4iNi96wWD9zQSwfQEuBtXC5XcHIUwTQkkOot7AYRUOjb+PQUL1qd2WH0lVSDbW1KzsBoEYRSLNCpZ4xHWk1s7kXq1q7/7DH3D+scUfyUL1GEbViWhbvRdMbepI5rKZsXddvAAAAFQDeThx3/D95fBnr/t7OaUd+yrDofQAAAIArIYUbKbe+iMS2PxSZsyTMUu3GgBKPKRVQXbXkrDHcnXd6h+omLi28oKG2ZsGqsTeEQZAiBSTXegPux4/TUijqrFj0pt+1mVi3yt4Na12MO6o6Ih7C6eWyEMIhJxVUggo+wHUao5T9gBZI9Ctb2BbxUEF93bwPezE/0SqLvDE7fgAAAIBNUb5Yn7AqSWpDQIe4DY9MhwX4o/yJKDih/hYzwf6A8IxMLAE6Bpooj5lJaeGZpp58YRc4peKZbMpI+13EHQFZ9g+2XPGTuHErm84kWUWZcTMUnKoguHevpd6QDRYOLfmconAnPqj2pgqPDEIIcn4yg2e169N8p25F+e291EMuMQ==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 89e1df9d9f782bbe165493fda627a8e20249c0c5",
+        "sha256": "SSHFP 3 2 d62c0863c095aef1fbcb3a5d8003ded2b913f6b553fe40600697226d9dd3c18a"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBEBFXijienEhKxpYzOl1gy8RKSNwgoXlvYhaKRdjO6XZTkJB/xrR/VbF5c67Ip5uvL4oBlM9B6Tay5rmRsFTDk=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 bac125c932a8bb9599740b06648ac4dfd4324399",
+        "sha256": "SSHFP 4 2 6c8a4ed535c1441501516c138b7bb06993fce4efed44046694aa21ff31ae401a"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHiGHFfFuX3y+Be8CKlgAV6SkaHTfcNg5V/UtjDBkHsh",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 af2300ce3b8646c9b3a499e76b5d47342fc85129",
+        "sha256": "SSHFP 1 2 d818a35474be56648bb48ae362a63fdbef244f24ce468d4b216bf001e06bea5d"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDHIijLrDgiEzrAakvAcOUS8ZWb4KOmOJGcSaUPTAAwpYQAmqh1Et1mO0Yr1sXNnPGnI38QFLHeDKNmdvQu7zxhQV3zD7ehJEgRAbetMim/2S8JVUmVpxCiHDD60Vcw5ip/NUTWddTeLrwhAK8z0RKOPi/HZmtNsKHxvmWBM8kIUz5DRnFPWkUWFbmB5tDqIIiGUx4khe1tJKGElZQuuTFGZZGDpX593uNQN9u8TBqf3TJCaSs+LNjQd0A8Z+LgSKerGlMF/UlQccreHkFgN8RRTOp161jLpjdTBqUVWXlF2ih57lQyRCi/iU/JfE33yh68wTlhCww7PR1XLmMRHr1cxoqpSY8a+undPnBCiXgzfw2QrHG0Yq+qyKvjGdSL7rN/3M3Jz4B6SDnAVbJSj6Z4mncMlt9/VIC+jPliV7JLZixGIxKf73SSkihIifHxjYHySK/g6ZFlpbK2EdmX0tRaYjYolvopVmHaKooZrkC/UwUv2h4LLxDrCfyvTZdDo1s=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 317,
+    "uptime": "0:05 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.8/windows-2022-x86_64.facts
+++ b/facts/4.8/windows-2022-x86_64.facts
@@ -1,0 +1,168 @@
+{
+  "aio_agent_version": "8.8.1",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-8afd7ad4-bfe9-4f5a-8d30-93c42b25907d",
+      "uuid": "8AFD7AD4-BFE9-4F5A-8D30-93C42B25907D"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.8.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.20348",
+  "kernelversion": "10.0.20348",
+  "memory": {
+    "system": {
+      "available": "671.70 MiB",
+      "available_bytes": 704331776,
+      "capacity": "66.91%",
+      "total": "1.98 GiB",
+      "total_bytes": 2128289792,
+      "used": "1.33 GiB",
+      "used_bytes": 1423958016
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::46ab:507:687:5b80",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::aff:b25e:a03e:f84f",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::46ab:507:687:5b80",
+        "mac": "08:00:27:07:2A:6E",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::46ab:507:687:5b80",
+    "mac": "08:00:27:07:2A:6E",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2022",
+      "major": "2022"
+    },
+    "windows": {
+      "display_version": "21H2",
+      "edition_id": "ServerStandardEval",
+      "installation_type": "Server Core",
+      "product_name": "Windows Server 2022 Standard Evaluation",
+      "release_id": "21H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.8.1",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.4"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a8d082d65ba073f4b588ca1532b2afff564655a5",
+        "sha256": "SSHFP 2 2 d58da160af2402446a90fefa3406636720cd41086332826939d95c9e3093b052"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAKKFEAtK0bNFrprCzPCwDTRR9kTrsuVgGhfWHH/z6cDb2MW3MiZR7FwPAMjyF8uDkOmujzx4v+T6OzqgjEm3d/AIbaBY7Ngk19RMGd6DcP6jj6356p1yQmZP/YRinSfYM6I6sYmjPopjREh7oCSw+mAtbpa6o0GZcwf8xyGU2CGvAAAAFQDSzyN8rO7yngMTJnsc5judSNv6nQAAAIAH7xfPEkE7jMV/BuVdmCsMfmHpI+KiKnyp+JjRBgz13FxfvWUu+tbCP6xJ2yeECKjk1oFfT/bsrKm0ChkZ7HssYRKcQW9CvcH6Z5ttRx9Oqm8PCM0kJpSxWm5a5dFPiHMdBCRIvJNksW7BPLCkuj/D+XzHCaDCDECzXELksPpspQAAAIBsV6OxseQ22u+48sDJJj1Jwl72cFtcxoZ7dFs/q78/xxeKHIRjNzTiaMqhBPY4V+2Sm6Zzgu2wJOQXYkEkq5F8X3BeTB0+xFkGPUXa/VexXJD71/Mc2uq0b24Z4ZqyqJfigp3PM6GzWuOUC14aS56t++ddGG690sPW1PhebPdgrw==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 92c1a6d77ee3c13a54441b60a59a646f505f1309",
+        "sha256": "SSHFP 3 2 6630092ecc8589ad778944e3d203de842348b151e0dd3a0457533701a7fbb383"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJuKojHoqRInzDL4edrdYI7gbbBrhj/oSptoChw4Y62/9id2Li73+6MEPc5RjnY+d5bBu0zUBUN5bSIEa0EaRI4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 baaf376fcd4d0e07122280476eb61443fd17ab7f",
+        "sha256": "SSHFP 4 2 435cfd5fe8021a37548cc0e595c56c72de2c705f84992413f686c97de282d844"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKRQrcC/RFnVsJO8EI0Y0okEa6cfasfwaDYNXsRKlmb6",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 959d4674df454c8659a7da15a806b1892c784ce5",
+        "sha256": "SSHFP 1 2 95c4ce016dae223545270157b40fdb6e1d3b854464460637ba3e707316ec3c33"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gpkm190gP0gU8pD15mzIRdZl22QzkOUMnODF53qcYOgprQG4xni+1IGXZUrt2JoTbFG5yj0IVz6lZ+BOuk55vZ+WStIHMvVgAwxahelwaEHbbC0F7hAqfuPtUaqGSrjvGjRlGUEMZD/TTI/3jcvhb6ps31YsWHdhqRwo7nUPAWLVwpmX9EI1XENnwj38BD9jdLbhiXqJZMNyGmbivLwoQYUPZrtNGmO44Hfxx0rZqoXk5uexp/XR7r3qM3M4aa62zQKsDLDnfjwidkIbkUNTZgc1zC4tDQfd0zfa2LDiiawKCXBs18MhzcZJ581VCgs/D8Oa+PPOs3f4Ecl93HKd8bHiJ16ZBdBvcDFa9nZTQgQqyGZa72TyxXjwsyHHIOQ8wsAScjAufnBNoVFUugjgIhF9cuo/AfcMPGhUAgw2tlD6jT5QJyYOg7YG87qGKzU4XYeVQMnLgE1esoDkSA+IWmIX0rbDFoOi7ex8qComb7Z+HCldm7uIu5lgWE3zxwE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 154,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/amazon-2-x86_64.facts
+++ b/facts/4.9/amazon-2-x86_64.facts
@@ -1,0 +1,265 @@
+{
+  "aio_agent_version": "8.12.1",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VBb9e5a750-6988346e",
+      "size": "25.00 GiB",
+      "size_bytes": 26843545600,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "0",
+      "uuid": "AE0C2099-5AB6-F946-9339-3F778AA14C51",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.9.0",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "gem_version": "~> 4.9.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.14",
+  "kernelrelease": "4.14.314-237.533.amzn2.x86_64",
+  "kernelversion": "4.14.314",
+  "load_averages": {
+    "15m": 0.24,
+    "1m": 1.34,
+    "5m": 0.64
+  },
+  "memory": {
+    "system": {
+      "available": "1.63 GiB",
+      "available_bytes": 1754329088,
+      "capacity": "15.51%",
+      "total": "1.93 GiB",
+      "total_bytes": 2076364800,
+      "used": "307.12 MiB",
+      "used_bytes": 322035712
+    }
+  },
+  "mountpoints": {},
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fea6:b56c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::a00:27ff:fea6:b56c",
+        "mac": "08:00:27:a6:b5:6c",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::a00:27ff:fea6:b56c",
+    "mac": "08:00:27:a6:b5:6c",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Karoo",
+      "description": "Amazon Linux release 2 (Karoo)",
+      "id": "Amazon",
+      "release": {
+        "full": "2",
+        "major": "2"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "Amazon",
+    "release": {
+      "full": "2",
+      "major": "2"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "xfs",
+      "label": "/",
+      "partlabel": "Linux",
+      "parttype": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+      "partuuid": "75b4352e-e52a-45b8-8f48-41b67d22c88a",
+      "size": "25.00 GiB",
+      "size_bytes": 26841431552,
+      "uuid": "4760f23c-fe8b-4a31-a741-8867c2600105"
+    },
+    "/dev/sda128": {
+      "partlabel": "BIOS Boot Partition",
+      "parttype": "21686148-6449-6e6f-744e-656564454649",
+      "partuuid": "6f098d92-678b-4e34-8361-daa42f96fbea",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K",
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.7"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 03ad6a8c0b981b4f59de3fb89d1b497480d966d0",
+        "sha256": "SSHFP 3 2 54f274ff5a2eb0a8e513cae59e9bc4f99ebfc8d2a37bba380510cc2753e19ed5"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQF03MxXCxVhMvHtFahoGc+axzZuv4oBVH6oqBMN9KfFGnba3W/VO3hRXrcaGO57SRBCS3yPk0g9nTPEVAeWAY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 e4eea94029d3ad5298b473976ae27da3f423b5bb",
+        "sha256": "SSHFP 4 2 366e6e86cfd04d0286af7c563aecb7d2b3717f22127a92cbfc86726168ca90bd"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKx4qPydq2r2jT7EZEAJAGdk8t8Uqwt27WMLyccKvGRD",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 b6f1bf491e53a718ce84545b4f30388820a4aa81",
+        "sha256": "SSHFP 1 2 a7f1152651242ce53ce8ba0c9958a010da8e96d98efb06faf03d95dfc94390ea"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQCkzZvIwVlc2g5luIq8yobqEU9dRNVLdxK0h3gLMUcmtIjxkr6bEdszb+39NbAQTcdVuaWGGa6vm12GgIKJhlDJZedLC7a0hPRs7/nzAd7YYpmiletvifx1MQPI1VYVWfUVAZLD4V93Rhk5jQOEgfcZk1k3WTSz3Ngemjgf2faQ6OZheMzKgudmscJQPA9STcDHqMnEtG21iMaDhNYXOC8ggo2jADeQ539jq76agwLoug2nx8G2I+oT1+us6hCN20neTlLhqHH2PDgvXeFRYzgp1go8cZeQ+B/bWxKIF+fz00z1FhvgegaMcnvuTEmmBUmFhUq8tiqDytb/W04W/aQ5",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 93,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/opensuse-15-x86_64.facts
+++ b/facts/4.9/opensuse-15-x86_64.facts
@@ -1,0 +1,482 @@
+{
+  "aio_agent_version": "8.10.0",
+  "augeas": {
+    "version": "1.14.1"
+  },
+  "disks": {
+    "sda": {
+      "model": "VBOX HARDDISK",
+      "serial": "VB4f82cad1-18aa0ba4",
+      "size": "42.00 GiB",
+      "size_bytes": 45097156608,
+      "type": "hdd",
+      "vendor": "ATA"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "12/01/2006",
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox"
+    },
+    "board": {
+      "manufacturer": "Oracle Corporation",
+      "product": "VirtualBox",
+      "serial_number": "0"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-e4d260f7-2d9d-44ab-a42b-5c083e9fcbc1",
+      "uuid": "f760d2e4-9d2d-ab44-a42b-5c083e9fcbc1",
+      "version": "1.2"
+    }
+  },
+  "facterversion": "4.9.0",
+  "filesystems": "ext2,ext3,ext4",
+  "fips_enabled": false,
+  "gem_version": "~> 4.9.0",
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "5.14",
+  "kernelrelease": "5.14.21-150400.24.60-default",
+  "kernelversion": "5.14.21",
+  "load_averages": {
+    "15m": 0.1,
+    "1m": 0.82,
+    "5m": 0.26
+  },
+  "memory": {
+    "system": {
+      "available": "701.14 MiB",
+      "available_bytes": 735199232,
+      "capacity": "27.17%",
+      "total": "962.70 MiB",
+      "total_bytes": 1009463296,
+      "used": "261.56 MiB",
+      "used_bytes": 274264064
+    }
+  },
+  "mountpoints": {
+    "/": {
+      "available": "37.42 GiB",
+      "available_bytes": 40181022720,
+      "capacity": "3.87%",
+      "device": "/dev/sda1",
+      "filesystem": "ext4",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "41.04 GiB",
+      "size_bytes": 44069601280,
+      "used": "1.51 GiB",
+      "used_bytes": 1616998400
+    },
+    "/dev": {
+      "available": "3.99 MiB",
+      "available_bytes": 4186112,
+      "capacity": "0.20%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "size=4096k",
+        "nr_inodes=1048576",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "8.00 KiB",
+      "used_bytes": 8192
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "481.34 MiB",
+      "available_bytes": 504725504,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "inode64"
+      ],
+      "size": "481.35 MiB",
+      "size_bytes": 504729600,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/run": {
+      "available": "187.14 MiB",
+      "available_bytes": 196227072,
+      "capacity": "2.81%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "size=197164k",
+        "nr_inodes=819200",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "192.54 MiB",
+      "size_bytes": 201895936,
+      "used": "5.41 MiB",
+      "used_bytes": 5668864
+    },
+    "/run/credentials/systemd-sysusers.service": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "none",
+      "filesystem": "ramfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "mode=700"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run/user/1000": {
+      "available": "96.27 MiB",
+      "available_bytes": 100941824,
+      "capacity": "0.00%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=98580k",
+        "nr_inodes=24645",
+        "mode=700",
+        "uid=1000",
+        "gid=1000",
+        "inode64"
+      ],
+      "size": "96.27 MiB",
+      "size_bytes": 100945920,
+      "used": "4.00 KiB",
+      "used_bytes": 4096
+    },
+    "/sys/fs/cgroup": {
+      "available": "4.00 MiB",
+      "available_bytes": 4194304,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "size=4096k",
+        "nr_inodes=1024",
+        "mode=755",
+        "inode64"
+      ],
+      "size": "4.00 MiB",
+      "size_bytes": 4194304,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "431.92 GiB",
+      "available_bytes": 463768137728,
+      "capacity": "52.84%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "iocharset=utf8",
+        "uid=1000",
+        "gid=1000"
+      ],
+      "size": "915.81 GiB",
+      "size_bytes": 983345152000,
+      "used": "483.89 GiB",
+      "used_bytes": 519577014272
+    }
+  },
+  "networking": {
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::bf30:22dc:342a:4dc9",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": [
+              "temporary"
+            ]
+          },
+          {
+            "address": "fd00::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global",
+            "flags": []
+          },
+          {
+            "address": "fe80::a00:27ff:fe7a:a2d7",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "duplex": "full",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::bf30:22dc:342a:4dc9",
+        "mac": "08:00:27:7a:a2:d7",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "operational_state": "up",
+        "physical": true,
+        "scope6": "global",
+        "speed": 1000
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "operational_state": "unknown",
+        "physical": false,
+        "scope6": "host"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::bf30:22dc:342a:4dc9",
+    "mac": "08:00:27:7a:a2:d7",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "eth0",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "n/a",
+      "description": "openSUSE Leap 15.4",
+      "id": "SUSE",
+      "release": {
+        "full": "15.4",
+        "major": "15",
+        "minor": "4"
+      }
+    },
+    "family": "Suse",
+    "hardware": "x86_64",
+    "name": "openSUSE",
+    "release": {
+      "full": "15.4",
+      "major": "15",
+      "minor": "4"
+    },
+    "selinux": {
+      "enabled": false
+    }
+  },
+  "partitions": {
+    "/dev/sda1": {
+      "filesystem": "ext4",
+      "label": "ROOT",
+      "mount": "/",
+      "parttype": "0x83",
+      "partuuid": "f42329f8-01",
+      "size": "42.00 GiB",
+      "size_bytes": 45096108032,
+      "uuid": "30832e7a-e906-43bc-b445-247b91cb9e0e"
+    }
+  },
+  "path": "/home/vagrant/vendor/bundler/ruby/3.2.0/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "extensions": [
+      "x86_64",
+      "x86_64-v1",
+      "x86_64-v2",
+      "x86_64-v3"
+    ],
+    "isa": "x86_64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "speed": "3.19 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 fa6a59446c44186ae52f2c6434cdadc13cc4d87b",
+        "sha256": "SSHFP 2 2 3581fde41bb78a886f78215ff2612c4fa630edc2b8247294ec84bfd3badd08af"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAOHqZjSkv/ufdFSSvgGFrycROq8oII65NjjTPI9v6e3sTCL34bugS6zUmlELg3HHgTVb826UdXOg6VuoId+cPCtYBbKw7Dqecfd6+AQRQVAXbPSx13+lwBdiY9/lxZQbQVFJzs7N+shor+Vkmz3T7gEOYvVlSqV8ZOw+qK0sk5LBAAAAFQDvWtZVlWOanpnpmRAsxLHLcTVxhwAAAIA6uJGdcsgrTq42MQi4DH1mAtdYxTQwI1OM30+TG77EqkL3uqVAJufIIgYT3Q2PuV3qNgGatjIP7kVpnhZm6hRHCqPNucIy6tULaSa4nufeIxFW95OIwDZEzKJVNLFr/7KeeBPuw9DLKPxjSIteVtgpUqDYivQKwhs1Xl6SQ9xYvwAAAIEArZ58uV8Cj4CbRi/Fe5JiZxEU7GWZRui9n7k8pCBVoV4gJ1OLDEGXYusbEu9QWYjRi7F9N91Sjzw09k8cDtpXrZ/F623NWVxnxIZ9k59kMhZD3BlBrbXv/5YUlnPH/+7EwcmP2h06FxEK4Zg48GATzsXuURDZ/1OpN/MLHSKtyJ8=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 3fdc4c6af3cf9605bc8399011fe6783ceac3d8ab",
+        "sha256": "SSHFP 3 2 b63d5f583bf1cabbb281b3a696771b2516f22e633356557de566e5d7e05d00a0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCoB6SFbcfcROGXvuhUrCfJnr0Zr1aU92M7tXzXdhqXmAT/UjGPww1m/g2aoqoAMJANa18+pTIq/gW2Q80YDhG0=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 5d7825e0feca470bbebc2677b6f911ca0dcbcb29",
+        "sha256": "SSHFP 4 2 1546726e2154cbe24fd9fa23e1cb7fca585769dc788be8c8bd502af9b6a504fa"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFyXCK7NNLRKf5eGIVtiyDpXx7DHpLJ0/XoUk0WFzF59",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 a5fb27b70d27f80bc556297d0537e724bbf56063",
+        "sha256": "SSHFP 1 2 e090c7f5e1850844186c6b6903fa9095a3821d9085456ec2e14a4fc37247b4aa"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDBpOtNRerOup8tDFot/DPmMQ51h7SK/Py5y1Z2KwZNVrF0cEX+D/T0Kg65w3PxfGITxsaU2ohfXiFOZSwOeZ5iEXOawRm5ndR+6fDjsrqsj8HKmq6nExP2Prun1ea4ujyhsQgrVL0mf8G9e6KfySuMehsjhTO4xrZYjBxdmhegfVGNyQ+/87w0pPlf943/khkygLEErdRpju31dZkZNoSTKIdYh+3SvxMkDEd93BTWUuWbBymCP8OpInqwomeJgAhOqzn/KrUwthbspLZs/Uzd2v2hHM/xFSyhSHvgpIdY2dQZBDkGUbzmK5dk1k0SCfJ+/GrooeJyPhjP25sl0wJFvtKT6R29ZxPRDO85Gs9r5sbOz+LOzX95QqNJvtzEDchgiVZ+ihoJ8ikrHdZemoJ0PgNjYFKKp+5AosZ2vtbH4MrEoGt9bpBw+iTjMiytpWFfuxMn81SsqVJ+mCdgWfMyQC1OWUuygxCYomtXlQEWq/uXRM+k6UzU+a7kDcJm0M8=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 139,
+    "uptime": "0:02 hours"
+  },
+  "timezone": "UTC",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/windows-10-x86_64.facts
+++ b/facts/4.9/windows-10-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.9.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-0699f12e-1a6b-4a14-8f99-e6fabf380f80",
+      "uuid": "0699F12E-1A6B-4A14-8F99-E6FABF380F80"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.9.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.19045",
+  "kernelversion": "10.0.19045",
+  "memory": {
+    "system": {
+      "available": "1.48 GiB",
+      "available_bytes": 1589125120,
+      "capacity": "62.83%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "2.50 GiB",
+      "used_bytes": 2686648320
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::5ce8:7c62:3daf:521c",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::c957:e844:529:1260",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::c957:e844:529:1260",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::fca9:4ad5:2331:5a96",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::5ce8:7c62:3daf:521c",
+        "mac": "08:00:27:41:A5:BB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::5ce8:7c62:3daf:521c",
+    "mac": "08:00:27:41:A5:BB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "10",
+      "major": "10"
+    },
+    "windows": {
+      "display_version": "22H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "22H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.9.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 1e6d6f5051ddb2bed3ba836c8beecb9e44dd3859",
+        "sha256": "SSHFP 2 2 8a32b8908fa1fd8d210f7715dd84e0a6a10145650b2a0ff6fc505d11ddb2beea"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBANxCGgsHCLb1HKFsQoDznyfMNvNM3uhXZ7DzyX4DkMFMEzvjb8hp0tg3V+Y3kQCzQbVTfJNFhp8Pa0yxOJ87iHO8f1xrhsT+3sk3kn4i3f+ombYm7oBFAg3A06hWpv/1P1pvvME1oZYXzzParVhmLjnliSu5pXqXE1AH8ix02tBNAAAAFQC0LBvWWRtvyFiMl8MqClt7bufrjQAAAIEAhcJVFBF3+rBwo3enZ3F38K+UB/Y4PkzbtaZGfIchWEcaTMpM6iewVXwQKxyI/+HnRPUuBMocjdlCSdsDXdidUdJOpe77HrbFMsRqbStZUG+iI+CfcxFbFiJk5DdP5zJiMikfSrfDwZz8WqSzxejloJB+kyKCf4tyVBAxrhj6QUAAAACAUfczVEEjzLNrXXb/LrxqNh1i1BV25pFztvrtLELLeNkSX47weU1jkyorbbRH4/zsfCyCslexcEVESr1BM++CGQ/h3BJQyNhUqNdPjT4zJXQliGCTIG299i6XiEBsnXuHhPoLYZkMI/4a1pxf43B/a1/N6CxLLscSwnal/JvkJFM=",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 727d2ac3fa8fd4c1d9ad11bfb69e046887e6f002",
+        "sha256": "SSHFP 3 2 112f7cadb360eec726c95e5261e22ca85d4e6f323583f72bc2698c8d41f0aed0"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHqrpTPvjMm3yNx5DQN4nGy9q3y0y3OvmySffb1fo35zhGNCHqBlq5VBF88N76+c2zXKsGkrKzfCkIoIZnFQhag=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 c29a0d2f14ec94061ce5a9837674f492e99db5b3",
+        "sha256": "SSHFP 4 2 c0b0ff427cf1a621871539b49a7ea04f7d0fa9adff8b0aa8c882957071e797ca"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIIBZtECISp2veFqOfSB0ovYrsKRu545I0RCbn+yEGa0h",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 cd9568a2b3a50416c6554c3538f2311157be7c5e",
+        "sha256": "SSHFP 1 2 01d88fff37df8f7dabb7427314f81179a67c0b68248b22647e53a359b47729b5"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQCgJRy9zs5MmqA4FACZesRAOdvBE9u1+aWjL5QMC3ZHj9O2BG9FshrqIVKgMlmRQj4prnsiR3aSc/wKic3/sKr4Vh06QMkDLaxaaBtmt3gBxft+exeAxS15z0KtWOjvFC0v+Z2+qQ/UDMlSIJMS/3GtykX/5agAJGZ3Ftf9MQEvuIpAn1Yp4WbPwxOEWIu5PGNH+z5JANVDsSrg1vK8vmpoBBanxSwj7fcrnC6u/obzhb2hzX13Te/D6JkFcg2sB5u2zESzFasVlmJClDwRqEHlHVRcyexOuorL/5oNp1FzBvazZQZAyegptiQRwPJnWE3pjqAdruR485KxdAo3Bv1tjUpWUmIfSrYMpc2p4Ud7AaEz7j6B5nf9TRS05A6DH/Iqeg3IdxTFufle6Oqw7juKzVY8J4P24irgvPrgaYLoiIri282zy6v+5DQDhKp09ZVI4sqKvsFZHtYVwXFHGoUw/6gZELCcWeZ3L25kFZ2YI/L6HKGqtYjk0Wq5Km3iN/U=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 1865,
+    "uptime": "0:31 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/windows-11-x86_64.facts
+++ b/facts/4.9/windows-11-x86_64.facts
@@ -1,0 +1,174 @@
+{
+  "aio_agent_version": "8.9.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-02f503cd-4af5-4d3e-9f62-ed36f67b4e7c",
+      "uuid": "02F503CD-4AF5-4D3E-9F62-ED36F67B4E7C"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.9.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.26100",
+  "kernelversion": "10.0.26100",
+  "memory": {
+    "system": {
+      "available": "2.04 GiB",
+      "available_bytes": 2194128896,
+      "capacity": "48.68%",
+      "total": "3.98 GiB",
+      "total_bytes": 4275773440,
+      "used": "1.94 GiB",
+      "used_bytes": 2081644544
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::b0fc:25f4:9c4:2410",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fd00::7c4c:7ba5:25b4:fa86",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fd00::7c4c:7ba5:25b4:fa86",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::8721:b67c:9c3d:b2ad",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::b0fc:25f4:9c4:2410",
+        "mac": "08:00:27:CA:30:DB",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::b0fc:25f4:9c4:2410",
+    "mac": "08:00:27:CA:30:DB",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "11",
+      "major": "11"
+    },
+    "windows": {
+      "display_version": "24H2",
+      "edition_id": "EnterpriseEval",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Enterprise Evaluation",
+      "release_id": "24H2",
+      "system32": "C:\\WINDOWS\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.9.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a267414bf6e283e1889f38fdd77561f36f914d39",
+        "sha256": "SSHFP 2 2 ada979fc12f1ecc17477b90cbd8c18e4b8efdff22bf9b2d1cab55f9ca98614c2"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAPPqAjpZAWwdE5mu8clESdJ0hj+ryOMR8Qrp+hr+r4iNi96wWD9zQSwfQEuBtXC5XcHIUwTQkkOot7AYRUOjb+PQUL1qd2WH0lVSDbW1KzsBoEYRSLNCpZ4xHWk1s7kXq1q7/7DH3D+scUfyUL1GEbViWhbvRdMbepI5rKZsXddvAAAAFQDeThx3/D95fBnr/t7OaUd+yrDofQAAAIArIYUbKbe+iMS2PxSZsyTMUu3GgBKPKRVQXbXkrDHcnXd6h+omLi28oKG2ZsGqsTeEQZAiBSTXegPux4/TUijqrFj0pt+1mVi3yt4Na12MO6o6Ih7C6eWyEMIhJxVUggo+wHUao5T9gBZI9Ctb2BbxUEF93bwPezE/0SqLvDE7fgAAAIBNUb5Yn7AqSWpDQIe4DY9MhwX4o/yJKDih/hYzwf6A8IxMLAE6Bpooj5lJaeGZpp58YRc4peKZbMpI+13EHQFZ9g+2XPGTuHErm84kWUWZcTMUnKoguHevpd6QDRYOLfmconAnPqj2pgqPDEIIcn4yg2e169N8p25F+e291EMuMQ==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 89e1df9d9f782bbe165493fda627a8e20249c0c5",
+        "sha256": "SSHFP 3 2 d62c0863c095aef1fbcb3a5d8003ded2b913f6b553fe40600697226d9dd3c18a"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBEBFXijienEhKxpYzOl1gy8RKSNwgoXlvYhaKRdjO6XZTkJB/xrR/VbF5c67Ip5uvL4oBlM9B6Tay5rmRsFTDk=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 bac125c932a8bb9599740b06648ac4dfd4324399",
+        "sha256": "SSHFP 4 2 6c8a4ed535c1441501516c138b7bb06993fce4efed44046694aa21ff31ae401a"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIHiGHFfFuX3y+Be8CKlgAV6SkaHTfcNg5V/UtjDBkHsh",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 af2300ce3b8646c9b3a499e76b5d47342fc85129",
+        "sha256": "SSHFP 1 2 d818a35474be56648bb48ae362a63fdbef244f24ce468d4b216bf001e06bea5d"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDHIijLrDgiEzrAakvAcOUS8ZWb4KOmOJGcSaUPTAAwpYQAmqh1Et1mO0Yr1sXNnPGnI38QFLHeDKNmdvQu7zxhQV3zD7ehJEgRAbetMim/2S8JVUmVpxCiHDD60Vcw5ip/NUTWddTeLrwhAK8z0RKOPi/HZmtNsKHxvmWBM8kIUz5DRnFPWkUWFbmB5tDqIIiGUx4khe1tJKGElZQuuTFGZZGDpX593uNQN9u8TBqf3TJCaSs+LNjQd0A8Z+LgSKerGlMF/UlQccreHkFgN8RRTOp161jLpjdTBqUVWXlF2ih57lQyRCi/iU/JfE33yh68wTlhCww7PR1XLmMRHr1cxoqpSY8a+undPnBCiXgzfw2QrHG0Yq+qyKvjGdSL7rN/3M3Jz4B6SDnAVbJSj6Z4mncMlt9/VIC+jPliV7JLZixGIxKf73SSkihIifHxjYHySK/g6ZFlpbK2EdmX0tRaYjYolvopVmHaKooZrkC/UwUv2h4LLxDrCfyvTZdDo1s=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 221,
+    "uptime": "0:03 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/4.9/windows-2022-x86_64.facts
+++ b/facts/4.9/windows-2022-x86_64.facts
@@ -1,0 +1,168 @@
+{
+  "aio_agent_version": "8.9.0",
+  "dmi": {
+    "manufacturer": "innotek GmbH",
+    "product": {
+      "name": "VirtualBox",
+      "serial_number": "VirtualBox-8afd7ad4-bfe9-4f5a-8d30-93c42b25907d",
+      "uuid": "8AFD7AD4-BFE9-4F5A-8D30-93C42B25907D"
+    }
+  },
+  "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
+  "facterversion": "4.9.0",
+  "fips_enabled": false,
+  "hypervisors": {
+    "virtualbox": {
+      "revision": "167084",
+      "version": "7.1.6"
+    }
+  },
+  "identity": {
+    "privileged": true,
+    "user": "FOO\\vagrant"
+  },
+  "is_virtual": true,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.20348",
+  "kernelversion": "10.0.20348",
+  "memory": {
+    "system": {
+      "available": "671.30 MiB",
+      "available_bytes": 703913984,
+      "capacity": "66.93%",
+      "total": "1.98 GiB",
+      "total_bytes": 2128289792,
+      "used": "1.33 GiB",
+      "used_bytes": 1424375808
+    }
+  },
+  "networking": {
+    "dhcp": "10.0.2.2",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
+    "hostname": "foo",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "10.0.2.15",
+            "netmask": "255.255.255.0",
+            "network": "10.0.2.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fd00::46ab:507:687:5b80",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fd00::",
+            "scope6": "global"
+          },
+          {
+            "address": "fe80::aff:b25e:a03e:f84f",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "dhcp": "10.0.2.2",
+        "ip": "10.0.2.15",
+        "ip6": "fd00::46ab:507:687:5b80",
+        "mac": "08:00:27:07:2A:6E",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "10.0.2.0",
+        "network6": "fd00::",
+        "scope6": "global"
+      }
+    },
+    "ip": "10.0.2.15",
+    "ip6": "fd00::46ab:507:687:5b80",
+    "mac": "08:00:27:07:2A:6E",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "10.0.2.0",
+    "network6": "fd00::",
+    "primary": "Ethernet",
+    "scope6": "global"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2022",
+      "major": "2022"
+    },
+    "windows": {
+      "display_version": "21H2",
+      "edition_id": "ServerStandardEval",
+      "installation_type": "Server Core",
+      "product_name": "Windows Server 2022 Standard Evaluation",
+      "release_id": "21H2",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\OpenSSH-Win64;C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps",
+  "processors": {
+    "cores": 2,
+    "count": 2,
+    "isa": "x64",
+    "models": [
+      "12th Gen Intel(R) Core(TM) i9-12900K"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "puppetversion": "8.9.0",
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/3.2.0",
+    "version": "3.2.5"
+  },
+  "ssh": {
+    "dsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 2 1 a8d082d65ba073f4b588ca1532b2afff564655a5",
+        "sha256": "SSHFP 2 2 d58da160af2402446a90fefa3406636720cd41086332826939d95c9e3093b052"
+      },
+      "key": "AAAAB3NzaC1kc3MAAACBAKKFEAtK0bNFrprCzPCwDTRR9kTrsuVgGhfWHH/z6cDb2MW3MiZR7FwPAMjyF8uDkOmujzx4v+T6OzqgjEm3d/AIbaBY7Ngk19RMGd6DcP6jj6356p1yQmZP/YRinSfYM6I6sYmjPopjREh7oCSw+mAtbpa6o0GZcwf8xyGU2CGvAAAAFQDSzyN8rO7yngMTJnsc5judSNv6nQAAAIAH7xfPEkE7jMV/BuVdmCsMfmHpI+KiKnyp+JjRBgz13FxfvWUu+tbCP6xJ2yeECKjk1oFfT/bsrKm0ChkZ7HssYRKcQW9CvcH6Z5ttRx9Oqm8PCM0kJpSxWm5a5dFPiHMdBCRIvJNksW7BPLCkuj/D+XzHCaDCDECzXELksPpspQAAAIBsV6OxseQ22u+48sDJJj1Jwl72cFtcxoZ7dFs/q78/xxeKHIRjNzTiaMqhBPY4V+2Sm6Zzgu2wJOQXYkEkq5F8X3BeTB0+xFkGPUXa/VexXJD71/Mc2uq0b24Z4ZqyqJfigp3PM6GzWuOUC14aS56t++ddGG690sPW1PhebPdgrw==",
+      "type": "ssh-dss"
+    },
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 92c1a6d77ee3c13a54441b60a59a646f505f1309",
+        "sha256": "SSHFP 3 2 6630092ecc8589ad778944e3d203de842348b151e0dd3a0457533701a7fbb383"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJuKojHoqRInzDL4edrdYI7gbbBrhj/oSptoChw4Y62/9id2Li73+6MEPc5RjnY+d5bBu0zUBUN5bSIEa0EaRI4=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 baaf376fcd4d0e07122280476eb61443fd17ab7f",
+        "sha256": "SSHFP 4 2 435cfd5fe8021a37548cc0e595c56c72de2c705f84992413f686c97de282d844"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIKRQrcC/RFnVsJO8EI0Y0okEa6cfasfwaDYNXsRKlmb6",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 959d4674df454c8659a7da15a806b1892c784ce5",
+        "sha256": "SSHFP 1 2 95c4ce016dae223545270157b40fdb6e1d3b854464460637ba3e707316ec3c33"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC/gpkm190gP0gU8pD15mzIRdZl22QzkOUMnODF53qcYOgprQG4xni+1IGXZUrt2JoTbFG5yj0IVz6lZ+BOuk55vZ+WStIHMvVgAwxahelwaEHbbC0F7hAqfuPtUaqGSrjvGjRlGUEMZD/TTI/3jcvhb6ps31YsWHdhqRwo7nUPAWLVwpmX9EI1XENnwj38BD9jdLbhiXqJZMNyGmbivLwoQYUPZrtNGmO44Hfxx0rZqoXk5uexp/XR7r3qM3M4aa62zQKsDLDnfjwidkIbkUNTZgc1zC4tDQfd0zfa2LDiiawKCXBs18MhzcZJ581VCgs/D8Oa+PPOs3f4Ecl93HKd8bHiJ16ZBdBvcDFa9nZTQgQqyGZa72TyxXjwsyHHIOQ8wsAScjAufnBNoVFUugjgIhF9cuo/AfcMPGhUAgw2tlD6jT5QJyYOg7YG87qGKzU4XYeVQMnLgE1esoDkSA+IWmIX0rbDFoOi7ex8qComb7Z+HCldm7uIu5lgWE3zxwE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 106,
+    "uptime": "0:01 hours"
+  },
+  "timezone": "Coordinated Universal Time",
+  "virtual": "virtualbox"
+}

--- a/facts/Vagrantfile
+++ b/facts/Vagrantfile
@@ -141,7 +141,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     host.vm.provision 'shell', inline: '/sbin/shutdown -h now'
   end
   config.vm.define 'rockylinux-9-x86_64', autostart: false do |host|
-    host.vm.box = 'rockylinux/9'
+    # this box has no vboxguestadditions as of 2025-04-25
+    # so the synced_folder doesnt mount
+    #host.vm.box = 'rockylinux/9'
+    host.vm.box = 'bento/rockylinux-9'
     host.vm.synced_folder '.', '/vagrant'
     host.vm.provision 'shell', inline: 'dnf -y install wget make gcc net-tools'
     host.vm.provision 'file', source: 'Gemfile', destination: 'Gemfile'


### PR DESCRIPTION
Add in a collection of more facts for OS releases that hadn't been added previously

Switch the Rocky 9 box to one that includes the virtualbox guest additions so that the mount works to share back the facts without having to take manual steps.