### PR TITLE
Mark release gem group as optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-        env:
-          BUNDLE_WITHOUT: release
       - name: Generate database
         run: bundle exec rake database
       - name: Build gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   rubocop_and_matrix:
-    env:
-      BUNDLE_WITHOUT: release
     runs-on: ubuntu-latest
     outputs:
       ruby: ${{ steps.ruby.outputs.versions }}
@@ -39,8 +37,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-        env:
-          BUNDLE_WITHOUT: release
       - name: Run tests
         run: bundle exec rake spec
       - name: Build gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-group :development do
-  gem 'faraday-retry', require: false
-  gem 'github_changelog_generator', '>= 1.16.4', require: false
-  gem 'redcarpet'
-  gem 'yard'
+group :release, optional: true do
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end


### PR DESCRIPTION
This is our current best practice, we do the same in other modules.